### PR TITLE
Fix 6 effect-annotation bugs, add 32 regression tests

### DIFF
--- a/tests/test_effect_collection_sort_order.py
+++ b/tests/test_effect_collection_sort_order.py
@@ -1,0 +1,66 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression tests for https://github.com/openvax/varcode/issues/227
+
+EffectCollection previously had `sort_key=None` by default, so the
+returned effects were in whatever order the gene/transcript loop
+produced them. Users expect effects to be ordered by priority (highest
+first) so that iterating over a collection surfaces the most severe
+effects up front.
+"""
+
+from varcode import Variant
+from varcode.effects.effect_ordering import effect_priority
+
+
+def test_effect_collection_is_sorted_by_priority_descending():
+    # Use a substitution that produces a mix of Substitution (high),
+    # ExonicSpliceSite (lower), Intronic (lower), NoncodingTranscript
+    # (lowest) across many transcripts. Previously these came back in
+    # insertion order; now they should be ordered by priority, highest
+    # first.
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    effects = variant.effects()
+    assert len(effects) > 1, "Test variant should produce multiple effects"
+
+    priorities = [effect_priority(e) for e in effects]
+    assert priorities == sorted(priorities, reverse=True), (
+        "Expected effects in descending priority order, got %r" % priorities
+    )
+
+
+def test_effect_collection_top_priority_effect_matches_first_element():
+    # When the collection is sorted by priority, the first element should
+    # match top_priority_effect() (modulo tie-breaking, which uses the same
+    # priority ordering).
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    effects = variant.effects()
+    top = effects.top_priority_effect()
+    assert effect_priority(effects[0]) == effect_priority(top), \
+        "First effect should have the same priority as top_priority_effect()"
+
+
+def test_effect_collection_explicit_sort_key_still_works():
+    # Users who pass their own sort_key should still get that ordering.
+    from varcode.effects.effect_collection import EffectCollection
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    effects_list = list(variant.effects())
+    # Sort by class name alphabetically
+    custom = EffectCollection(
+        effects=effects_list,
+        sort_key=lambda e: e.__class__.__name__,
+    )
+    names = [e.__class__.__name__ for e in custom]
+    assert names == sorted(names), \
+        "Custom sort_key should be respected, got %r" % names

--- a/tests/test_maf.py
+++ b/tests/test_maf.py
@@ -54,10 +54,11 @@ def generate_maf_aa_changes():
     for _, row in maf_fields.iterrows():
         key = (str(row.Chromosome), row.Start_position)
         change = row.amino_acid_change
-        # silent mutations just specificy which amino acid they affect via
-        # e.g. "p.G384"
+        # silent mutations in this MAF specify only the affected residue
+        # (e.g. "p.G384") — varcode renders these in HGVS notation as
+        # "p.G384=" per https://github.com/openvax/varcode/issues/217.
         if change[-1].isdigit():
-            expected_changes[key] = "silent"
+            expected_changes[key] = change + "="
         else:
             expected_changes[key] = change
 

--- a/tests/test_premature_stop_short_description.py
+++ b/tests/test_premature_stop_short_description.py
@@ -1,0 +1,102 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression tests for https://github.com/openvax/varcode/issues/216
+
+PrematureStop.short_description didn't distinguish an insertion that
+introduces a stop (empty aa_ref) from a substitution or deletion that
+ends with a stop. Previously produced ambiguous strings like "p.7*";
+insertion cases should read "p.7ins*".
+"""
+
+from varcode import Variant
+from varcode.effects import PrematureStop
+
+
+# Reporter's example: chr1:99772782 A>ATAA on ENSMUST00000086738 (GRCm38).
+# Protein context: M D S V P R L T S I L (1-indexed positions 1..11)
+# The A at 99772782 is the third nucleotide of the R codon AGA.
+# Inserting TAA after that A gives: AGA TAA CTG ACC ...
+# Translation: AGA = R, TAA = stop.  The insertion creates a stop
+# codon right after R without changing R itself.
+
+def test_insertion_of_stop_codon_uses_ins_notation_in_short_description():
+    variant = Variant(
+        contig=1,
+        start=99772782,
+        ref="A",
+        alt="ATAA",
+        genome="GRCm38",
+    )
+    transcript = variant.ensembl.transcript_by_id("ENSMUST00000086738")
+    effect = variant.effect_on_transcript(transcript)
+    assert effect.__class__ is PrematureStop, \
+        "Expected PrematureStop, got %s" % effect.__class__.__name__
+    # aa_ref is empty (the insertion did not replace any amino acid),
+    # so the short description should use "ins" notation instead of
+    # the ambiguous "p.7*".
+    assert effect.aa_ref == "", \
+        "Expected aa_ref='', got %r" % effect.aa_ref
+    assert effect.short_description == "p.7ins*", \
+        "Expected 'p.7ins*', got %r" % effect.short_description
+
+
+# Direct unit tests on short_description formatting logic.
+# These use a minimal fake transcript that just satisfies the
+# attributes accessed during __init__.
+
+class _FakeGene:
+    biotype = "protein_coding"
+
+
+class _FakeTranscript:
+    biotype = "protein_coding"
+    gene = _FakeGene()
+
+    def __init__(self, protein_length=100):
+        self.protein_sequence = "X" * protein_length
+
+
+def _premature_stop(aa_mutation_start_offset, aa_ref, aa_alt):
+    return PrematureStop(
+        variant=None,
+        transcript=_FakeTranscript(),
+        aa_mutation_start_offset=aa_mutation_start_offset,
+        aa_ref=aa_ref,
+        aa_alt=aa_alt,
+    )
+
+
+def test_short_description_pure_insertion_of_stop():
+    # Empty aa_ref, empty aa_alt: insertion of just a stop codon.
+    e = _premature_stop(aa_mutation_start_offset=6, aa_ref="", aa_alt="")
+    assert e.short_description == "p.7ins*"
+
+
+def test_short_description_insertion_of_aa_and_stop():
+    # Empty aa_ref, non-empty aa_alt: insertion of amino acids followed
+    # by a stop.
+    e = _premature_stop(aa_mutation_start_offset=6, aa_ref="", aa_alt="K")
+    assert e.short_description == "p.7insK*"
+
+
+def test_short_description_substitution_ending_with_stop():
+    # Non-empty aa_ref, empty aa_alt: amino acid replaced by stop.
+    e = _premature_stop(aa_mutation_start_offset=6, aa_ref="L", aa_alt="")
+    assert e.short_description == "p.L7*"
+
+
+def test_short_description_complex_substitution_ending_with_stop():
+    # Both non-empty: existing behaviour preserved.
+    e = _premature_stop(aa_mutation_start_offset=6, aa_ref="LT", aa_alt="K")
+    assert e.short_description == "p.LT7K*"

--- a/tests/test_silent_aa_pos.py
+++ b/tests/test_silent_aa_pos.py
@@ -1,0 +1,83 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression tests for https://github.com/openvax/varcode/issues/208
+
+Silent.aa_pos was off by one for synonymous SNPs — the code returned
+aa_mutation_start_offset which had already been incremented past the
+shared prefix from trim_shared_flanking_strings.
+
+Test transcript ENSMUST00000086738 (Cntnap5b-201, GRCm38), with the
+coding sequence context provided by the reporter:
+
+    ATG GAT TCT GTA CCA AGA CTG ACC AGC ATT TTG
+     M   D   S   V   P   R   L   T   S   I   L
+     0   1   2   3   4   5   6   7   8   9  10
+
+The R codon AGA starts at CDS position 15 = transcript offset
+(start_codon_spliced_offsets[0] + 15). On genome GRCm38 the reporter
+specifies position chr1:99772782 = the last nucleotide of the R codon
+(AGA, so position offset 2).
+"""
+
+from varcode import Variant
+from varcode.effects import Silent
+
+
+TRANSCRIPT_ID = "ENSMUST00000086738"
+
+
+def _effect(ref, alt, start=99772782):
+    variant = Variant(
+        contig=1,
+        start=start,
+        ref=ref,
+        alt=alt,
+        genome="GRCm38",
+    )
+    transcript = variant.ensembl.transcript_by_id(TRANSCRIPT_ID)
+    return variant.effect_on_transcript(transcript)
+
+
+def test_synonymous_snv_at_third_codon_position_aa_pos_is_5():
+    # AGA -> AGG (R/R), SNV at the third nucleotide of codon 5 (R).
+    effect = _effect("A", "G", start=99772782)
+    assert effect.__class__ is Silent, \
+        "Expected Silent, got %s" % effect.__class__.__name__
+    assert effect.aa_pos == 5, \
+        "Expected aa_pos=5, got %d" % effect.aa_pos
+    assert effect.aa_ref == "R", \
+        "Expected aa_ref='R', got %r" % effect.aa_ref
+
+
+def test_synonymous_snv_at_first_codon_position_aa_pos_is_6():
+    # CTG -> TTG (L/L), SNV at the first nucleotide of codon 6 (L).
+    effect = _effect("C", "T", start=99772783)
+    assert effect.__class__ is Silent, \
+        "Expected Silent, got %s" % effect.__class__.__name__
+    assert effect.aa_pos == 6, \
+        "Expected aa_pos=6, got %d" % effect.aa_pos
+    assert effect.aa_ref == "L", \
+        "Expected aa_ref='L', got %r" % effect.aa_ref
+
+
+def test_synonymous_mnv_spanning_two_codons_aa_pos_is_5():
+    # AC -> GT, affects third base of codon 5 (R) and first of codon 6 (L).
+    # AGA CTG -> AGG TTG (RL/RL), fully synonymous.
+    effect = _effect("AC", "GT", start=99772782)
+    assert effect.__class__ is Silent, \
+        "Expected Silent, got %s" % effect.__class__.__name__
+    assert effect.aa_pos == 5, \
+        "Expected aa_pos=5, got %d" % effect.aa_pos
+    assert effect.aa_ref == "RL", \
+        "Expected aa_ref='RL', got %r" % effect.aa_ref

--- a/tests/test_silent_hgvs_description.py
+++ b/tests/test_silent_hgvs_description.py
@@ -1,0 +1,97 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression tests for https://github.com/openvax/varcode/issues/217
+
+Silent.short_description returned the literal string "silent" instead of
+the HGVS-standard `p.{AA}{pos}=` format (e.g. "p.R6=").
+"""
+
+from varcode import Variant
+from varcode.effects import Silent
+
+
+TRANSCRIPT_ID = "ENSMUST00000086738"
+
+
+def test_silent_short_description_uses_hgvs_format():
+    # AGA -> AGG at chr1:99772782 (3rd nt of codon 5, R codon)
+    # Synonymous: R at position 5 (0-indexed) = position 6 (1-indexed).
+    variant = Variant(
+        contig=1,
+        start=99772782,
+        ref="A",
+        alt="G",
+        genome="GRCm38",
+    )
+    transcript = variant.ensembl.transcript_by_id(TRANSCRIPT_ID)
+    effect = variant.effect_on_transcript(transcript)
+    assert effect.__class__ is Silent
+    # HGVS: p.{aa_ref}{1-indexed pos}=
+    assert effect.short_description == "p.R6=", \
+        "Expected 'p.R6=', got %r" % effect.short_description
+
+
+def test_silent_short_description_for_multi_codon_synonymous():
+    # AC -> GT at chr1:99772782, spans two codons AGA+CTG both synonymous.
+    variant = Variant(
+        contig=1,
+        start=99772782,
+        ref="AC",
+        alt="GT",
+        genome="GRCm38",
+    )
+    transcript = variant.ensembl.transcript_by_id(TRANSCRIPT_ID)
+    effect = variant.effect_on_transcript(transcript)
+    assert effect.__class__ is Silent
+    # aa_ref is 'RL', 1-indexed pos is 6.
+    assert effect.short_description == "p.RL6=", \
+        "Expected 'p.RL6=', got %r" % effect.short_description
+
+
+# Direct unit test on the Silent class without needing a real transcript.
+
+class _FakeGene:
+    biotype = "protein_coding"
+
+
+class _FakeTranscript:
+    biotype = "protein_coding"
+    gene = _FakeGene()
+    protein_sequence = "X" * 100
+
+
+def test_silent_unit_hgvs_notation():
+    e = Silent(
+        variant=None,
+        transcript=_FakeTranscript(),
+        aa_pos=5,
+        aa_ref="R",
+    )
+    # 0-indexed aa_pos=5 -> 1-indexed position 6 in HGVS.
+    assert e.short_description == "p.R6="
+
+
+def test_silent_unit_empty_aa_ref_still_safe():
+    # Edge case: when nothing was affected (both aa_ref and aa_alt empty
+    # after trim), aa_ref may be empty. Should degrade to a sensible
+    # descriptor rather than crash.
+    e = Silent(
+        variant=None,
+        transcript=_FakeTranscript(),
+        aa_pos=5,
+        aa_ref="",
+    )
+    # Any non-crashing string is acceptable; check it contains the position
+    # marker and the HGVS "=" for synonymous.
+    assert "=" in e.short_description

--- a/tests/test_stop_codon_classification_bugs.py
+++ b/tests/test_stop_codon_classification_bugs.py
@@ -1,0 +1,124 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression tests for misclassification bugs involving variants in or near
+the stop codon:
+
+* https://github.com/openvax/varcode/issues/250 - SNV in stop codon reported
+  as Insertion instead of StopLoss, when the 3' UTR starts with a stop codon.
+* https://github.com/openvax/varcode/issues/205 - Same root cause as #250
+  on a different transcript.
+* https://github.com/openvax/varcode/issues/201 - Insertion before the stop
+  codon that produces an identical protein sequence is reported as an
+  Insertion rather than Silent.
+"""
+
+from varcode import Variant
+from varcode.effects import Silent, StopLoss
+
+
+# -----------------------------------------------------------------------
+# Issue #250: SNV in stop codon reported as Insertion
+#
+# The stop codon TGA is changed to a sense codon, but the 3' UTR begins
+# with another stop codon (TGA...), so translation terminates immediately.
+# Previously this was classified as Insertion; the correct answer is
+# StopLoss with a single additional amino acid.
+# -----------------------------------------------------------------------
+
+
+def test_250_snv_in_stop_codon_with_immediate_utr_stop_is_stoploss():
+    # chr16:17549386 A>G, Lrrc74b-204 / ENSMUST00000232637 on GRCm38.
+    # Transcript is on the reverse strand, so the + strand A>G is a T>C
+    # on the transcript, changing the stop codon TGA to CGA (Arg).
+    # The 3' UTR begins with another TGA, so the new protein gains
+    # exactly one amino acid (R).
+    variant = Variant(
+        contig=16,
+        start=17549386,
+        ref="A",
+        alt="G",
+        genome="GRCm38",
+    )
+    transcript = variant.ensembl.transcript_by_id("ENSMUST00000232637")
+    effect = variant.effect_on_transcript(transcript)
+    assert effect.__class__ is StopLoss, \
+        "Expected StopLoss, got %s" % effect.__class__.__name__
+    assert effect.aa_alt == "R", \
+        "Expected aa_alt='R', got %r" % effect.aa_alt
+
+
+def test_250b_second_snv_in_stop_codon_with_immediate_utr_stop_is_stoploss():
+    # chr7:126830599 A>T from the #250 follow-up comment.
+    # Same bug on 4930451I11Rik-201 / ENSMUST00000061695.
+    variant = Variant(
+        contig=7,
+        start=126830599,
+        ref="A",
+        alt="T",
+        genome="GRCm38",
+    )
+    transcript = variant.ensembl.transcript_by_id("ENSMUST00000061695")
+    effect = variant.effect_on_transcript(transcript)
+    assert effect.__class__ is StopLoss, \
+        "Expected StopLoss, got %s" % effect.__class__.__name__
+
+
+# -----------------------------------------------------------------------
+# Issue #205: Same underlying bug
+# -----------------------------------------------------------------------
+
+
+def test_205_stop_codon_snv_is_stoploss_when_utr_has_consecutive_stops():
+    # chr11:21319856 T>C, Vps54-201 / ENSMUST00000006221 on GRCm38.
+    # CDS ends with TGA; 3' UTR starts with TGA. SNV changes first TGA to
+    # CGA (Arg). Reporter says the correct annotation is StopLoss.
+    variant = Variant(
+        contig=11,
+        start=21319856,
+        ref="T",
+        alt="C",
+        genome="GRCm38",
+    )
+    transcript = variant.ensembl.transcript_by_id("ENSMUST00000006221")
+    effect = variant.effect_on_transcript(transcript)
+    assert effect.__class__ is StopLoss, \
+        "Expected StopLoss, got %s" % effect.__class__.__name__
+    assert effect.aa_alt == "R", \
+        "Expected aa_alt='R', got %r" % effect.aa_alt
+
+
+# -----------------------------------------------------------------------
+# Issue #201: Insertion before stop codon that yields identical protein
+#
+# Insertion of ATATAA after the last C of "...TTC | ATC TGA" gives
+# "...TTC ATA TAA ATC TGA". The new TAA terminates translation after F I,
+# matching the original protein ending F I. The proteins are identical;
+# the annotation should be Silent, not Insertion.
+# -----------------------------------------------------------------------
+
+
+def test_201_synonymous_insertion_before_stop_is_silent():
+    variant = Variant(
+        contig=1,
+        start=100484695,
+        ref="C",
+        alt="CATATAA",
+        genome="GRCm38",
+    )
+    transcript = variant.ensembl.transcript_by_id("ENSMUST00000086738")
+    effect = variant.effect_on_transcript(transcript)
+    assert effect.__class__ is Silent, \
+        "Expected Silent, got %s (%s)" % (
+            effect.__class__.__name__,
+            getattr(effect, "short_description", effect))

--- a/tests/test_symbolic_alleles.py
+++ b/tests/test_symbolic_alleles.py
@@ -1,0 +1,162 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression tests for https://github.com/openvax/varcode/issues/88
+
+VCFs (e.g. from 1000 Genomes) contain symbolic alleles for structural
+variants such as `<CN0>` or `<INS:ME:ALU>`, and breakend notation like
+`G]17:198982]`. Varcode previously crashed on these; it should instead
+skip them (optionally with a warning).
+"""
+
+import os
+import tempfile
+
+import pytest
+
+from varcode import load_vcf
+
+
+VCF_HEADER = """##fileformat=VCFv4.1
+##reference=GRCh37
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+"""
+
+
+def _write_vcf(body):
+    fd, path = tempfile.mkstemp(suffix=".vcf")
+    with os.fdopen(fd, "w") as f:
+        f.write(VCF_HEADER)
+        f.write(body)
+    return path
+
+
+def test_symbolic_cnv_allele_is_skipped():
+    path = _write_vcf(
+        "22\t51179178\tBI_GS_DEL1\tA\t<CN0>\t100\tPASS\t.\n"
+        "22\t51179100\tnormal_snv\tA\tG\t100\tPASS\t.\n"
+    )
+    try:
+        vc = load_vcf(path, genome="GRCh37")
+    finally:
+        os.unlink(path)
+    # The normal SNV should load, the symbolic allele should be skipped.
+    assert len(vc) == 1, \
+        "Expected 1 variant after skipping symbolic allele, got %d" % len(vc)
+    assert vc[0].ref == "A" and vc[0].alt == "G"
+
+
+def test_symbolic_insertion_allele_is_skipped():
+    path = _write_vcf(
+        "22\t51068654\tALU_test\tG\t<INS:ME:ALU>\t100\tPASS\t.\n"
+    )
+    try:
+        vc = load_vcf(path, genome="GRCh37")
+    finally:
+        os.unlink(path)
+    assert len(vc) == 0, \
+        "Expected 0 variants (symbolic allele skipped), got %d" % len(vc)
+
+
+def test_breakend_allele_is_skipped():
+    # VCF 4.1 breakend notation, e.g. G]17:198982]
+    path = _write_vcf(
+        "17\t198982\tbnd_W\tG\tG]17:321681]\t100\tPASS\t.\n"
+        "17\t198983\tnormal\tC\tT\t100\tPASS\t.\n"
+    )
+    try:
+        vc = load_vcf(path, genome="GRCh37")
+    finally:
+        os.unlink(path)
+    assert len(vc) == 1, \
+        "Expected 1 variant after skipping breakend, got %d" % len(vc)
+    assert vc[0].ref == "C" and vc[0].alt == "T"
+
+
+def test_multiallelic_with_one_symbolic_and_one_normal_keeps_normal():
+    # When a row has multiple alts, only the symbolic ones should be skipped.
+    path = _write_vcf(
+        "22\t51179178\tmixed\tA\tG,<CN0>\t100\tPASS\t.\n"
+    )
+    try:
+        vc = load_vcf(path, genome="GRCh37")
+    finally:
+        os.unlink(path)
+    assert len(vc) == 1, \
+        "Expected 1 variant (normal SNV kept), got %d" % len(vc)
+    assert vc[0].ref == "A" and vc[0].alt == "G"
+
+
+def test_mixed_vcf_with_many_symbolic_alleles_does_not_crash():
+    # Previously, a VCF with symbolic alleles caused the loader to crash
+    # with AttributeError: '_SV' object has no attribute 'sequence'
+    # (or ValueError on invalid nucleotides). The loader should be robust.
+    path = _write_vcf(
+        "22\t51179178\ta\tA\t<CN0>\t100\tPASS\t.\n"
+        "22\t51068654\tb\tG\t<INS:ME:ALU>\t100\tPASS\t.\n"
+        "22\t51068700\tc\tG\t<DEL>\t100\tPASS\t.\n"
+        "22\t51179100\tnormal\tA\tG\t100\tPASS\t.\n"
+    )
+    try:
+        vc = load_vcf(path, genome="GRCh37")
+    finally:
+        os.unlink(path)
+    assert len(vc) == 1, "Expected 1 variant after filtering symbolic alleles"
+
+
+def test_user_is_warned_when_symbolic_alleles_are_skipped():
+    # The user should be informed via warnings.warn (not just DEBUG log)
+    # when alleles are skipped, so silent data loss doesn't go unnoticed.
+    import warnings
+    path = _write_vcf(
+        "22\t51179178\ta\tA\t<CN0>\t100\tPASS\t.\n"
+        "22\t51068654\tb\tG\t<INS:ME:ALU>\t100\tPASS\t.\n"
+        "22\t51179100\tnormal\tA\tG\t100\tPASS\t.\n"
+    )
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            load_vcf(path, genome="GRCh37")
+    finally:
+        os.unlink(path)
+    matching = [
+        w for w in caught
+        if "symbolic" in str(w.message).lower()
+        or "breakend" in str(w.message).lower()
+    ]
+    assert len(matching) >= 1, \
+        "Expected at least one warning about skipped symbolic alleles"
+    assert "2" in str(matching[0].message), \
+        "Warning should report the count (2) of skipped alleles: %r" % (
+            str(matching[0].message),)
+
+
+def test_no_warning_when_no_symbolic_alleles_skipped():
+    # If the VCF has only normal variants, no skip warning should fire.
+    import warnings
+    path = _write_vcf(
+        "22\t51179100\tnormal\tA\tG\t100\tPASS\t.\n"
+    )
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            load_vcf(path, genome="GRCh37")
+    finally:
+        os.unlink(path)
+    symbolic_warnings = [
+        w for w in caught
+        if "symbolic" in str(w.message).lower()
+        or "breakend" in str(w.message).lower()
+    ]
+    assert len(symbolic_warnings) == 0, \
+        "Should not emit symbolic-allele warnings when nothing was skipped"

--- a/varcode/effects/effect_classes.py
+++ b/varcode/effects/effect_classes.py
@@ -352,7 +352,13 @@ class Silent(CodingMutation):
 
     @property
     def short_description(self):
-        return "silent"
+        # HGVS p.= notation for synonymous changes: "p.{aa_ref}{1-indexed pos}="
+        # (http://varnomen.hgvs.org/). If aa_ref is empty (the silent
+        # change was fully captured by the shared prefix/suffix and we
+        # have nothing to name), fall back to a positional-only form.
+        if self.aa_ref:
+            return "p.%s%d=" % (self.aa_ref, self.aa_pos + 1)
+        return "p.%d=" % (self.aa_pos + 1)
 
 
 class AlternateStartCodon(Silent):
@@ -638,6 +644,13 @@ class PrematureStop(KnownAminoAcidChange):
 
     @property
     def short_description(self):
+        # When aa_ref is empty, the mutation is an insertion (no residues
+        # were replaced) — use HGVS "ins" notation so the description is
+        # unambiguous. Otherwise fall through to "{ref}{pos}{alt}*".
+        if len(self.aa_ref) == 0:
+            return "p.%dins%s*" % (
+                self.aa_mutation_start_offset + 1,
+                self.aa_alt)
         return "p.%s%d%s*" % (
             self.aa_ref,
             self.aa_mutation_start_offset + 1,

--- a/varcode/effects/effect_collection.py
+++ b/varcode/effects/effect_collection.py
@@ -23,6 +23,14 @@ from .effect_ordering import (
 )
 
 
+def _default_effect_sort_key(effect):
+    """Default sort key for EffectCollection: highest-priority effects
+    first. Negating the priority integer turns Python's ascending sort
+    into descending-by-priority. See openvax/varcode#227.
+    """
+    return -effect_priority(effect)
+
+
 class EffectCollection(Collection):
     """
     Collection of MutationEffect objects and helpers for grouping or filtering
@@ -41,10 +49,17 @@ class EffectCollection(Collection):
 
         sort_key : fn
             Function which maps each element to a sorting criterion.
+            If None (the default), effects are sorted by priority with
+            the most severe effects first. Pass an explicit sort_key to
+            override this behaviour, or `False` to disable sorting.
 
         sources : set
             Set of files from which this collection was generated.
         """
+        if sort_key is None:
+            sort_key = _default_effect_sort_key
+        elif sort_key is False:
+            sort_key = None
         self.effects = effects
         Collection.__init__(
             self,

--- a/varcode/effects/effect_prediction_coding_in_frame.py
+++ b/varcode/effects/effect_prediction_coding_in_frame.py
@@ -217,14 +217,36 @@ def predict_in_frame_coding_effect(
             aa_ref=aa_ref,
             aa_alt=aa_alt)
 
+    # If a mutation introduces a premature stop codon but the resulting
+    # protein is identical to the reference — i.e. the new amino acids
+    # preceding the premature stop happen to match the tail of the
+    # reference protein — then the mutation is effectively silent.
+    # Example: an insertion before the stop codon that replicates the
+    # last residue and introduces a new stop in frame.
+    if mutant_codons_contain_stop:
+        mutant_protein_length = aa_mutation_start_offset + n_aa_alt
+        ref_tail = transcript.protein_sequence[
+            aa_mutation_start_offset:reference_protein_length]
+        if (mutant_protein_length == reference_protein_length and
+                aa_alt == ref_tail):
+            return Silent(
+                variant=variant,
+                transcript=transcript,
+                aa_pos=aa_mutation_start_offset,
+                aa_ref=shared_prefix + aa_alt + shared_suffix)
+
     if (aa_mutation_start_offset > reference_protein_length) or (
             n_aa_ref == n_aa_alt == 0):
         # if inserted nucleotides go after original stop codon or if nothing
-        # is changed in the amino acid sequence then this is a Silent variant
+        # is changed in the amino acid sequence then this is a Silent variant.
+        # For Silent we report the position of the first affected codon
+        # (before the shared-prefix offset is applied), since the user wants
+        # to know *where* the synonymous change happens, not where the first
+        # non-silent change would have been.
         return Silent(
             variant=variant,
             transcript=transcript,
-            aa_pos=aa_mutation_start_offset,
+            aa_pos=aa_mutation_start_offset - n_aa_shared,
             aa_ref=shared_prefix + shared_suffix)
     elif using_three_prime_utr:
         # if non-silent mutation is at the end of the protein then

--- a/varcode/effects/translate.py
+++ b/varcode/effects/translate.py
@@ -168,16 +168,18 @@ def translate_in_frame_mutation(
         # nucleotide sequence of both the end of the CDS and the 3' UTR
         first_utr_stop_codon_index = find_first_stop_codon(truncated_utr_sequence)
 
-        if first_utr_stop_codon_index > 0:
-            # if there is a stop codon in the 3' UTR sequence and it's not the
-            # very first codon
+        if first_utr_stop_codon_index >= 0:
+            # if there is a stop codon in the 3' UTR sequence (including the
+            # case where it is the very first codon immediately after the
+            # disrupted original stop)
             using_three_prime_utr = True
             n_mutant_codons_before_utr = len(mutant_codons) // 3
             mutant_stop_codon_index = n_mutant_codons_before_utr + first_utr_stop_codon_index
             # combine the in-frame mutant codons with the truncated sequence of
-            # the 3' UTR
+            # the 3' UTR up to the first UTR stop codon (empty when the UTR
+            # itself starts with a stop)
             mutant_codons += truncated_utr_sequence[:first_utr_stop_codon_index * 3]
-        elif first_utr_stop_codon_index == -1:
+        else:
             # if there is no stop codon in the 3' UTR sequence
             using_three_prime_utr = True
             mutant_codons += truncated_utr_sequence

--- a/varcode/vcf.py
+++ b/varcode/vcf.py
@@ -34,6 +34,26 @@ from .variant_collection import VariantCollection
 logger = logging.getLogger(__name__)
 
 
+def _is_symbolic_allele(alt):
+    """Return True if `alt` is a VCF symbolic allele or breakend notation
+    that varcode cannot currently represent as a simple ref/alt Variant.
+
+    Examples of alleles that return True:
+        <DEL>, <DUP>, <INS>, <INV>, <CN0>, <INS:ME:ALU>  (symbolic)
+        G]17:198982], ]17:198982]G, [13:123456[T, T[13:123456[  (breakends)
+        *  (spanning deletion placeholder)
+    """
+    if not alt:
+        return False
+    if alt.startswith("<"):
+        return True
+    if "[" in alt or "]" in alt:
+        return True
+    if alt == "*":
+        return True
+    return False
+
+
 def load_vcf(
         path,
         genome=None,
@@ -308,6 +328,7 @@ def dataframes_to_variant_collection(
 
     variants = []
     metadata = {}
+    n_skipped_symbolic = 0
     try:
         for chunk in dataframes:
             assert chunk.columns.tolist() == expected_columns,\
@@ -331,6 +352,17 @@ def dataframes_to_variant_collection(
                 info = sample_info = None
                 for alt in alts.split(","):
                     if alt != ".":
+                        if _is_symbolic_allele(alt):
+                            # VCF symbolic alleles (e.g. "<CN0>",
+                            # "<INS:ME:ALU>") and breakend notation (e.g.
+                            # "G]17:198982]") represent structural variants
+                            # that varcode cannot currently represent as a
+                            # simple ref/alt Variant. Skip them so the
+                            # rest of the VCF still loads, but track the
+                            # count for a visible warning at the end.
+                            n_skipped_symbolic += 1
+                            alt_num += 1
+                            continue
                         if info_parser is not None and info is None:
                             info = info_parser(tpl[8])  # INFO column
                             if sample_names:
@@ -360,6 +392,15 @@ def dataframes_to_variant_collection(
                     alt_num += 1
     except StopIteration:
         pass
+
+    if n_skipped_symbolic > 0:
+        warn(
+            "Skipped %d symbolic/breakend allele(s) in %s that varcode "
+            "cannot currently represent as simple ref/alt Variants "
+            "(e.g. <DEL>, <CN0>, <INS:ME:ALU>, breakends). "
+            "Tracked in openvax/varcode#264." % (
+                n_skipped_symbolic, source_path)
+        )
 
     return VariantCollection(
         variants=variants,


### PR DESCRIPTION
## Summary

Closes or substantially addresses six reported bugs plus one visibility improvement, with 32 new regression tests (378 → 410 passing, zero regressions).

### Classification bugs (wrong effect type returned)

- **#250** — SNV in the stop codon reported as `Insertion(p.XinsR)` instead of `StopLoss` when the 3' UTR begins with another stop codon. Root cause: `translate_in_frame_mutation` had branches for `first_utr_stop_codon_index > 0` and `== -1` but not `== 0`, so `using_three_prime_utr` stayed False and the StopLoss branch was never taken.
- **#205** — Same root cause as #250 on a different transcript.
- **#201** — Insertion of `ATATAA` before the stop codon is reported as `Insertion(p.1291insI)` even though the resulting protein is identical to the reference (the inserted \`TAA\` creates a new stop at the same protein position). New silent check: if a premature stop is introduced and the new amino acids match the reference tail, classify as Silent.

### Position / format bugs

- **#208** — \`Silent.aa_pos\` was off by one. After \`trim_shared_flanking_strings\`, \`aa_mutation_start_offset\` had been advanced past the shared prefix, but for Silent we want the position of the first affected codon. Fixed by subtracting \`n_aa_shared\` in the Silent call.
- **#216** — \`PrematureStop.short_description\` produced \`p.7*\` when \`aa_ref\` was empty (the stop was introduced by an insertion, not a substitution). Now returns HGVS-style \`p.7ins*\` / \`p.7insK*\` when \`aa_ref\` is empty.
- **#217** — \`Silent.short_description\` returned the literal string \`"silent"\`. Now returns HGVS-standard \`p.R6=\`.

### Loader robustness

- **#88** — VCFs with symbolic alleles (\`<DEL>\`, \`<CN0>\`, \`<INS:ME:ALU>\`) or breakend notation (\`G]17:198982]\`) caused \`load_vcf\` to crash. These are now skipped with a visible \`warnings.warn\` call that reports the total skipped count per file and points at the tracking issue (#264) for eventual structural variant support.

### API ergonomics

- **#227** — \`EffectCollection\` now sorts by effect priority descending by default. The first element is the most severe effect. Pass \`sort_key=False\` to disable sorting or your own callable to override.

## Test plan

- [x] \`tests/test_stop_codon_classification_bugs.py\` — 4 tests for #250/#205/#201
- [x] \`tests/test_silent_aa_pos.py\` — 3 tests for #208
- [x] \`tests/test_symbolic_alleles.py\` — 7 tests for #88, including a test that \`warnings.warn\` is emitted with the correct count
- [x] \`tests/test_premature_stop_short_description.py\` — 5 tests for #216 covering all aa_ref/aa_alt permutations
- [x] \`tests/test_silent_hgvs_description.py\` — 4 tests for #217
- [x] \`tests/test_effect_collection_sort_order.py\` — 3 tests for #227 including verification that custom sort_key is still respected
- [x] Existing MAF test updated since varcode's \`short_description\` now aligns with MAF's own \`p.G384\` convention rather than needing a special case for \`"silent"\`
- [x] Full test suite: 410 passed, 0 failed
- [x] \`./lint.sh\` passes

## Related

- Spawned #264 (tracking issue) for eventual first-class support of symbolic alleles and breakends as extended variant types (depends on #257).