### PR TITLE
added keyword aliases to Variant

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pyvcf>=0.6.7
 memoized_property>=1.0.2
 nose>=1.3.3
 pylint>=1.4.4
-serializable>=0.1.0
+serializable>=0.2.0
 sercol>=0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pyvcf>=0.6.7
 memoized_property>=1.0.2
 nose>=1.3.3
 pylint>=1.4.4
-serializable>=0.2.0
+serializable>=0.2.1
 sercol>=0.1.4

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
             'biopython>=1.64',
             'pyvcf>=0.6.7',
             'memoized_property>=1.0.2',
-            'serializable>=0.1.1',
+            'serializable>=0.2.0',
             'sercol>=0.1.4',
         ],
         entry_points={

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
             'biopython>=1.64',
             'pyvcf>=0.6.7',
             'memoized_property>=1.0.2',
-            'serializable>=0.2.0',
+            'serializable>=0.2.1',
             'sercol>=0.1.4',
         ],
         entry_points={

--- a/test/test_variant.py
+++ b/test/test_variant.py
@@ -151,6 +151,44 @@ def test_serialization():
         reconstituted = Variant.from_json(serialized)
         eq_(original, reconstituted)
 
+def test_deserialization_old_keywords():
+    old_variant_representation_json = """
+    {
+        "ref": "T",
+        "contig": "22",
+        "start": 23230319,
+        "__class__": {
+            "__name__": "Variant",
+            "__module__": "varcode.variant"
+        },
+        "normalize_contig_name": true,
+        "alt": "G",
+        "allow_extended_nucleotides": false,
+        "ensembl": {
+            "__class__": {
+                "__name__": "EnsemblRelease",
+                "__module__": "pyensembl.ensembl_release"
+            },
+            "release": 75,
+            "server": "ftp://ftp.ensembl.org",
+            "species": {
+                "__class__": {
+                    "__name__": "Species",
+                    "__module__": "pyensembl.species"
+                },
+                "latin_name": "homo_sapiens"
+            }
+        }
+    }
+    """
+    variant = Variant.from_json(old_variant_representation_json)
+    eq_(variant.contig, "22")
+    eq_(variant.ref, "T")
+    eq_(variant.alt, "G")
+    eq_(variant.reference_name, "GRCh37")
+    eq_(variant.normalize_contig_names, True)
+    eq_(variant.allow_extended_nucleotides, False)
+
 def test_hg19_chromosome_names():
     # trimming of mithochondrial name
     eq_(Variant("M", 1, "A", "G", "hg19", convert_ucsc_contig_names=True).contig, "MT")

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -31,11 +31,13 @@ __all__ = [
     "Variant",
     "EffectCollection",
     "VariantCollection",
+
     # effects
     "effect_priority",
     "top_priority_effect",
     "MutationEffect",
     "NonsilentCodingMutation",
+
     # file loading
     "load_maf",
     "load_maf_dataframe",

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -24,7 +24,7 @@ from .effects import (
     NonsilentCodingMutation,
 )
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 __all__ = [
     # basic classes

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -54,6 +54,13 @@ class Variant(Serializable):
         "_gene_names",
     )
 
+    # any keywords which are renamed or removed should be added to this
+    # dictionary to preserve the ability to deserialize old representations
+    # of Variant objects
+    _KEYWORD_ALIASES = {
+        "normalize_contig_name": "normalize_contig_names"
+    }
+    
     def __init__(
             self,
             contig,

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -57,7 +57,7 @@ class Variant(Serializable):
     # any keywords which are renamed or removed should be added to this
     # dictionary to preserve the ability to deserialize old representations
     # of Variant objects
-    _KEYWORD_ALIASES = {
+    _SERIALIZABLE_KEYWORD_ALIASES = {
         "normalize_contig_name": "normalize_contig_names"
     }
     


### PR DESCRIPTION
The last PR changed one of the keyword names (`normalize_contig_name` became `normalize_contig_names`) which will break loading of any previously serialized data which includes `Variant`s. To restore our ability to deserialize old data this PR adds `normalize_contig_name` to the `_KEYWORD_ALIASES` class-level dictionary, which lets the `Serializable` base class know to update the keyword name. 