### PR TITLE
Fix error of transcript name

### DIFF
--- a/varcode/effects/effect_ordering.py
+++ b/varcode/effects/effect_ordering.py
@@ -172,7 +172,7 @@ def name_of_associated_transcript(effect):
     """
     return apply_to_transcript_if_exists(
         effect=effect,
-        fn=lambda t: t.name,
+        fn=lambda t: None if t.name is None else "",
         default="")
 
 


### PR DESCRIPTION
When the transcript name is None, the package would trigger the error in string operation. 

```
site-packages/varcode/effects/effect_ordering.py", line 251, in transcript_name_ends_with_01
    return name_of_associated_transcript(effect).endswith("01")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'endswith'
```