### PR TITLE
Fix #220 - sync .variants/.effects with iteration order

### DIFF
--- a/tests/test_collection_variants_attr_consistency.py
+++ b/tests/test_collection_variants_attr_consistency.py
@@ -1,0 +1,88 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression tests for https://github.com/openvax/varcode/issues/220
+
+VariantCollection.variants was assigned the raw input list before
+Collection.__init__ sorted / de-duplicated elements, so iterating a
+VariantCollection produced one order while `.variants` produced
+another. The same pattern existed in EffectCollection.effects.
+"""
+
+import varcode
+from varcode import Variant, VariantCollection
+from varcode.effects.effect_collection import EffectCollection
+
+
+def _unsorted_variants():
+    return [
+        Variant(contig="1", start=4, ref="A", alt="T"),
+        Variant(contig="1", start=1, ref="A", alt="T"),
+        Variant(contig="1", start=3, ref="A", alt="T"),
+        Variant(contig="1", start=2, ref="A", alt="T"),
+    ]
+
+
+def test_variant_collection_variants_matches_iteration_with_default_sort():
+    vc = VariantCollection(variants=_unsorted_variants())
+    iterated = [v.start for v in vc]
+    via_attr = [v.start for v in vc.variants]
+    assert iterated == via_attr, (
+        "vc.variants should match iteration order, got %r vs %r"
+        % (via_attr, iterated)
+    )
+
+
+def test_variant_collection_variants_matches_iteration_with_sort_key_none_distinct_false():
+    # Explicitly opt out of sorting and deduplication. Iteration and
+    # .variants should both preserve the original input order.
+    variants = _unsorted_variants()
+    vc = VariantCollection(
+        variants=variants, sort_key=None, distinct=False
+    )
+    iterated = [v.start for v in vc]
+    via_attr = [v.start for v in vc.variants]
+    assert iterated == via_attr
+    # And the order should match the input.
+    assert iterated == [4, 1, 3, 2]
+
+
+def test_variant_collection_variants_matches_iteration_with_distinct_true():
+    # When distinct=True and sort_key=None, the base Collection uses
+    # set() which loses order. Regardless of what order it ends up in,
+    # iteration and .variants should agree.
+    variants = _unsorted_variants()
+    vc = VariantCollection(
+        variants=variants, sort_key=None, distinct=True
+    )
+    iterated = [v.start for v in vc]
+    via_attr = [v.start for v in vc.variants]
+    assert iterated == via_attr
+
+
+def test_variant_collection_len_matches_variants_attr():
+    vc = VariantCollection(variants=_unsorted_variants())
+    assert len(vc) == len(vc.variants)
+
+
+def test_effect_collection_effects_matches_iteration():
+    # Same bug existed in EffectCollection.effects — produce an effect
+    # collection and verify the two access paths agree.
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    effects = variant.effects()
+    iterated = [e.__class__.__name__ for e in effects]
+    via_attr = [e.__class__.__name__ for e in effects.effects]
+    assert iterated == via_attr, (
+        "effects.effects should match iteration order, got %r vs %r"
+        % (via_attr, iterated)
+    )

--- a/varcode/effects/effect_collection.py
+++ b/varcode/effects/effect_collection.py
@@ -60,13 +60,16 @@ class EffectCollection(Collection):
             sort_key = _default_effect_sort_key
         elif sort_key is False:
             sort_key = None
-        self.effects = effects
         Collection.__init__(
             self,
             elements=effects,
             distinct=distinct,
             sort_key=sort_key,
             sources=sources)
+        # Keep self.effects in sync with the Collection's post-sort
+        # elements so that iterating and reading `.effects` produce
+        # the same order.  See openvax/varcode#220.
+        self.effects = self.elements
 
     def to_dict(self):
         return dict(

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -50,7 +50,6 @@ class VariantCollection(Collection):
             from metadata attributes to values.
         """
         self.source_to_metadata_dict = source_to_metadata_dict
-        self.variants = variants
         if sources is None:
             sources = set(source_to_metadata_dict.keys())
         if any(source not in sources for source in source_to_metadata_dict.keys()):
@@ -64,6 +63,10 @@ class VariantCollection(Collection):
             distinct=distinct,
             sort_key=sort_key,
             sources=sources)
+        # Keep self.variants in sync with the Collection's post-sort,
+        # post-dedup elements so that iterating `vc` and reading
+        # `vc.variants` produce the same order.  See openvax/varcode#220.
+        self.variants = self.elements
 
     @property
     def metadata(self):


### PR DESCRIPTION
## Summary

VariantCollection stored the raw input list in `self.variants` before `Collection.__init__` sorted/de-duped elements into `self.elements`, so iterating the collection and reading `.variants` produced different orders. Same bug existed in `EffectCollection.effects`.

## Fix

Move the `self.variants = ...` assignment to after `Collection.__init__` and set it to `self.elements` so both access paths share the same underlying list.

## Test plan

- [x] 5 new regression tests in `tests/test_collection_variants_attr_consistency.py` covering:
  - Default sort
  - sort_key=None, distinct=False (preserves input order)
  - sort_key=None, distinct=True (set-driven order, but iteration and .variants agree)
  - len() consistency
  - EffectCollection.effects vs iteration
- [x] Full test suite: 415 passed, 0 regressions

Closes #220