### PR TITLE
Fix reference names from CLI 

### DIFF
--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -24,7 +24,7 @@ from .effects import (
     NonsilentCodingMutation,
 )
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 __all__ = [
     # basic classes

--- a/varcode/cli/effects_script.py
+++ b/varcode/cli/effects_script.py
@@ -14,7 +14,6 @@
 
 from __future__ import division, absolute_import
 
-import logging
 import logging.config
 import pkg_resources
 import sys

--- a/varcode/cli/variant_args.py
+++ b/varcode/cli/variant_args.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016. Mount Sinai School of Medicine
+# Copyright (c) 2016-2019. Mount Sinai School of Medicine
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,9 @@
 from __future__ import print_function, division, absolute_import
 from argparse import ArgumentParser
 
-from pyensembl import genome_for_reference_name
-
 from ..vcf import load_vcf
 from ..maf import load_maf
+from ..reference import infer_genome
 from ..variant_collection import VariantCollection
 from ..variant import Variant
 
@@ -120,21 +119,15 @@ def download_and_install_reference_data(variant_collections):
 def variant_collection_from_args(args, required=True):
     variant_collections = []
 
-    if args.genome:
-        genome = genome_for_reference_name(args.genome)
-    else:
-        # no genome specified, assume it can be inferred from the file(s)
-        # we're loading
-        genome = None
-
     for vcf_path in args.vcf:
-        variant_collections.append(load_vcf(vcf_path, genome=genome))
+        variant_collections.append(
+            load_vcf(vcf_path, genome=args.genome))
 
     for maf_path in args.maf:
         variant_collections.append(load_maf(maf_path))
 
     if args.variant:
-        if not genome:
+        if not args.genome:
             raise ValueError(
                 "--genome must be specified when using --variant")
 
@@ -144,7 +137,7 @@ def variant_collection_from_args(args, required=True):
                 start=position,
                 ref=ref,
                 alt=alt,
-                ensembl=genome)
+                genome=args.genome)
             for (chromosome, position, ref, alt)
             in args.variant
         ]

--- a/varcode/cli/variant_args.py
+++ b/varcode/cli/variant_args.py
@@ -17,7 +17,6 @@ from argparse import ArgumentParser
 
 from ..vcf import load_vcf
 from ..maf import load_maf
-from ..reference import infer_genome
 from ..variant_collection import VariantCollection
 from ..variant import Variant
 

--- a/varcode/maf.py
+++ b/varcode/maf.py
@@ -79,6 +79,7 @@ def load_maf_dataframe(path, nrows=None, raise_on_error=True, encoding=None):
         low_memory=False,
         skip_blank_lines=True,
         header=0,
+        nrows=nrows,
         encoding=encoding)
 
     if len(df.columns) < n_basic_columns:
@@ -117,7 +118,8 @@ def load_maf(
         sort_key=variant_ascending_position_sort_key,
         distinct=True,
         raise_on_error=True,
-        encoding=None):
+        encoding=None,
+        nrows=None):
     """
     Load reference name and Variant objects from MAF filename.
 
@@ -143,10 +145,17 @@ def load_maf(
 
     encoding : str, optional
         Encoding to use for UTF when reading MAF file.
+
+    nrows : int, optional
+        Limit to number of rows loaded
     """
     # pylint: disable=no-member
     # pylint gets confused by read_csv inside load_maf_dataframe
-    maf_df = load_maf_dataframe(path, raise_on_error=raise_on_error, encoding=encoding)
+    maf_df = load_maf_dataframe(
+        path,
+        nrows=nrows,
+        raise_on_error=raise_on_error,
+        encoding=encoding)
 
     if len(maf_df) == 0 and raise_on_error:
         raise ValueError("Empty MAF file %s" % path)


### PR DESCRIPTION
Previously we could only use Ensembl reference names such as "GRCh37" from the commandline (for both Varcode and any applications that reuse its CLI code). This PR enables use of other related genome names such as "hg19", "hg38". 

Unrelated: noticed that the `nrows` argument was unused in `load_maf_dataframe` and fixed it so it both does something and can be specified in `load_maf`. 