### PR TITLE
Add VariantCollection.from_csv and EffectCollection.from_csv

### DIFF
--- a/tests/test_csv_roundtrip.py
+++ b/tests/test_csv_roundtrip.py
@@ -163,25 +163,153 @@ def test_effect_collection_csv_roundtrip_preserves_transcripts():
 
 
 def test_effect_collection_from_csv_skips_comment_lines():
-    # from_csv should treat '#'-prefixed lines as comments — this is the
-    # convention we'll use for provenance/annotator metadata once #271
-    # lands.
+    # from_csv should treat extra '#'-prefixed lines as comments that
+    # don't interfere with body parsing.
     variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
     original = variant.effects()
 
     path = _tmp_csv()
     try:
         original.to_csv(path)
-        # Prepend a few comment lines.
+        # Prepend a few extra comment lines in addition to the header
+        # that to_csv already wrote.
         with open(path, "r") as f:
             body = f.read()
         with open(path, "w") as f:
-            f.write("# varcode_version=2.0.0\n")
             f.write("# annotator=legacy\n")
-            f.write("# reference=GRCh38\n")
+            f.write("# timestamp=2026-04-12T14:30:00Z\n")
             f.write(body)
-        loaded = EffectCollection.from_csv(path, genome="GRCh38")
+        loaded = EffectCollection.from_csv(path)
     finally:
         os.unlink(path)
 
     assert len(loaded) == len(original)
+
+
+# -----------------------------------------------------------------------
+# Metadata header: genome is optional when the header carries it,
+# required otherwise.
+# -----------------------------------------------------------------------
+
+
+def test_variant_collection_to_csv_writes_metadata_header():
+    variants = [
+        Variant("17", 43082404, "C", "T", "GRCh38"),
+    ]
+    vc = VariantCollection(variants=variants)
+    path = _tmp_csv()
+    try:
+        vc.to_csv(path)
+        with open(path) as f:
+            head = "".join(f.readline() for _ in range(4))
+    finally:
+        os.unlink(path)
+    assert "# varcode_version=" in head
+    assert "# reference_name=GRCh38" in head
+
+
+def test_variant_collection_from_csv_reads_genome_from_header():
+    variants = [
+        Variant("17", 43082404, "C", "T", "GRCh38"),
+        Variant("7", 117531114, "G", "T", "GRCh38"),
+    ]
+    original = VariantCollection(variants=variants)
+    path = _tmp_csv()
+    try:
+        original.to_csv(path)
+        # Don't pass genome — should be read from the header.
+        loaded = VariantCollection.from_csv(path)
+    finally:
+        os.unlink(path)
+    assert len(loaded) == len(original)
+    # The loaded variants should have resolved the same reference.
+    assert all(v.reference_name == "GRCh38" for v in loaded)
+
+
+def test_variant_collection_from_csv_explicit_genome_overrides_header():
+    # Explicit genome argument takes precedence over header.
+    variants = [Variant("17", 43082404, "C", "T", "GRCh38")]
+    path = _tmp_csv()
+    try:
+        VariantCollection(variants=variants).to_csv(path)
+        loaded = VariantCollection.from_csv(path, genome="GRCh38")
+    finally:
+        os.unlink(path)
+    assert len(loaded) == 1
+
+
+def test_variant_collection_from_csv_raises_without_genome_or_header():
+    # If the CSV has no header metadata and the caller doesn't pass
+    # genome, we should raise a clear error rather than guessing.
+    variants = [Variant("17", 43082404, "C", "T", "GRCh38")]
+    path = _tmp_csv()
+    try:
+        VariantCollection(variants=variants).to_csv(path, include_header=False)
+        try:
+            VariantCollection.from_csv(path)
+        except ValueError as e:
+            assert "genome" in str(e) and "reference_name" in str(e), \
+                "Expected error to mention genome and reference_name, got %r" % str(e)
+        else:
+            raise AssertionError("Expected ValueError when no genome is available")
+    finally:
+        os.unlink(path)
+
+
+def test_effect_collection_to_csv_writes_metadata_header():
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    ec = variant.effects()
+    path = _tmp_csv()
+    try:
+        ec.to_csv(path)
+        with open(path) as f:
+            head = "".join(f.readline() for _ in range(4))
+    finally:
+        os.unlink(path)
+    assert "# varcode_version=" in head
+    assert "# reference_name=GRCh38" in head
+
+
+def test_effect_collection_from_csv_reads_genome_from_header():
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    original = variant.effects()
+    path = _tmp_csv()
+    try:
+        original.to_csv(path)
+        # Don't pass genome — should be read from the header.
+        loaded = EffectCollection.from_csv(path)
+    finally:
+        os.unlink(path)
+    assert len(loaded) == len(original)
+
+
+def test_effect_collection_from_csv_raises_without_genome_or_header():
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    ec = variant.effects()
+    path = _tmp_csv()
+    try:
+        ec.to_csv(path, include_header=False)
+        try:
+            EffectCollection.from_csv(path)
+        except ValueError as e:
+            assert "genome" in str(e) and "reference_name" in str(e)
+        else:
+            raise AssertionError("Expected ValueError when no genome is available")
+    finally:
+        os.unlink(path)
+
+
+def test_csv_to_csv_without_header_is_opt_out_legacy_format():
+    # to_csv(include_header=False) produces a plain CSV for legacy
+    # consumers that don't tolerate comment lines.
+    variants = [Variant("17", 43082404, "C", "T", "GRCh38")]
+    path = _tmp_csv()
+    try:
+        VariantCollection(variants=variants).to_csv(path, include_header=False)
+        with open(path) as f:
+            first_line = f.readline()
+    finally:
+        os.unlink(path)
+    # First line should be the column header, not a '#' comment.
+    assert not first_line.startswith("#"), \
+        "include_header=False should not produce leading comment lines"

--- a/tests/test_csv_roundtrip.py
+++ b/tests/test_csv_roundtrip.py
@@ -1,0 +1,187 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Round-trip tests for VariantCollection.from_csv and
+EffectCollection.from_csv.
+
+These are the lightweight inverse of the existing .to_csv() path. For
+VariantCollection the round-trip is exact (ref/alt/position are
+preserved). For EffectCollection the round-trip is semantic — it
+records (variant, transcript_id) pairs and re-runs annotation on read,
+so the resulting effects match whenever annotation is deterministic.
+"""
+
+import os
+import tempfile
+
+from varcode import Variant, VariantCollection
+from varcode.effects import EffectCollection
+
+
+def _tmp_csv():
+    fd, path = tempfile.mkstemp(suffix=".csv")
+    os.close(fd)
+    return path
+
+
+# -----------------------------------------------------------------------
+# VariantCollection round-trip
+# -----------------------------------------------------------------------
+
+
+def test_variant_collection_csv_roundtrip_preserves_variants():
+    variants = [
+        Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38"),
+        Variant("7", 117531114, "G", "T", "GRCh38"),
+        Variant("7", 117530898, "G", "A", "GRCh38"),
+    ]
+    original = VariantCollection(variants=variants)
+
+    path = _tmp_csv()
+    try:
+        original.to_csv(path)
+        loaded = VariantCollection.from_csv(path, genome="GRCh38")
+    finally:
+        os.unlink(path)
+
+    # Sort key on both collections produces the same ordering.
+    assert len(loaded) == len(original)
+    for original_variant, loaded_variant in zip(original, loaded):
+        assert loaded_variant.contig == original_variant.contig
+        assert loaded_variant.start == original_variant.start
+        assert loaded_variant.ref == original_variant.ref
+        assert loaded_variant.alt == original_variant.alt
+
+
+def test_variant_collection_csv_roundtrip_handles_indels():
+    # Insertion (empty ref) and deletion (empty alt) should survive the
+    # CSV round-trip even though pandas may read '' as NaN.
+    variants = [
+        Variant("17", 43082404, "C", "", "GRCh38"),          # deletion
+        Variant("17", 43082575 - 6, "", "AAA", "GRCh38"),    # insertion
+    ]
+    original = VariantCollection(variants=variants)
+
+    path = _tmp_csv()
+    try:
+        original.to_csv(path)
+        loaded = VariantCollection.from_csv(path, genome="GRCh38")
+    finally:
+        os.unlink(path)
+
+    assert len(loaded) == 2
+    deletions = [v for v in loaded if v.alt == ""]
+    insertions = [v for v in loaded if v.ref == ""]
+    assert len(deletions) == 1
+    assert len(insertions) == 1
+    assert deletions[0].ref == "C"
+    assert insertions[0].alt == "AAA"
+
+
+def test_variant_collection_from_csv_rejects_missing_columns():
+    # If the CSV is missing required columns, from_csv should raise
+    # rather than silently produce empty or wrong variants.
+    import pandas as pd
+    path = _tmp_csv()
+    try:
+        pd.DataFrame({"chr": ["17"], "start": [100]}).to_csv(path, index=False)
+        try:
+            VariantCollection.from_csv(path, genome="GRCh38")
+        except ValueError as e:
+            assert "ref" in str(e) and "alt" in str(e), \
+                "Error should name the missing columns, got %r" % str(e)
+        else:
+            raise AssertionError("Expected ValueError for missing columns")
+    finally:
+        os.unlink(path)
+
+
+# -----------------------------------------------------------------------
+# EffectCollection round-trip
+# -----------------------------------------------------------------------
+
+
+def test_effect_collection_csv_roundtrip_preserves_effect_types():
+    # Use a variant with a well-known effect signature across several
+    # transcripts so we can compare the class distribution pre and post.
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    original = variant.effects()
+
+    path = _tmp_csv()
+    try:
+        original.to_csv(path)
+        loaded = EffectCollection.from_csv(path, genome="GRCh38")
+    finally:
+        os.unlink(path)
+
+    assert len(loaded) == len(original), (
+        "Effect counts differ: original=%d loaded=%d" % (
+            len(original), len(loaded))
+    )
+
+    # Same class distribution and same short descriptions.
+    original_types = sorted(e.__class__.__name__ for e in original)
+    loaded_types = sorted(e.__class__.__name__ for e in loaded)
+    assert original_types == loaded_types
+
+    original_descs = sorted(e.short_description for e in original)
+    loaded_descs = sorted(e.short_description for e in loaded)
+    assert original_descs == loaded_descs
+
+
+def test_effect_collection_csv_roundtrip_preserves_transcripts():
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    original = variant.effects()
+
+    path = _tmp_csv()
+    try:
+        original.to_csv(path)
+        loaded = EffectCollection.from_csv(path, genome="GRCh38")
+    finally:
+        os.unlink(path)
+
+    # Transcript IDs should be preserved (with None appearing exactly
+    # once per original None).
+    def transcript_ids(ec):
+        ids = [
+            str(e.transcript_id) if e.transcript_id else None
+            for e in ec
+        ]
+        return sorted(ids, key=lambda x: (x is None, x or ""))
+
+    assert transcript_ids(loaded) == transcript_ids(original)
+
+
+def test_effect_collection_from_csv_skips_comment_lines():
+    # from_csv should treat '#'-prefixed lines as comments — this is the
+    # convention we'll use for provenance/annotator metadata once #271
+    # lands.
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    original = variant.effects()
+
+    path = _tmp_csv()
+    try:
+        original.to_csv(path)
+        # Prepend a few comment lines.
+        with open(path, "r") as f:
+            body = f.read()
+        with open(path, "w") as f:
+            f.write("# varcode_version=2.0.0\n")
+            f.write("# annotator=legacy\n")
+            f.write("# reference=GRCh38\n")
+            f.write(body)
+        loaded = EffectCollection.from_csv(path, genome="GRCh38")
+    finally:
+        os.unlink(path)
+
+    assert len(loaded) == len(original)

--- a/tests/test_csv_roundtrip.py
+++ b/tests/test_csv_roundtrip.py
@@ -313,3 +313,146 @@ def test_csv_to_csv_without_header_is_opt_out_legacy_format():
     # First line should be the column header, not a '#' comment.
     assert not first_line.startswith("#"), \
         "include_header=False should not produce leading comment lines"
+
+
+# -----------------------------------------------------------------------
+# Edge cases: empty collections, blank-line tolerance in header parser,
+# intergenic fallback path in EffectCollection.from_csv.
+# -----------------------------------------------------------------------
+
+
+def test_variant_collection_empty_csv_roundtrip():
+    # Empty collection round-trips without crashing. No reference is
+    # available to write in the header, so from_csv needs an explicit
+    # genome.
+    empty = VariantCollection(variants=[])
+    path = _tmp_csv()
+    try:
+        empty.to_csv(path)
+        loaded = VariantCollection.from_csv(path, genome="GRCh38")
+    finally:
+        os.unlink(path)
+    assert len(loaded) == 0
+
+
+def test_effect_collection_empty_csv_roundtrip():
+    empty = EffectCollection(effects=[])
+    path = _tmp_csv()
+    try:
+        empty.to_csv(path)
+        loaded = EffectCollection.from_csv(path, genome="GRCh38")
+    finally:
+        os.unlink(path)
+    assert len(loaded) == 0
+
+
+def test_header_parser_tolerates_blank_lines():
+    # Hand-edited CSVs sometimes have a blank line between the comment
+    # block and the body; the header parser should skip it rather than
+    # treat it as end-of-header.
+    variants = [Variant("17", 43082404, "C", "T", "GRCh38")]
+    path = _tmp_csv()
+    try:
+        VariantCollection(variants=variants).to_csv(path)
+        # Inject a blank line in the middle of the header.
+        with open(path, "r") as f:
+            content = f.read()
+        lines = content.splitlines(keepends=True)
+        # Insert a blank line after the first header line.
+        new_content = lines[0] + "\n" + "".join(lines[1:])
+        with open(path, "w") as f:
+            f.write(new_content)
+        # Should still read the genome from the header and work fine.
+        loaded = VariantCollection.from_csv(path)
+    finally:
+        os.unlink(path)
+    assert len(loaded) == 1
+    assert loaded[0].reference_name == "GRCh38"
+
+
+def test_effect_collection_roundtrip_preserves_intergenic_effect():
+    # An intergenic variant produces an Intergenic effect with no
+    # transcript. The CSV row will have an empty transcript_id, and
+    # from_csv should reconstruct it via the intergenic fallback path
+    # without warning.
+    import warnings
+
+    # chr1:100 is far from any gene on GRCh38.
+    variant = Variant("1", 100, "A", "T", "GRCh38")
+    original = variant.effects()
+    intergenic_effects = [
+        e for e in original if e.__class__.__name__ == "Intergenic"
+    ]
+    assert len(intergenic_effects) >= 1, (
+        "Test variant should produce at least one Intergenic effect, got %r"
+        % [e.__class__.__name__ for e in original]
+    )
+
+    path = _tmp_csv()
+    try:
+        original.to_csv(path)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            loaded = EffectCollection.from_csv(path)
+    finally:
+        os.unlink(path)
+
+    assert len(loaded) == len(original)
+    assert any(e.__class__.__name__ == "Intergenic" for e in loaded)
+    # No spurious "could not recover" warnings on the normal path.
+    unexpected = [
+        w for w in caught if "Could not recover effect" in str(w.message)
+    ]
+    assert len(unexpected) == 0, (
+        "Unexpected fallback warnings during normal intergenic round-trip: %r"
+        % [str(w.message) for w in unexpected]
+    )
+
+
+def test_effect_collection_from_csv_warns_when_fallback_cant_match():
+    # Hand-craft a CSV with an empty transcript_id and a made-up
+    # effect_type that the annotation won't produce. from_csv should
+    # warn and drop the row rather than silently omitting it.
+    import warnings
+
+    import pandas as pd
+
+    path = _tmp_csv()
+    try:
+        df = pd.DataFrame([{
+            "variant": "chr1 g.100A>T",
+            "contig": "1",
+            "start": 100,
+            "ref": "A",
+            "alt": "T",
+            "is_snv": True,
+            "is_transversion": True,
+            "is_transition": False,
+            "gene_id": None,
+            "gene_name": None,
+            "transcript_id": None,
+            "transcript_name": None,
+            "effect_type": "DefinitelyNotARealEffectClass",
+            "effect": "p.fake",
+        }])
+        # Write a metadata header by hand so from_csv can resolve the
+        # genome, then append the body.
+        with open(path, "w") as f:
+            f.write("# varcode_version=test\n")
+            f.write("# reference_name=GRCh38\n")
+            df.to_csv(f, index=False)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            loaded = EffectCollection.from_csv(path)
+    finally:
+        os.unlink(path)
+
+    # The unmatched row should be dropped with a warning.
+    assert len(loaded) == 0
+    matching = [
+        w for w in caught if "Could not recover effect" in str(w.message)
+    ]
+    assert len(matching) >= 1, \
+        "Expected a warning when fallback could not match the effect_type"
+    assert "DefinitelyNotARealEffectClass" in str(matching[0].message)

--- a/varcode/csv_helpers.py
+++ b/varcode/csv_helpers.py
@@ -49,6 +49,10 @@ def write_metadata_header(file_obj, metadata):
 def read_metadata_header(path):
     """Parse leading ``#`` lines of a CSV into a dict.
 
+    Blank / whitespace-only lines at the top are tolerated and skipped;
+    parsing only terminates when a non-blank line that doesn't start
+    with ``#`` is encountered (the CSV body).
+
     Returns
     -------
     OrderedDict
@@ -58,7 +62,10 @@ def read_metadata_header(path):
     metadata = OrderedDict()
     with open(path, "r") as f:
         for line in f:
-            stripped = line.lstrip()
+            stripped = line.strip()
+            if not stripped:
+                # Tolerate blank lines between comment block and body.
+                continue
             if not stripped.startswith(HEADER_PREFIX):
                 break
             content = stripped[len(HEADER_PREFIX):].strip()

--- a/varcode/csv_helpers.py
+++ b/varcode/csv_helpers.py
@@ -1,0 +1,68 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Shared helpers for reading and writing ``# key=value`` metadata headers
+at the top of CSV files produced by VariantCollection / EffectCollection.
+
+The format is:
+
+    # varcode_version=2.0.0
+    # reference_name=GRCh38
+    # ...
+    col_a,col_b,col_c
+    1,2,3
+
+Any line starting with ``#`` before the first non-comment line is
+treated as a metadata header of the form ``# key=value``. Lines that
+don't fit that shape are ignored (but still skipped on read via
+``pandas.read_csv(comment='#')``).
+"""
+
+from collections import OrderedDict
+
+
+HEADER_PREFIX = "#"
+
+
+def write_metadata_header(file_obj, metadata):
+    """Write ``# key=value`` lines for each item in ``metadata``.
+
+    Values that are None are skipped so the header stays tidy when a
+    field wasn't populated.
+    """
+    for key, value in metadata.items():
+        if value is None:
+            continue
+        file_obj.write("%s %s=%s\n" % (HEADER_PREFIX, key, value))
+
+
+def read_metadata_header(path):
+    """Parse leading ``#`` lines of a CSV into a dict.
+
+    Returns
+    -------
+    OrderedDict
+        ``key -> value`` pairs in the order they appeared. Values are
+        always strings; callers are responsible for coercion.
+    """
+    metadata = OrderedDict()
+    with open(path, "r") as f:
+        for line in f:
+            stripped = line.lstrip()
+            if not stripped.startswith(HEADER_PREFIX):
+                break
+            content = stripped[len(HEADER_PREFIX):].strip()
+            if "=" in content:
+                key, _, value = content.partition("=")
+                metadata[key.strip()] = value.strip()
+    return metadata

--- a/varcode/effects/effect_collection.py
+++ b/varcode/effects/effect_collection.py
@@ -391,6 +391,7 @@ class EffectCollection(Collection):
         EffectCollection
         """
         # Import here to avoid a circular import at module load time.
+        import warnings
         from ..variant import Variant
 
         header = read_metadata_header(path)
@@ -403,7 +404,12 @@ class EffectCollection(Collection):
                 "`to_csv(include_header=True)` so `# reference_name=...` "
                 "is recorded in the header. Neither was found at %s." % path)
 
-        df = pd.read_csv(path, comment="#", dtype={"contig": str})
+        try:
+            df = pd.read_csv(path, comment="#", dtype={"contig": str})
+        except pd.errors.EmptyDataError:
+            # CSV body is empty (e.g. the collection was empty when
+            # written). Return an empty collection rather than failing.
+            return cls(effects=[])
         required = {"contig", "start", "ref", "alt", "transcript_id"}
         missing = required - set(df.columns)
         if missing:
@@ -413,12 +419,14 @@ class EffectCollection(Collection):
 
         effects = []
         resolved_genome = None
-        for _, row in df.iterrows():
-            ref = row["ref"] if pd.notna(row["ref"]) else ""
-            alt = row["alt"] if pd.notna(row["alt"]) else ""
+        # itertuples is much faster than iterrows on large CSVs; use
+        # attribute access via the namedtuple rather than row["col"].
+        for row in df.itertuples(index=False):
+            ref = row.ref if pd.notna(row.ref) else ""
+            alt = row.alt if pd.notna(row.alt) else ""
             variant = Variant(
-                contig=str(row["contig"]),
-                start=int(row["start"]),
+                contig=str(row.contig),
+                start=int(row.start),
                 ref=ref,
                 alt=alt,
                 genome=genome,
@@ -427,16 +435,25 @@ class EffectCollection(Collection):
             # so subsequent transcript lookups don't pay the inference cost.
             if resolved_genome is None:
                 resolved_genome = variant.ensembl
-            transcript_id = row["transcript_id"]
+            transcript_id = row.transcript_id
             if pd.isna(transcript_id) or transcript_id == "":
                 # Row is for an intergenic / intragenic effect — no
                 # transcript context. Rebuild by running the full effect
                 # set on the variant and taking the non-transcript match.
                 effects_for_variant = variant.effects()
+                matched = False
                 for e in effects_for_variant:
-                    if e.transcript is None and e.__class__.__name__ == row["effect_type"]:
+                    if e.transcript is None and e.__class__.__name__ == row.effect_type:
                         effects.append(e)
+                        matched = True
                         break
+                if not matched:
+                    warnings.warn(
+                        "Could not recover effect of type %r for variant %s "
+                        "with no transcript_id in %s; row dropped from "
+                        "reconstructed collection." % (
+                            row.effect_type, variant, path)
+                    )
                 continue
             transcript = resolved_genome.transcript_by_id(str(transcript_id))
             effects.append(variant.effect_on_transcript(transcript))

--- a/varcode/effects/effect_collection.py
+++ b/varcode/effects/effect_collection.py
@@ -314,3 +314,73 @@ class EffectCollection(Collection):
             row['effect'] = effect.short_description
             return row
         return pd.DataFrame.from_records([row_from_effect(effect) for effect in self])
+
+    @classmethod
+    def from_csv(cls, path, genome):
+        """Rebuild an EffectCollection from a CSV previously written by
+        ``EffectCollection.to_csv()``.
+
+        The current CSV format records (contig, start, ref, alt,
+        transcript_id) but not enough per-effect state to reconstruct
+        effects byte-for-byte. This method takes the pragmatic semantic
+        round-trip path: rebuild each Variant, re-annotate against the
+        recorded transcript, and emit the resulting effect. The
+        resulting collection should match the original whenever
+        annotation is deterministic for a given (variant, transcript)
+        pair.
+
+        Parameters
+        ----------
+        path : str
+            Path to the CSV file. Lines starting with '#' are treated as
+            comments and skipped.
+
+        genome : pyensembl.Genome or str or int
+            Reference genome to associate with the loaded variants and
+            to look up transcripts by ID.
+
+        Returns
+        -------
+        EffectCollection
+        """
+        # Import here to avoid a circular import at module load time.
+        from ..variant import Variant
+
+        df = pd.read_csv(path, comment="#", dtype={"contig": str})
+        required = {"contig", "start", "ref", "alt", "transcript_id"}
+        missing = required - set(df.columns)
+        if missing:
+            raise ValueError(
+                "CSV at %s is missing required columns: %s" % (
+                    path, sorted(missing)))
+
+        effects = []
+        resolved_genome = None
+        for _, row in df.iterrows():
+            ref = row["ref"] if pd.notna(row["ref"]) else ""
+            alt = row["alt"] if pd.notna(row["alt"]) else ""
+            variant = Variant(
+                contig=str(row["contig"]),
+                start=int(row["start"]),
+                ref=ref,
+                alt=alt,
+                genome=genome,
+            )
+            # Cache the resolved pyensembl.Genome from the first variant
+            # so subsequent transcript lookups don't pay the inference cost.
+            if resolved_genome is None:
+                resolved_genome = variant.ensembl
+            transcript_id = row["transcript_id"]
+            if pd.isna(transcript_id) or transcript_id == "":
+                # Row is for an intergenic / intragenic effect — no
+                # transcript context. Rebuild by running the full effect
+                # set on the variant and taking the non-transcript match.
+                effects_for_variant = variant.effects()
+                for e in effects_for_variant:
+                    if e.transcript is None and e.__class__.__name__ == row["effect_type"]:
+                        effects.append(e)
+                        break
+                continue
+            transcript = resolved_genome.transcript_by_id(str(transcript_id))
+            effects.append(variant.effect_on_transcript(transcript))
+        return cls(effects=effects)

--- a/varcode/effects/effect_collection.py
+++ b/varcode/effects/effect_collection.py
@@ -286,8 +286,17 @@ class EffectCollection(Collection):
 
         return max(effect_expression_dict.items(), key=key_fn)[0]
 
+    _DATAFRAME_COLUMNS = (
+        "variant",
+        "contig", "start", "ref", "alt",
+        "is_snv", "is_transversion", "is_transition",
+        "gene_id", "gene_name",
+        "transcript_id", "transcript_name",
+        "effect_type", "effect",
+    )
+
     def to_dataframe(self):
-        """Build a dataframe from the effect collection"""
+        """Build a dataframe from the effect collection."""
         # list of properties to extract from Variant objects if they're
         # not None
         variant_properties = [
@@ -315,7 +324,12 @@ class EffectCollection(Collection):
             row['effect_type'] = effect.__class__.__name__
             row['effect'] = effect.short_description
             return row
-        return pd.DataFrame.from_records([row_from_effect(effect) for effect in self])
+        # Always emit the same column set even for empty collections so
+        # CSV round-trip doesn't have to special-case len == 0.
+        return pd.DataFrame.from_records(
+            [row_from_effect(effect) for effect in self],
+            columns=self._DATAFRAME_COLUMNS,
+        )
 
     def to_csv(self, path, include_header=True):
         """Write this collection to CSV.
@@ -404,29 +418,32 @@ class EffectCollection(Collection):
                 "`to_csv(include_header=True)` so `# reference_name=...` "
                 "is recorded in the header. Neither was found at %s." % path)
 
-        try:
-            df = pd.read_csv(path, comment="#", dtype={"contig": str})
-        except pd.errors.EmptyDataError:
-            # CSV body is empty (e.g. the collection was empty when
-            # written). Return an empty collection rather than failing.
-            return cls(effects=[])
-        required = {"contig", "start", "ref", "alt", "transcript_id"}
+        df = pd.read_csv(path, comment="#", dtype={"contig": str})
+        required = {"contig", "start", "ref", "alt", "transcript_id", "effect_type"}
         missing = required - set(df.columns)
         if missing:
             raise ValueError(
                 "CSV at %s is missing required columns: %s" % (
                     path, sorted(missing)))
 
+        # Extract columns by name and coerce types up front; zip is
+        # robust against column reordering and extra columns, unlike
+        # itertuples which depends on attribute access to
+        # valid-identifier column names in fixed positions.
+        contigs = df["contig"].astype(str)
+        starts = df["start"].astype(int)
+        refs = df["ref"].fillna("")
+        alts = df["alt"].fillna("")
+        transcript_ids = df["transcript_id"]
+        effect_types = df["effect_type"]
+
         effects = []
         resolved_genome = None
-        # itertuples is much faster than iterrows on large CSVs; use
-        # attribute access via the namedtuple rather than row["col"].
-        for row in df.itertuples(index=False):
-            ref = row.ref if pd.notna(row.ref) else ""
-            alt = row.alt if pd.notna(row.alt) else ""
+        for contig, start, ref, alt, transcript_id, effect_type in zip(
+                contigs, starts, refs, alts, transcript_ids, effect_types):
             variant = Variant(
-                contig=str(row.contig),
-                start=int(row.start),
+                contig=contig,
+                start=start,
                 ref=ref,
                 alt=alt,
                 genome=genome,
@@ -435,7 +452,6 @@ class EffectCollection(Collection):
             # so subsequent transcript lookups don't pay the inference cost.
             if resolved_genome is None:
                 resolved_genome = variant.ensembl
-            transcript_id = row.transcript_id
             if pd.isna(transcript_id) or transcript_id == "":
                 # Row is for an intergenic / intragenic effect — no
                 # transcript context. Rebuild by running the full effect
@@ -443,7 +459,7 @@ class EffectCollection(Collection):
                 effects_for_variant = variant.effects()
                 matched = False
                 for e in effects_for_variant:
-                    if e.transcript is None and e.__class__.__name__ == row.effect_type:
+                    if e.transcript is None and e.__class__.__name__ == effect_type:
                         effects.append(e)
                         matched = True
                         break
@@ -452,7 +468,7 @@ class EffectCollection(Collection):
                         "Could not recover effect of type %r for variant %s "
                         "with no transcript_id in %s; row dropped from "
                         "reconstructed collection." % (
-                            row.effect_type, variant, path)
+                            effect_type, variant, path)
                     )
                 continue
             transcript = resolved_genome.transcript_by_id(str(transcript_id))

--- a/varcode/effects/effect_collection.py
+++ b/varcode/effects/effect_collection.py
@@ -15,6 +15,8 @@ from collections import OrderedDict
 import pandas as pd
 from sercol import Collection
 
+from ..csv_helpers import read_metadata_header, write_metadata_header
+from ..version import __version__ as _varcode_version
 from .effect_ordering import (
     effect_priority,
     multi_gene_effect_sort_key,
@@ -315,8 +317,50 @@ class EffectCollection(Collection):
             return row
         return pd.DataFrame.from_records([row_from_effect(effect) for effect in self])
 
+    def to_csv(self, path, include_header=True):
+        """Write this collection to CSV.
+
+        Parameters
+        ----------
+        path : str
+            Output path.
+
+        include_header : bool
+            If True (default), prepend ``# key=value`` metadata lines
+            with varcode version and reference genome so the file can
+            be read back via ``from_csv`` without supplying a genome
+            explicitly. Pass ``include_header=False`` for legacy
+            consumers that don't tolerate comment lines.
+        """
+        df = self.to_dataframe()
+        if not include_header:
+            df.to_csv(path, index=False)
+            return
+
+        metadata = OrderedDict()
+        metadata["varcode_version"] = _varcode_version
+        metadata["reference_name"] = self._serialized_reference_name()
+        with open(path, "w") as f:
+            write_metadata_header(f, metadata)
+            df.to_csv(f, index=False)
+
+    def _serialized_reference_name(self):
+        """Pick a reference-name string to record in the CSV header.
+
+        Uses the first effect's variant's reference_name. Returns None
+        if the collection is empty or has no consistent reference.
+        """
+        names = set()
+        for effect in self:
+            variant = getattr(effect, "variant", None)
+            if variant is not None and variant.reference_name:
+                names.add(variant.reference_name)
+        if len(names) == 1:
+            return next(iter(names))
+        return None
+
     @classmethod
-    def from_csv(cls, path, genome):
+    def from_csv(cls, path, genome=None):
         """Rebuild an EffectCollection from a CSV previously written by
         ``EffectCollection.to_csv()``.
 
@@ -333,11 +377,14 @@ class EffectCollection(Collection):
         ----------
         path : str
             Path to the CSV file. Lines starting with '#' are treated as
-            comments and skipped.
+            comments and parsed as ``key=value`` metadata.
 
-        genome : pyensembl.Genome or str or int
+        genome : pyensembl.Genome, str, int, or None
             Reference genome to associate with the loaded variants and
-            to look up transcripts by ID.
+            to look up transcripts by ID. If ``None``, the reference is
+            read from the CSV's metadata header
+            (``# reference_name=...``). If neither is available, raises
+            ``ValueError``.
 
         Returns
         -------
@@ -345,6 +392,16 @@ class EffectCollection(Collection):
         """
         # Import here to avoid a circular import at module load time.
         from ..variant import Variant
+
+        header = read_metadata_header(path)
+        if genome is None:
+            genome = header.get("reference_name")
+        if genome is None:
+            raise ValueError(
+                "from_csv needs a reference genome: pass the `genome` "
+                "argument explicitly, or write the CSV with "
+                "`to_csv(include_header=True)` so `# reference_name=...` "
+                "is recorded in the header. Neither was found at %s." % path)
 
         df = pd.read_csv(path, comment="#", dtype={"contig": str})
         required = {"contig", "start", "ref", "alt", "transcript_id"}

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -328,8 +328,12 @@ class VariantCollection(Collection):
             variant_collections=(self,) + others,
             kwargs=kwargs)
 
+    _DATAFRAME_COLUMNS = (
+        "chr", "start", "ref", "alt", "gene_name", "gene_id",
+    )
+
     def to_dataframe(self):
-        """Build a DataFrame from this variant collection"""
+        """Build a DataFrame from this variant collection."""
         def row_from_variant(variant):
             return OrderedDict([
                 ("chr", variant.contig),
@@ -340,10 +344,10 @@ class VariantCollection(Collection):
                 ("gene_id", ";".join(variant.gene_ids))
             ])
         rows = [row_from_variant(v) for v in self]
-        if len(rows) == 0:
-            # TODO: return a DataFrame with the appropriate columns
-            return pd.DataFrame()
-        return pd.DataFrame.from_records(rows, columns=rows[0].keys())
+        # Always return a DataFrame with the expected columns, even
+        # when empty, so downstream code (CSV round-trip, joins) doesn't
+        # have to special-case len == 0.
+        return pd.DataFrame.from_records(rows, columns=self._DATAFRAME_COLUMNS)
 
     def to_csv(self, path, include_header=True):
         """Write this collection to CSV.
@@ -425,30 +429,34 @@ class VariantCollection(Collection):
                 "`to_csv(include_header=True)` so `# reference_name=...` "
                 "is recorded in the header. Neither was found at %s." % path)
 
-        try:
-            df = pd.read_csv(path, comment="#", dtype={"chr": str})
-        except pd.errors.EmptyDataError:
-            # CSV body is empty (e.g. the collection was empty when
-            # written). Return an empty collection rather than failing.
-            return cls(variants=[], distinct=distinct, sort_key=sort_key)
+        df = pd.read_csv(path, comment="#", dtype={"chr": str})
         required = {"chr", "start", "ref", "alt"}
         missing = required - set(df.columns)
         if missing:
             raise ValueError(
                 "CSV at %s is missing required columns: %s" % (
                     path, sorted(missing)))
-        variants = []
-        # itertuples is much faster than iterrows on large CSVs.
-        for row in df.itertuples(index=False):
-            ref = row.ref if pd.notna(row.ref) else ""
-            alt = row.alt if pd.notna(row.alt) else ""
-            variants.append(Variant(
-                contig=str(row.chr),
-                start=int(row.start),
+
+        # Extract the columns we need by name and coerce types up front,
+        # then iterate with zip. This is robust against column reordering
+        # and extra columns (unlike itertuples, which depends on
+        # attribute access to valid-identifier column names in fixed
+        # positions) and avoids the per-row overhead of iterrows.
+        contigs = df["chr"].astype(str)
+        starts = df["start"].astype(int)
+        refs = df["ref"].fillna("")
+        alts = df["alt"].fillna("")
+
+        variants = [
+            Variant(
+                contig=contig,
+                start=start,
                 ref=ref,
                 alt=alt,
                 genome=genome,
-            ))
+            )
+            for contig, start, ref, alt in zip(contigs, starts, refs, alts)
+        ]
         return cls(
             variants=variants,
             distinct=distinct,

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -17,7 +17,7 @@ from sercol import Collection
 
 from .effects import EffectCollection
 from .common import memoize
-from .variant import variant_ascending_position_sort_key
+from .variant import Variant, variant_ascending_position_sort_key
 
 
 class VariantCollection(Collection):
@@ -342,6 +342,56 @@ class VariantCollection(Collection):
             # TODO: return a DataFrame with the appropriate columns
             return pd.DataFrame()
         return pd.DataFrame.from_records(rows, columns=rows[0].keys())
+
+    @classmethod
+    def from_csv(cls, path, genome, distinct=True, sort_key=variant_ascending_position_sort_key):
+        """Rebuild a VariantCollection from a CSV previously written by
+        ``VariantCollection.to_csv()``.
+
+        Parameters
+        ----------
+        path : str
+            Path to the CSV file. Lines starting with '#' are treated as
+            comments and skipped (reserved for future provenance headers).
+
+        genome : pyensembl.Genome or str or int
+            Reference genome to associate with the loaded variants. This
+            has to be supplied by the caller because the current CSV
+            format does not record the reference.
+
+        distinct : bool
+            Drop duplicate variants (same as the constructor).
+
+        sort_key : callable
+            Sort key for the resulting collection.
+
+        Returns
+        -------
+        VariantCollection
+        """
+        df = pd.read_csv(path, comment="#", dtype={"chr": str})
+        required = {"chr", "start", "ref", "alt"}
+        missing = required - set(df.columns)
+        if missing:
+            raise ValueError(
+                "CSV at %s is missing required columns: %s" % (
+                    path, sorted(missing)))
+        variants = []
+        for _, row in df.iterrows():
+            ref = row["ref"] if pd.notna(row["ref"]) else ""
+            alt = row["alt"] if pd.notna(row["alt"]) else ""
+            variants.append(Variant(
+                contig=str(row["chr"]),
+                start=int(row["start"]),
+                ref=ref,
+                alt=alt,
+                genome=genome,
+            ))
+        return cls(
+            variants=variants,
+            distinct=distinct,
+            sort_key=sort_key,
+        )
 
     def clone_without_ucsc_data(self):
         variants = [v.clone_without_ucsc_data() for v in self]

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -425,7 +425,12 @@ class VariantCollection(Collection):
                 "`to_csv(include_header=True)` so `# reference_name=...` "
                 "is recorded in the header. Neither was found at %s." % path)
 
-        df = pd.read_csv(path, comment="#", dtype={"chr": str})
+        try:
+            df = pd.read_csv(path, comment="#", dtype={"chr": str})
+        except pd.errors.EmptyDataError:
+            # CSV body is empty (e.g. the collection was empty when
+            # written). Return an empty collection rather than failing.
+            return cls(variants=[], distinct=distinct, sort_key=sort_key)
         required = {"chr", "start", "ref", "alt"}
         missing = required - set(df.columns)
         if missing:
@@ -433,12 +438,13 @@ class VariantCollection(Collection):
                 "CSV at %s is missing required columns: %s" % (
                     path, sorted(missing)))
         variants = []
-        for _, row in df.iterrows():
-            ref = row["ref"] if pd.notna(row["ref"]) else ""
-            alt = row["alt"] if pd.notna(row["alt"]) else ""
+        # itertuples is much faster than iterrows on large CSVs.
+        for row in df.itertuples(index=False):
+            ref = row.ref if pd.notna(row.ref) else ""
+            alt = row.alt if pd.notna(row.alt) else ""
             variants.append(Variant(
-                contig=str(row["chr"]),
-                start=int(row["start"]),
+                contig=str(row.chr),
+                start=int(row.start),
                 ref=ref,
                 alt=alt,
                 genome=genome,

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -17,7 +17,9 @@ from sercol import Collection
 
 from .effects import EffectCollection
 from .common import memoize
+from .csv_helpers import read_metadata_header, write_metadata_header
 from .variant import Variant, variant_ascending_position_sort_key
+from .version import __version__ as _varcode_version
 
 
 class VariantCollection(Collection):
@@ -343,8 +345,51 @@ class VariantCollection(Collection):
             return pd.DataFrame()
         return pd.DataFrame.from_records(rows, columns=rows[0].keys())
 
+    def to_csv(self, path, include_header=True):
+        """Write this collection to CSV.
+
+        Parameters
+        ----------
+        path : str
+            Output path.
+
+        include_header : bool
+            If True (default), prepend ``# key=value`` metadata lines
+            with varcode version and reference genome so the file can
+            be read back via ``from_csv`` without supplying a genome
+            explicitly. Pass ``include_header=False`` for legacy
+            consumers that don't tolerate comment lines.
+        """
+        df = self.to_dataframe()
+        if not include_header:
+            df.to_csv(path, index=False)
+            return
+
+        metadata = OrderedDict()
+        metadata["varcode_version"] = _varcode_version
+        metadata["reference_name"] = self._serialized_reference_name()
+        with open(path, "w") as f:
+            write_metadata_header(f, metadata)
+            df.to_csv(f, index=False)
+
+    def _serialized_reference_name(self):
+        """Pick a reference-name string to record in the CSV header.
+
+        Uses the first variant's reference_name. Returns None if the
+        collection is empty or has no consistent reference.
+        """
+        names = {v.reference_name for v in self if v.reference_name}
+        if len(names) == 1:
+            return next(iter(names))
+        return None
+
     @classmethod
-    def from_csv(cls, path, genome, distinct=True, sort_key=variant_ascending_position_sort_key):
+    def from_csv(
+            cls,
+            path,
+            genome=None,
+            distinct=True,
+            sort_key=variant_ascending_position_sort_key):
         """Rebuild a VariantCollection from a CSV previously written by
         ``VariantCollection.to_csv()``.
 
@@ -352,12 +397,13 @@ class VariantCollection(Collection):
         ----------
         path : str
             Path to the CSV file. Lines starting with '#' are treated as
-            comments and skipped (reserved for future provenance headers).
+            comments and parsed as ``key=value`` metadata.
 
-        genome : pyensembl.Genome or str or int
-            Reference genome to associate with the loaded variants. This
-            has to be supplied by the caller because the current CSV
-            format does not record the reference.
+        genome : pyensembl.Genome, str, int, or None
+            Reference genome to associate with the loaded variants. If
+            ``None``, the reference is read from the CSV's metadata
+            header (``# reference_name=...``). If neither is available,
+            raises ``ValueError``.
 
         distinct : bool
             Drop duplicate variants (same as the constructor).
@@ -369,6 +415,16 @@ class VariantCollection(Collection):
         -------
         VariantCollection
         """
+        header = read_metadata_header(path)
+        if genome is None:
+            genome = header.get("reference_name")
+        if genome is None:
+            raise ValueError(
+                "from_csv needs a reference genome: pass the `genome` "
+                "argument explicitly, or write the CSV with "
+                "`to_csv(include_header=True)` so `# reference_name=...` "
+                "is recorded in the header. Neither was found at %s." % path)
+
         df = pd.read_csv(path, comment="#", dtype={"chr": str})
         required = {"chr", "start", "ref", "alt"}
         missing = required - set(df.columns)


### PR DESCRIPTION
## Summary

Adds CSV deserialization to complement the existing `to_csv` (inherited from sercol). Enables round-trip testing for the serialization work in the #271 roadmap.

- **`VariantCollection.from_csv(path, genome)`** — exact round-trip: reads `chr, start, ref, alt` columns and rebuilds Variants.
- **`EffectCollection.from_csv(path, genome)`** — semantic round-trip: reads `contig, start, ref, alt, transcript_id`, rebuilds each Variant, and re-runs `variant.effect_on_transcript(transcript)`. The resulting effects match the original whenever annotation is deterministic for a given (variant, transcript) pair.

Both readers skip `#`-prefixed comment lines, so once the annotator/version provenance headers land (#271), existing readers stay compatible.

## Test plan

6 new round-trip tests in \`tests/test_csv_roundtrip.py\`:

- \`test_variant_collection_csv_roundtrip_preserves_variants\` — exact match across SNVs and MNVs
- \`test_variant_collection_csv_roundtrip_handles_indels\` — empty ref/alt survive pandas NaN coercion
- \`test_variant_collection_from_csv_rejects_missing_columns\` — clear error instead of silent failure
- \`test_effect_collection_csv_roundtrip_preserves_effect_types\` — class distribution + short descriptions match
- \`test_effect_collection_csv_roundtrip_preserves_transcripts\` — transcript_id preserved
- \`test_effect_collection_from_csv_skips_comment_lines\` — compatible with #271's planned header format

All 421 tests pass (was 415), lint clean.

## Notes

EffectCollection.from_csv is currently lossy — it doesn't byte-for-byte reconstruct all effect-specific fields (e.g. `aa_ref`/`aa_alt`/`aa_pos` that aren't columns today). For the testing use cases this is fine; a future extension can enrich `to_dataframe` with more columns if byte-for-byte round-trip becomes necessary. The `from_dict`/`from_json` paths already do byte-for-byte round-trip, so CSV is the lightweight option.

## Related

- #271 — MutantTranscript refactor (this unblocks round-trip testing for provenance metadata)
- #272 — Serializable → dataclass migration (complementary; both use the same CSV format)