### PR TITLE
CSV polish: accept both contig aliases, warn on version drift, doc JSON preference

### DIFF
--- a/tests/test_csv_roundtrip.py
+++ b/tests/test_csv_roundtrip.py
@@ -409,6 +409,115 @@ def test_effect_collection_roundtrip_preserves_intergenic_effect():
     )
 
 
+# -----------------------------------------------------------------------
+# #274: VariantCollection and EffectCollection use different column
+# names for the contig field ("chr" vs "contig"). Readers should accept
+# either so CSVs are interchangeable across the two types.
+# -----------------------------------------------------------------------
+
+
+def test_variant_collection_from_csv_accepts_contig_column_name():
+    # A CSV written by EffectCollection-style code uses "contig" but
+    # should still load as a VariantCollection.
+    import pandas as pd
+    path = _tmp_csv()
+    try:
+        df = pd.DataFrame([
+            {"contig": "17", "start": 43082404, "ref": "C", "alt": "T"},
+            {"contig": "7", "start": 117531114, "ref": "G", "alt": "T"},
+        ])
+        with open(path, "w") as f:
+            f.write("# reference_name=GRCh38\n")
+            df.to_csv(f, index=False)
+        loaded = VariantCollection.from_csv(path)
+    finally:
+        os.unlink(path)
+    assert len(loaded) == 2
+    starts = sorted(v.start for v in loaded)
+    assert starts == [43082404, 117531114]
+
+
+def test_effect_collection_from_csv_accepts_chr_column_name():
+    # An EffectCollection CSV with the VariantCollection-style "chr"
+    # column should still load — we only need one contig column name
+    # present.
+    import pandas as pd
+    path = _tmp_csv()
+    try:
+        df = pd.DataFrame([
+            {
+                "variant": "chr1 g.100A>T",
+                "chr": "1",  # the alternate name
+                "start": 100,
+                "ref": "A",
+                "alt": "T",
+                "transcript_id": None,
+                "effect_type": "Intergenic",
+                "effect": "intergenic",
+            }
+        ])
+        with open(path, "w") as f:
+            f.write("# reference_name=GRCh38\n")
+            df.to_csv(f, index=False)
+        loaded = EffectCollection.from_csv(path)
+    finally:
+        os.unlink(path)
+    # Intergenic variant at chr1:100 produces at least one Intergenic
+    # effect after re-annotation.
+    assert any(e.__class__.__name__ == "Intergenic" for e in loaded)
+
+
+def test_variant_collection_from_csv_errors_without_contig_column():
+    import pandas as pd
+    path = _tmp_csv()
+    try:
+        df = pd.DataFrame([
+            # No 'chr' or 'contig' column at all.
+            {"start": 100, "ref": "A", "alt": "T"},
+        ])
+        with open(path, "w") as f:
+            f.write("# reference_name=GRCh38\n")
+            df.to_csv(f, index=False)
+        try:
+            VariantCollection.from_csv(path)
+        except ValueError as e:
+            assert "contig" in str(e) and "chr" in str(e), \
+                "Error should list both aliases, got %r" % str(e)
+        else:
+            raise AssertionError("Expected ValueError for missing contig column")
+    finally:
+        os.unlink(path)
+
+
+def test_effect_collection_from_csv_errors_without_contig_column():
+    import pandas as pd
+    path = _tmp_csv()
+    try:
+        df = pd.DataFrame([
+            {
+                "variant": "chr1 g.100A>T",
+                # No 'chr' or 'contig'.
+                "start": 100,
+                "ref": "A",
+                "alt": "T",
+                "transcript_id": None,
+                "effect_type": "Intergenic",
+                "effect": "intergenic",
+            }
+        ])
+        with open(path, "w") as f:
+            f.write("# reference_name=GRCh38\n")
+            df.to_csv(f, index=False)
+        try:
+            EffectCollection.from_csv(path)
+        except ValueError as e:
+            assert "contig" in str(e) and "chr" in str(e)
+        else:
+            raise AssertionError("Expected ValueError for missing contig column")
+    finally:
+        os.unlink(path)
+
+
 def test_effect_collection_from_csv_warns_when_fallback_cant_match():
     # Hand-craft a CSV with an empty transcript_id and a made-up
     # effect_type that the annotation won't produce. from_csv should

--- a/tests/test_csv_roundtrip.py
+++ b/tests/test_csv_roundtrip.py
@@ -518,6 +518,98 @@ def test_effect_collection_from_csv_errors_without_contig_column():
         os.unlink(path)
 
 
+# -----------------------------------------------------------------------
+# #275: warn on major-version drift when loading serialized collections.
+# Because from_csv re-runs annotation, mismatch between the varcode
+# version that wrote the file and the one reading it can produce
+# different effects. We only warn on major-version drift since minor
+# and patch are semver-compatible.
+# -----------------------------------------------------------------------
+
+
+def _write_csv_with_header_version(path, version, body_df):
+    with open(path, "w") as f:
+        f.write("# varcode_version=%s\n" % version)
+        f.write("# reference_name=GRCh38\n")
+        body_df.to_csv(f, index=False)
+
+
+def test_from_csv_warns_on_major_version_drift():
+    import warnings
+    import pandas as pd
+
+    path = _tmp_csv()
+    try:
+        body = pd.DataFrame([
+            {"chr": "17", "start": 43082404, "ref": "C", "alt": "T"},
+        ])
+        # Pretend this CSV was written by an ancient 1.0.0.
+        _write_csv_with_header_version(path, "1.0.0", body)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            VariantCollection.from_csv(path)
+    finally:
+        os.unlink(path)
+
+    drift = [w for w in caught if "major versions" in str(w.message)]
+    assert len(drift) == 1, \
+        "Expected a single major-version drift warning, got %d: %r" % (
+            len(drift), [str(w.message) for w in caught])
+    assert "1.0.0" in str(drift[0].message)
+
+
+def test_from_csv_does_not_warn_on_patch_or_minor_drift():
+    import warnings
+    import pandas as pd
+    import varcode
+
+    path = _tmp_csv()
+    try:
+        body = pd.DataFrame([
+            {"chr": "17", "start": 43082404, "ref": "C", "alt": "T"},
+        ])
+        # Same major (2.x) as current install; different minor/patch.
+        # Compute the major from varcode.__version__.
+        current_major = varcode.__version__.split(".")[0]
+        fake_version = "%s.0.1" % current_major
+        _write_csv_with_header_version(path, fake_version, body)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            VariantCollection.from_csv(path)
+    finally:
+        os.unlink(path)
+
+    drift = [w for w in caught if "major versions" in str(w.message)]
+    assert len(drift) == 0, \
+        "Should not warn on within-major drift, got: %r" % (
+            [str(w.message) for w in drift])
+
+
+def test_from_csv_ignores_malformed_version_header():
+    import warnings
+    import pandas as pd
+
+    path = _tmp_csv()
+    try:
+        body = pd.DataFrame([
+            {"chr": "17", "start": 43082404, "ref": "C", "alt": "T"},
+        ])
+        # Malformed version string — the drift check should not
+        # raise, just silently skip the comparison.
+        _write_csv_with_header_version(path, "not-a-version", body)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            VariantCollection.from_csv(path)
+    finally:
+        os.unlink(path)
+
+    drift = [w for w in caught if "major versions" in str(w.message)]
+    assert len(drift) == 0
+
+
 def test_effect_collection_from_csv_warns_when_fallback_cant_match():
     # Hand-craft a CSV with an empty transcript_id and a made-up
     # effect_type that the annotation won't produce. from_csv should

--- a/varcode/csv_helpers.py
+++ b/varcode/csv_helpers.py
@@ -50,6 +50,59 @@ def resolve_contig_column(columns):
     return None
 
 
+def _parse_major_minor(version_string):
+    """Return (major, minor) integers from a semver-ish version string.
+
+    Tolerates trailing ``.patch``, ``+build`` and ``-pre`` suffixes;
+    returns ``None`` when the first two dot-separated components aren't
+    both integers.
+    """
+    if not version_string:
+        return None
+    # Strip build/pre-release metadata.
+    for sep in ("+", "-"):
+        if sep in version_string:
+            version_string = version_string.split(sep, 1)[0]
+    parts = version_string.split(".")
+    if len(parts) < 2:
+        return None
+    try:
+        return (int(parts[0]), int(parts[1]))
+    except ValueError:
+        return None
+
+
+def warn_on_version_drift(header_metadata, current_version, source_path):
+    """Emit ``warnings.warn`` when the CSV's ``varcode_version`` header
+    reports a major-version mismatch against ``current_version``.
+
+    Minor and patch drift are silent (semver guarantees compatibility
+    within a major line). Major drift is load-bearing because
+    annotation logic can change — the effects reconstructed on read
+    may differ from the ones that were written.
+
+    When #271 lands ``annotator`` / ``annotator_version``, that check
+    belongs here too.
+    """
+    import warnings
+
+    serialized = header_metadata.get("varcode_version")
+    if not serialized:
+        return
+    serialized_mm = _parse_major_minor(serialized)
+    current_mm = _parse_major_minor(current_version)
+    if serialized_mm is None or current_mm is None:
+        return
+    if serialized_mm[0] != current_mm[0]:
+        warnings.warn(
+            "CSV at %s was written by varcode %s but you are reading it "
+            "with varcode %s. Because from_csv re-runs annotation on "
+            "read, results may differ across major versions. See "
+            "openvax/varcode#275 for context." % (
+                source_path, serialized, current_version)
+        )
+
+
 def write_metadata_header(file_obj, metadata):
     """Write ``# key=value`` lines for each item in ``metadata``.
 

--- a/varcode/csv_helpers.py
+++ b/varcode/csv_helpers.py
@@ -33,6 +33,22 @@ from collections import OrderedDict
 
 HEADER_PREFIX = "#"
 
+# VariantCollection historically emits a "chr" column and
+# EffectCollection emits "contig" — the reader should accept either so
+# CSVs are interchangeable across the two collection types. Tracked in
+# openvax/varcode#274.
+CONTIG_COLUMN_ALIASES = ("contig", "chr")
+
+
+def resolve_contig_column(columns):
+    """Return the first of :data:`CONTIG_COLUMN_ALIASES` that appears in
+    ``columns``, or ``None`` if none do.
+    """
+    for name in CONTIG_COLUMN_ALIASES:
+        if name in columns:
+            return name
+    return None
+
 
 def write_metadata_header(file_obj, metadata):
     """Write ``# key=value`` lines for each item in ``metadata``.

--- a/varcode/effects/effect_collection.py
+++ b/varcode/effects/effect_collection.py
@@ -15,7 +15,12 @@ from collections import OrderedDict
 import pandas as pd
 from sercol import Collection
 
-from ..csv_helpers import read_metadata_header, write_metadata_header
+from ..csv_helpers import (
+    CONTIG_COLUMN_ALIASES,
+    read_metadata_header,
+    resolve_contig_column,
+    write_metadata_header,
+)
 from ..version import __version__ as _varcode_version
 from .effect_ordering import (
     effect_priority,
@@ -418,8 +423,18 @@ class EffectCollection(Collection):
                 "`to_csv(include_header=True)` so `# reference_name=...` "
                 "is recorded in the header. Neither was found at %s." % path)
 
-        df = pd.read_csv(path, comment="#", dtype={"contig": str})
-        required = {"contig", "start", "ref", "alt", "transcript_id", "effect_type"}
+        # Accept either "contig" or "chr" as the contig column so
+        # CSVs are interchangeable between VariantCollection and
+        # EffectCollection (openvax/varcode#274). Declaring both in
+        # dtype is a no-op for whichever column is absent.
+        df = pd.read_csv(
+            path, comment="#", dtype={"chr": str, "contig": str})
+        contig_col = resolve_contig_column(df.columns)
+        if contig_col is None:
+            raise ValueError(
+                "CSV at %s is missing a contig column: expected one of %s."
+                % (path, list(CONTIG_COLUMN_ALIASES)))
+        required = {"start", "ref", "alt", "transcript_id", "effect_type"}
         missing = required - set(df.columns)
         if missing:
             raise ValueError(
@@ -430,7 +445,7 @@ class EffectCollection(Collection):
         # robust against column reordering and extra columns, unlike
         # itertuples which depends on attribute access to
         # valid-identifier column names in fixed positions.
-        contigs = df["contig"].astype(str)
+        contigs = df[contig_col].astype(str)
         starts = df["start"].astype(int)
         refs = df["ref"].fillna("")
         alts = df["alt"].fillna("")

--- a/varcode/effects/effect_collection.py
+++ b/varcode/effects/effect_collection.py
@@ -19,6 +19,7 @@ from ..csv_helpers import (
     CONTIG_COLUMN_ALIASES,
     read_metadata_header,
     resolve_contig_column,
+    warn_on_version_drift,
     write_metadata_header,
 )
 from ..version import __version__ as _varcode_version
@@ -392,6 +393,14 @@ class EffectCollection(Collection):
         annotation is deterministic for a given (variant, transcript)
         pair.
 
+        **Prefer ``from_json`` for byte-for-byte round-trip** or for
+        larger collections (≳10k effects); per-row re-annotation makes
+        CSV loading significantly slower than JSON. Emits a warning
+        when the CSV header reports a different *major* varcode version
+        than the one currently installed — annotation logic can change
+        across major versions and the reconstructed effects may differ
+        from the ones that were written.
+
         Parameters
         ----------
         path : str
@@ -414,6 +423,7 @@ class EffectCollection(Collection):
         from ..variant import Variant
 
         header = read_metadata_header(path)
+        warn_on_version_drift(header, _varcode_version, path)
         if genome is None:
             genome = header.get("reference_name")
         if genome is None:

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -21,6 +21,7 @@ from .csv_helpers import (
     CONTIG_COLUMN_ALIASES,
     read_metadata_header,
     resolve_contig_column,
+    warn_on_version_drift,
     write_metadata_header,
 )
 from .variant import Variant, variant_ascending_position_sort_key
@@ -402,6 +403,11 @@ class VariantCollection(Collection):
         """Rebuild a VariantCollection from a CSV previously written by
         ``VariantCollection.to_csv()``.
 
+        The CSV round-trip is human-readable and easy to inspect. For
+        byte-for-byte round-trip or for faster loading of large
+        collections (≳10k variants), prefer ``from_json`` — CSV parsing
+        plus per-row Variant construction is significantly slower.
+
         Parameters
         ----------
         path : str
@@ -425,6 +431,7 @@ class VariantCollection(Collection):
         VariantCollection
         """
         header = read_metadata_header(path)
+        warn_on_version_drift(header, _varcode_version, path)
         if genome is None:
             genome = header.get("reference_name")
         if genome is None:

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -17,7 +17,12 @@ from sercol import Collection
 
 from .effects import EffectCollection
 from .common import memoize
-from .csv_helpers import read_metadata_header, write_metadata_header
+from .csv_helpers import (
+    CONTIG_COLUMN_ALIASES,
+    read_metadata_header,
+    resolve_contig_column,
+    write_metadata_header,
+)
 from .variant import Variant, variant_ascending_position_sort_key
 from .version import __version__ as _varcode_version
 
@@ -429,8 +434,18 @@ class VariantCollection(Collection):
                 "`to_csv(include_header=True)` so `# reference_name=...` "
                 "is recorded in the header. Neither was found at %s." % path)
 
-        df = pd.read_csv(path, comment="#", dtype={"chr": str})
-        required = {"chr", "start", "ref", "alt"}
+        # Accept either "chr" or "contig" as the contig column so
+        # CSVs are interchangeable between VariantCollection and
+        # EffectCollection (openvax/varcode#274). Declaring both in
+        # dtype is a no-op for whichever column is absent.
+        df = pd.read_csv(
+            path, comment="#", dtype={"chr": str, "contig": str})
+        contig_col = resolve_contig_column(df.columns)
+        if contig_col is None:
+            raise ValueError(
+                "CSV at %s is missing a contig column: expected one of %s."
+                % (path, list(CONTIG_COLUMN_ALIASES)))
+        required = {"start", "ref", "alt"}
         missing = required - set(df.columns)
         if missing:
             raise ValueError(
@@ -442,7 +457,7 @@ class VariantCollection(Collection):
         # and extra columns (unlike itertuples, which depends on
         # attribute access to valid-identifier column names in fixed
         # positions) and avoids the per-row overhead of iterrows.
-        contigs = df["chr"].astype(str)
+        contigs = df[contig_col].astype(str)
         starts = df["start"].astype(int)
         refs = df["ref"].fillna("")
         alts = df["alt"].fillna("")


### PR DESCRIPTION
## Summary

Bundle of three CSV quick-wins for the 2.2.0 release:

### #274 — Accept both `chr` and `contig` on read

`VariantCollection.to_dataframe` emits `chr`; `EffectCollection` emits `contig`. Previously each `from_csv` reader only accepted its own class's canonical name, so CSVs weren't interchangeable between the two types. Added a shared `resolve_contig_column` helper; both readers now accept either alias. Writers are unchanged — files on disk round-trip identically. Missing-column errors list both aliases.

### #275 — Warn on major `varcode_version` drift

`from_csv` re-runs annotation on read, so if a CSV was written under a different varcode major version, results can differ. `warn_on_version_drift` reads the header's `varcode_version`, compares major versions, and emits a warning on mismatch. Minor/patch drift is silent (semver-compatible). Malformed version strings are tolerated silently rather than raised.

### #276 — Document JSON preference in docstrings

Both `from_csv` docstrings now note that `from_json` is preferred for byte-for-byte round-trip and for larger collections (>=10k records), since CSV loading re-runs annotation per row.

## Test plan

- [x] #274: 4 tests for alias acceptance + clear error when neither alias is present
- [x] #275: 3 tests for major drift (warns), within-major drift (silent), malformed header (silent)
- [x] All existing round-trip tests still pass
- [x] Full test suite: 441 passed, 0 regressions, lint clean

Closes #274, #275, #276.