### PR TITLE
added --download-reference-genome-data command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,8 @@ before_script:
       pyensembl install
       --release 81
       --species human
-      --custom-mirror https://github.com/openvax/ensembl-data/releases/download/GRCh38.77/
-  - echo "Installed Ensembl 77" && df -h
+      --custom-mirror https://github.com/openvax/ensembl-data/releases/download/GRCh38.81/
+  - echo "Installed Ensembl 81" && df -h
   # Ensembl 93
   - >
       pyensembl install

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,15 +44,39 @@ install:
   - pip install -r requirements.txt
   - pip install .
   - pip install coveralls
-script:
+before_script:
   # run pylint
   - ./lint.sh
-  # install older human Ensembl releases needed for tests
-  - pyensembl install --release 75 --species human
-  - pyensembl install --release 81 --species human
-  # install latest human & mouse Ensembl releases
-  - pyensembl install --release 87 --species human
-  - pyensembl install --release 87 --species mouse
+  - echo "Before installing Ensembl releases" && df -h
+   # Ensembl 75
+  - >
+      pyensembl install
+      --release 75
+      --species human
+      --custom-mirror https://github.com/openvax/ensembl-data/releases/download/GRCh37.75/
+  - echo "Installed Ensembl 75" && df -h
+  # Ensembl 81
+  - >
+      pyensembl install
+      --release 81
+      --species human
+      --custom-mirror https://github.com/openvax/ensembl-data/releases/download/GRCh38.77/
+  - echo "Installed Ensembl 77" && df -h
+  # Ensembl 93
+  - >
+      pyensembl install
+      --release 93
+      --species human
+      --custom-mirror https://github.com/openvax/ensembl-data/releases/download/GRCh38.93/
+  - echo "Installed Ensembl 93 for humans" && df -h
+  # latest mouse release
+  - >
+      pyensembl install
+      --release 93
+      --species mouse
+      --custom-mirror https://github.com/openvax/ensembl-data/releases/download/GRCm38.93/
+  - echo "Installed Ensembl 93 for mice" && df -h
+script:
   # now actually run the tests, generate a coverage report and run linter
   - nosetests test --with-coverage --cover-package=varcode
 after_success:

--- a/test/test_collection_filtering.py
+++ b/test/test_collection_filtering.py
@@ -40,6 +40,7 @@ transcript_fpkm_dict = {
     "ENST00000464755": 20.0,
     "ENST00000371763": 30.0,
     "ENST00000613244": 40.0,
+    "ENST00000645461": 5.0,
 }
 
 effects = variants.effects()
@@ -47,13 +48,16 @@ effects = variants.effects()
 empty_variants = VariantCollection([])
 empty_effects = empty_variants.effects()
 
+
 def test_filter_variants():
     eq_(variants.filter(lambda _: True), variants)
     eq_(variants.filter(lambda _: False), empty_variants)
 
+
 def test_filter_effects():
     eq_(effects.filter(lambda _: True), effects)
     eq_(effects.filter(lambda _: False), empty_effects)
+
 
 def test_filter_variants_by_gene_expression():
     eq_(variants.filter_by_gene_expression(
@@ -61,11 +65,13 @@ def test_filter_variants_by_gene_expression():
     eq_(variants.filter_by_gene_expression(
         gene_fpkm_dict, 100.0), empty_variants)
 
+
 def test_filter_effects_by_gene_expression():
     eq_(effects.filter_by_gene_expression(
         gene_fpkm_dict, 0.0), effects)
     eq_(effects.filter_by_gene_expression(
         gene_fpkm_dict, 100.0), empty_effects)
+
 
 def test_filter_variants_by_transcript_expression():
     expect_all = variants.filter_by_gene_expression(
@@ -75,13 +81,16 @@ def test_filter_variants_by_transcript_expression():
         gene_fpkm_dict, 100.0)
     eq_(expect_none, empty_variants)
 
+
 def test_filter_effects_by_transcript_expression():
+
     expect_all = effects.filter_by_transcript_expression(
         transcript_fpkm_dict, 0.0)
     eq_(expect_all, effects)
     expect_none = effects.filter_by_transcript_expression(
         transcript_fpkm_dict, 100.0)
     eq_(expect_none, empty_effects)
+
 
 def test_filter_silent_effects():
     # all dbSNP entries in the collection are silent

--- a/test/test_mm10_klf6_frameshift.py
+++ b/test/test_mm10_klf6_frameshift.py
@@ -11,26 +11,31 @@ def validate_effect_values(effect):
     eq_(effect.__class__, FrameShift)
     transcript = effect.transcript
     eq_(transcript.name, "Klf6-201")
-    eq_(transcript.spliced_offset(5864876), 462)
+    eq_(transcript.spliced_offset(5864876), 469)
     eq_(effect.shifted_sequence, "GEEGGIRTEDFF")
 
 def test_mm10_Klf6_frameshift():
     variant = Variant("chr13", 5864876, "", "G", "GRCm38")
-    effects = variant.effects()
+    effects = variant.effects().drop_silent_and_noncoding()
     eq_(len(effects), 1)
     validate_effect_values(effects[0])
 
 def test_mm10_Klf6_frameshift_coding_effect_fn():
     variant = Variant("chr13", 5864876, "", "G", "GRCm38")
-    eq_(len(variant.transcripts), 1)
-    t = variant.transcripts[0]
+    transcripts = variant.transcripts
+    coding_transcripts = [
+        t for t in transcripts
+        if t.biotype == "protein_coding"
+    ]
+    eq_(len(coding_transcripts), 1)
+    t = coding_transcripts[0]
     eq_(t.name, "Klf6-201")
     # first start codon offset is 150
     # mutation occurs after offset 462
     effect = predict_frameshift_coding_effect(
         trimmed_cdna_ref="",
         trimmed_cdna_alt="G",
-        cds_offset=462 - 150,
+        cds_offset=469 - 150,
         sequence_from_start_codon=t.sequence[150:],
         variant=variant,
         transcript=t)
@@ -38,18 +43,19 @@ def test_mm10_Klf6_frameshift_coding_effect_fn():
 
 def test_mm10_Klf6_frameshift_cdna_codon_sequence():
     variant = Variant("chr13", 5864876, "", "G", "GRCm38")
-    eq_(len(variant.transcripts), 1)
-    t = variant.transcripts[0]
+    transcripts = variant.transcripts
+    coding_transcripts = [
+        t for t in transcripts
+        if t.biotype == "protein_coding"
+    ]
+    eq_(len(coding_transcripts), 1)
+    t = coding_transcripts[0]
     eq_(t.name, "Klf6-201")
     mutant_codon_index, seq_after_mutated_codon = \
         cdna_codon_sequence_after_insertion_frameshift(
             sequence_from_start_codon=t.sequence[150:],
-            cds_offset_before_insertion=462 - 150,
+            cds_offset_before_insertion=469 - 150,
             inserted_nucleotides="G")
     eq_(mutant_codon_index, 104)
-    expected_sequence = t.sequence[462] + "G" + t.sequence[463:]
-
-    print("Reference sequence (first 20 bases): %s" % t.sequence[462:482])
-    print("Expected sequence (first 20 bases):  %s" % expected_sequence[:20])
-    print("Returned sequence (first 20 bases):  %s" % seq_after_mutated_codon[:20])
+    expected_sequence = t.sequence[469] + "G" + t.sequence[470:]
     eq_(seq_after_mutated_codon, expected_sequence)

--- a/test/test_mm10_klf6_frameshift.py
+++ b/test/test_mm10_klf6_frameshift.py
@@ -7,6 +7,7 @@ from varcode.effects.effect_prediction_coding_frameshift import (
 
 from nose.tools import eq_
 
+
 def validate_effect_values(effect):
     eq_(effect.__class__, FrameShift)
     transcript = effect.transcript
@@ -14,11 +15,13 @@ def validate_effect_values(effect):
     eq_(transcript.spliced_offset(5864876), 469)
     eq_(effect.shifted_sequence, "GEEGGIRTEDFF")
 
+
 def test_mm10_Klf6_frameshift():
     variant = Variant("chr13", 5864876, "", "G", "GRCm38")
     effects = variant.effects().drop_silent_and_noncoding()
     eq_(len(effects), 1)
     validate_effect_values(effects[0])
+
 
 def test_mm10_Klf6_frameshift_coding_effect_fn():
     variant = Variant("chr13", 5864876, "", "G", "GRCm38")
@@ -30,16 +33,17 @@ def test_mm10_Klf6_frameshift_coding_effect_fn():
     eq_(len(coding_transcripts), 1)
     t = coding_transcripts[0]
     eq_(t.name, "Klf6-201")
-    # first start codon offset is 150
-    # mutation occurs after offset 462
+    # first start codon offset is 157
+    # mutation occurs after offset 469
     effect = predict_frameshift_coding_effect(
         trimmed_cdna_ref="",
         trimmed_cdna_alt="G",
-        cds_offset=469 - 150,
-        sequence_from_start_codon=t.sequence[150:],
+        cds_offset=469 - 157,
+        sequence_from_start_codon=t.sequence[157:],
         variant=variant,
         transcript=t)
     validate_effect_values(effect)
+
 
 def test_mm10_Klf6_frameshift_cdna_codon_sequence():
     variant = Variant("chr13", 5864876, "", "G", "GRCm38")
@@ -53,8 +57,8 @@ def test_mm10_Klf6_frameshift_cdna_codon_sequence():
     eq_(t.name, "Klf6-201")
     mutant_codon_index, seq_after_mutated_codon = \
         cdna_codon_sequence_after_insertion_frameshift(
-            sequence_from_start_codon=t.sequence[150:],
-            cds_offset_before_insertion=469 - 150,
+            sequence_from_start_codon=t.sequence[157:],
+            cds_offset_before_insertion=469 - 157,
             inserted_nucleotides="G")
     eq_(mutant_codon_index, 104)
     expected_sequence = t.sequence[469] + "G" + t.sequence[470:]

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -24,7 +24,7 @@ from .effects import (
     NonsilentCodingMutation,
 )
 
-__version__ = '0.6.6'
+__version__ = '0.7.0'
 
 __all__ = [
     # basic classes

--- a/varcode/cli/variants_script.py
+++ b/varcode/cli/variants_script.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2016-2018. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import logging.config
 import pkg_resources
 import sys
 
+from .version_info import print_version_info
 from .variant_args import make_variants_parser, variant_collection_from_args
 
 
@@ -37,6 +38,7 @@ def main(args_list=None):
             --variant chr1 498584 C G \
             --json-variants more_variants.json
     """
+    print_version_info()
     if args_list is None:
         args_list = sys.argv[1:]
     arg_parser = make_variants_parser(

--- a/varcode/cli/version_info.py
+++ b/varcode/cli/version_info.py
@@ -16,6 +16,7 @@ from __future__ import print_function, division, absolute_import
 
 from collections import OrderedDict
 from os.path import dirname
+from .. import __file__ as package_init_file_path
 from .. import __version__
 
 
@@ -27,7 +28,7 @@ def collect_version_info():
     major Python dependencies such as PyEnsembl
     """
     d = OrderedDict()
-    d["Varcode"] = (__version__, dirname(__file__))
+    d["Varcode"] = (__version__, dirname(package_init_file_path))
     return d
 
 

--- a/varcode/cli/version_info.py
+++ b/varcode/cli/version_info.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2016-2018. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function, division, absolute_import
+
+from collections import OrderedDict
+from os.path import dirname
+from .. import __version__
+
+
+def collect_version_info():
+    """
+    Collection the version and path of Varcode.
+
+    TODO: add a `dependencies=False` option to also collect this info from
+    major Python dependencies such as PyEnsembl
+    """
+    d = OrderedDict()
+    d["Varcode"] = (__version__, dirname(__file__))
+    return d
+
+
+def print_version_info(dependencies=False):
+    for (program, (version, path)) in collect_version_info().items():
+        print(program)
+        print("  Version: %s" % version)
+        print("  Path: %s" % path)

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -35,6 +35,7 @@ from .effects import (
     predict_variant_effect_on_transcript
 )
 
+
 class Variant(Serializable):
     __slots__ = (
         "contig",


### PR DESCRIPTION
If reference genome required for any input variants is missing then download and install it. This command should propagate up to other CLI's such as Vaxrank. 

Also added `print_version_info` and `collect_version_info` to `cli.version_info`. I would like to eventually have every OpenVax tool expose these, to allow every tool to print the versions/paths of its OpenVax dependency chain (as well as always printing the version with each command invocation). 

Also fixed klf6 frameshift unit test which appears to be broken. 