### PR TITLE
fixed top_priority_effect for ExonicSpliceSite

### DIFF
--- a/test/test_exonic_splice_site.py
+++ b/test/test_exonic_splice_site.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2018. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from varcode import Variant
+from varcode.effects import ExonicSpliceSite, PrematureStop
+
+
+def test_STAT1_stop_gain_at_exon_boundary():
+    # top priority effect for this variant should be PrematureStop,
+    # even though it's also ExonicSpliceSite
+    stat1_variant = Variant("2", "191872291", "G", "A", "GRCh37")
+    effects = stat1_variant.effects()
+    print(effects)
+    assert any([e.__class__ is ExonicSpliceSite for e in effects])
+    top_effect = effects.top_priority_effect()
+    print(top_effect)
+    assert top_effect.__class__ is PrematureStop

--- a/test/test_vcf_output.py
+++ b/test/test_vcf_output.py
@@ -13,17 +13,14 @@
 # limitations under the License.
 
 from __future__ import print_function, division, absolute_import
-import os
-from nose.tools import eq_
 from varcode import load_vcf, load_maf
-from varcode import VariantCollection
+
 from varcode.vcf_output import variants_to_vcf
 from .data import data_path
 import tempfile
 
-TEST_FILENAMES = [
+TEST_FILENAMES_HUMAN = [
     'duplicates.maf',
-    'mouse_vcf_dbsnp_chr1_partial.vcf',
     'multiallelic.vcf',
     'mutect-example.vcf',
     'ov.wustle.subset5.maf',
@@ -38,12 +35,20 @@ TEST_FILENAMES = [
     # 'somatic_hg19_14muts.vcf.gz',     # gzip
 ]
 
+TEST_FILENAMES_MOUSE = [
+    'mouse_vcf_dbsnp_chr1_partial.vcf',
+]
+
+TEST_FILENAMES = TEST_FILENAMES_HUMAN + TEST_FILENAMES_MOUSE
+
+
 def _merge_metadata_naive(variants):
     return {
         k: v
         for d in variants.source_to_metadata_dict.values()
         for k, v in d.items()
     }
+
 
 def _do_roundtrip_test(filenames):
 
@@ -69,11 +74,11 @@ def _do_roundtrip_test(filenames):
 
     # `==` checks the reference genome, which won't necessarily match.
     assert all(
-            v1.contig == v2.contig and \
-            v1.start == v2.start and \
-            v1.ref == v2.ref and \
-            v1.start == v2.start \
-            for (v1, v2) in zip(variants, reparsed_variants))
+        v1.contig == v2.contig and
+        v1.start == v2.start and
+        v1.ref == v2.ref and
+        v1.start == v2.start
+        for (v1, v2) in zip(variants, reparsed_variants))
 
     return (variants, reparsed_variants)
 
@@ -91,43 +96,47 @@ def _do_roundtrip_test(filenames):
     # metadata (without the need to individually convert fields), we'd need to add
     # these headers to the output VCF file. See `vcf_output.py` for more info.
 
+
 def test_single_file_roundtrip_conversion():
     for filename in TEST_FILENAMES:
         yield (_do_roundtrip_test, [filename])
+
 
 def test_multiple_file_roundtrip_conversion():
     file_groups = (
         ['simple.1.vcf', 'simple.2.vcf'],  # basic multi-file test
         ['duplicates.maf', 'multiallelic.vcf'],  # dif. file formats
         ['duplicate-id.1.vcf', 'duplicate-id.2.vcf'],
-        TEST_FILENAMES,  # because why not?
+        TEST_FILENAMES_HUMAN,
     )
     for file_group in file_groups:
         yield (_do_roundtrip_test, file_group)
+
 
 def test_same_samples_produce_samples():
     """Ensures that, if a set of variants have the same samples, the reparsed
     collection will output these samples.
     """
     (variants, reparsed_variants) = _do_roundtrip_test(
-            ['same-samples.1.vcf', 'same-samples.2.vcf'])
+        ['same-samples.1.vcf', 'same-samples.2.vcf'])
 
     original_metadata = _merge_metadata_naive(variants)
     reparsed_metadata = _merge_metadata_naive(reparsed_variants)
 
     sample_names = set(list(original_metadata.values())[0]['sample_info'].keys())
     assert all(
-            set(d.get('sample_info', {}).keys()) == sample_names
-            for d in reparsed_metadata.values())
+        set(d.get('sample_info', {}).keys()) == sample_names
+        for d in reparsed_metadata.values())
+
 
 def test_different_samples_produce_no_samples():
     """Ensures that, if a set of variants have different samples, the reparsed
     collection will not output any samples.
-    
+
     See `vcf_output.py` for details as to why this is the way it's done for now.
     """
     (_, reparsed_variants) = _do_roundtrip_test(
-            ['different-samples.1.vcf', 'different-samples.2.vcf'])
+        ['different-samples.1.vcf', 'different-samples.2.vcf'])
 
     metadata = _merge_metadata_naive(reparsed_variants)
     assert all(d.get('sample_info') is None for d in metadata.values())

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -23,6 +23,7 @@ from .effects import (
     MutationEffect,
     NonsilentCodingMutation,
 )
+
 __version__ = '0.8.0'
 
 __all__ = [

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -24,7 +24,7 @@ from .effects import (
     NonsilentCodingMutation,
 )
 
-__version__ = '0.7.0'
+__version__ = '0.8.0'
 
 __all__ = [
     # basic classes

--- a/varcode/effects/common.py
+++ b/varcode/effects/common.py
@@ -17,6 +17,7 @@ from __future__ import print_function, division, absolute_import
 from Bio.Seq import Seq
 from six import string_types, text_type
 
+
 def bio_seq_to_str(seq):
     if isinstance(seq, Seq):
         return str(seq)

--- a/varcode/effects/effect_collection.py
+++ b/varcode/effects/effect_collection.py
@@ -25,6 +25,7 @@ from .effect_ordering import (
     transcript_effect_priority_dict
 )
 
+
 class EffectCollection(Collection):
     """
     Collection of MutationEffect objects and helpers for grouping or filtering

--- a/varcode/effects/effect_ordering.py
+++ b/varcode/effects/effect_ordering.py
@@ -58,7 +58,8 @@ transcript_effect_priority_list = [
     IntronicSpliceSite,
     # exonic variants near a splice boundary
     ExonicSpliceSite,
-    # modification or deletion of stop codon
+    # mutation in the two nucleotides immediately following an exon/intron
+    # boundary
     SpliceDonor,
     # mutation in the two nucleotides immediately preceding an intron/exon
     # boundary
@@ -71,9 +72,9 @@ transcript_effect_priority_list = [
     # be interpreted as silent but also has some chance of causing an
     # alternative ORF
     AlternateStartCodon,
+    # modification or deletion of stop codon
     StopLoss,
-    # mutation in the two nucleotides immediately following an exon/intron
-    # boundary
+    # creation of a new stop codon within the coding sequence
     PrematureStop,
     # frame-shift which creates immediate stop codon, same as PrematureStop
     FrameShiftTruncation,

--- a/varcode/effects/effect_ordering.py
+++ b/varcode/effects/effect_ordering.py
@@ -127,6 +127,11 @@ def effect_sort_key(effect):
 
 
 def select_between_exonic_splice_site_and_alternate_effect(effect):
+    """
+    If the given effect is an ExonicSpliceSite then it might contain
+    an alternate effect of higher priority. In that case, return the
+    alternate effect. Otherwise, this acts as an identity function.
+    """
     if effect.__class__ is not ExonicSpliceSite:
         return effect
     if effect.alternate_effect is None:

--- a/varcode/effects/effect_prediction.py
+++ b/varcode/effects/effect_prediction.py
@@ -110,6 +110,7 @@ def predict_variant_effect_on_transcript_or_failure(variant, transcript):
             error)
         return Failure(variant, transcript)
 
+
 def predict_variant_effect_on_transcript(variant, transcript):
         """Return the transcript effect (such as FrameShift) that results from
         applying this genomic variant to a particular transcript.
@@ -218,6 +219,7 @@ def predict_variant_effect_on_transcript(variant, transcript):
             exon=exon,
             alternate_effect=exonic_effect_annotation)
 
+
 def choose_intronic_effect_class(
         variant,
         nearest_exon,
@@ -267,6 +269,7 @@ def choose_intronic_effect_class(
     else:
         # intronic mutation unrelated to splicing
         return Intronic
+
 
 def exonic_transcript_effect(variant, exon, exon_number, transcript):
     """Effect of this variant on a Transcript, assuming we already know

--- a/varcode/effects/effect_prediction_coding.py
+++ b/varcode/effects/effect_prediction_coding.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2016-2018. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ from __future__ import print_function, division, absolute_import
 
 from .effect_prediction_coding_frameshift import predict_frameshift_coding_effect
 from .effect_prediction_coding_in_frame import predict_in_frame_coding_effect
+
 
 def predict_variant_coding_effect_on_transcript(
         variant,

--- a/varcode/effects/effect_prediction_coding_frameshift.py
+++ b/varcode/effects/effect_prediction_coding_frameshift.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2016-2018. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ from .effect_classes import (
 )
 from .mutate import substitute
 from .translate import translate
+
 
 def create_frameshift_effect(
         mutated_codon_index,
@@ -201,6 +202,7 @@ def cdna_codon_sequence_after_deletion_or_substitution_frameshift(
         ref=trimmed_cdna_ref,
         alt=trimmed_cdna_alt)
     return mutated_codon_index, sequence_from_mutated_codon
+
 
 def predict_frameshift_coding_effect(
         variant,

--- a/varcode/effects/effect_prediction_coding_in_frame.py
+++ b/varcode/effects/effect_prediction_coding_in_frame.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2016-2018. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ from .effect_classes import (
     StopLoss,
 )
 from .translate import translate_in_frame_mutation, START_CODONS
+
 
 def get_codons(
         variant,
@@ -104,6 +105,7 @@ def get_codons(
         "Expected in-frame mutation but got %s (length = %d)" % (
             mutant_codons, len(mutant_codons))
     return ref_codon_start_offset, ref_codon_end_offset, mutant_codons
+
 
 def predict_in_frame_coding_effect(
         variant,

--- a/varcode/effects/translate.py
+++ b/varcode/effects/translate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2016-2018 Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ DNA_CODON_TABLE = CodonTable.standard_dna_table.forward_table
 START_CODONS = set(CodonTable.standard_dna_table.start_codons)
 STOP_CODONS = set(CodonTable.standard_dna_table.stop_codons)
 
+
 def translate_codon(codon, aa_pos):
     """Translate a single codon into a single amino acid or stop '*'
 
@@ -44,6 +45,7 @@ def translate_codon(codon, aa_pos):
         return "*"
     else:
         return DNA_CODON_TABLE[codon]
+
 
 def translate(
         nucleotide_sequence,
@@ -122,6 +124,7 @@ def find_first_stop_codon(nucleotide_sequence):
         if codon in STOP_CODONS:
             return i
     return -1
+
 
 def translate_in_frame_mutation(
         transcript,

--- a/varcode/vcf_output.py
+++ b/varcode/vcf_output.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import, print_function, division
 from collections import defaultdict
 import sys
 
+
 def variants_to_vcf(variants, variant_to_metadata, out=sys.stdout):
     """Output a VCF file from a list of Variant records.
 
@@ -248,9 +249,11 @@ def variants_to_vcf(variants, variant_to_metadata, out=sys.stdout):
         headers += ['FORMAT'] + sample_names
 
     unique_variants_list = merge_duplicate_variants()
+    # can't have more than one reference in VCF so pick the first one and pray
+    genome = list({v.ensembl for v in unique_variants_list})[0]
 
     print('##fileformat=VCFv4.2', file=out)
-    print("##reference=file:///projects/ngs/resources/gatk/2.3/ucsc.hg19.fasta", file=out)
+    print('##reference=%s' % genome.reference_name, file=out)
     print('\t'.join(headers), file=out)
     for variant in unique_variants_list:
         record = build_vcf_record(variant, add_sample_info=bool(sample_names))


### PR DESCRIPTION
Currently, if an `ExonicSpliceSite` effect has an `alternate_effect` which is more interesting (e.g. `StopGain`), it doesn't come up as the top priority. This changes the `top_priority_effect` logic to return the `alternate_effect` if it's higher priority than a potential exonic splice site change. 

Other changes:
* moved splicing mutations to be right after `Silent` in the effect ordering. 
* fixed bug I noticed in VCF writing where a random hg19 FASTA path was always used as the reference 

Fixes: https://github.com/openvax/varcode/issues/233