### PR TITLE
Add docs site (mkdocs-material) and docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,66 @@
+# Build the mkdocs site on every push/PR; deploy to GitHub Pages when
+# main is updated. Matches the pattern used by openvax/vaxrank.
+#
+# For the deploy to work, the repository's Pages source must be set to
+# "GitHub Actions" under Settings → Pages. The build job runs on PRs
+# so broken docs fail the check before merge.
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel in-flight runs on the same ref when a newer push arrives.
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # mkdocs plugins can look at git history
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install varcode and docs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # mkdocstrings needs varcode importable, but doesn't need
+          # the Ensembl FASTA caches that the test workflow downloads.
+          pip install -r requirements.txt
+          pip install .
+          pip install mkdocs mkdocs-material 'mkdocstrings[python]'
+
+      - name: Build docs
+        run: mkdocs build
+
+      - name: Upload site artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# mkdocs build output
+/site/
+
 # PyBuilder
 target/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,96 @@
 # Change Log
 
+## [v2.3.0](https://github.com/openvax/varcode/tree/v2.3.0) (2026-04-13)
+
+**Added**
+- Per-sample genotype / zygosity access ([#267](https://github.com/openvax/varcode/issues/267)).
+  `Genotype` frozen dataclass, `Zygosity` enum (`ABSENT`/`HETEROZYGOUS`/`HOMOZYGOUS`/`MISSING`),
+  new `VariantCollection` methods `.samples`, `.genotype(variant, sample)`,
+  `.zygosity(variant, sample)`, `.for_sample(name)`, `.heterozygous_in(name)`,
+  `.homozygous_alt_in(name)`. Multi-allelic aware: each split Variant
+  reports zygosity relative to its own alt.
+- `varcode.SampleNotFoundError(KeyError)` raised on typoed sample names.
+
+## [v2.2.1](https://github.com/openvax/varcode/tree/v2.2.1) (2026-04-13)
+
+**Fixed**
+- Ref-vs-genome mismatches now raise a dedicated
+  `varcode.ReferenceMismatchError` (subclass of `ValueError`) with an
+  actionable message naming the likely causes and pointing at
+  `raise_on_error=False` ([#215](https://github.com/openvax/varcode/issues/215),
+  [#246](https://github.com/openvax/varcode/issues/246)).
+
+## [v2.2.0](https://github.com/openvax/varcode/tree/v2.2.0) (2026-04-12)
+
+**Added**
+- `from_csv` now accepts either `chr` or `contig` as the contig column
+  name on both `VariantCollection` and `EffectCollection`, so CSVs are
+  interchangeable between the two types
+  ([#274](https://github.com/openvax/varcode/issues/274)).
+- `from_csv` warns on major `varcode_version` drift recorded in the
+  CSV header ([#275](https://github.com/openvax/varcode/issues/275)).
+
+**Changed**
+- `from_csv` docstrings now point users at `from_json` for byte-for-byte
+  round-trip or larger collections
+  ([#276](https://github.com/openvax/varcode/issues/276)).
+
+## [v2.1.0](https://github.com/openvax/varcode/tree/v2.1.0) (2026-04-12)
+
+**Added**
+- `VariantCollection.from_csv` and `EffectCollection.from_csv` for
+  round-trip deserialization ([#273](https://github.com/openvax/varcode/pull/273)).
+- `to_csv` prepends a `# key=value` metadata header by default
+  (`varcode_version`, `reference_name`); `from_csv` reads it so the
+  `genome` argument becomes optional. Pass `include_header=False` for
+  legacy consumers.
+
+**Fixed**
+- `VariantCollection.variants` and `EffectCollection.effects` now
+  match the collection's iteration order instead of holding the raw
+  pre-sort / pre-dedup input list
+  ([#220](https://github.com/openvax/varcode/issues/220)).
+
+## [v2.0.0](https://github.com/openvax/varcode/tree/v2.0.0) (2026-04-11)
+
+Major release — several backward-incompatible fixes. See
+[#263](https://github.com/openvax/varcode/pull/263) and
+[#265](https://github.com/openvax/varcode/pull/265) for full details.
+
+**Breaking**
+- `Silent.short_description` returns HGVS `p.{ref}{pos}=` (e.g.
+  `p.R6=`) instead of the literal `"silent"`
+  ([#217](https://github.com/openvax/varcode/issues/217)).
+- `Silent.aa_pos` no longer includes the shared-prefix offset; it now
+  points at the actual synonymous codon
+  ([#208](https://github.com/openvax/varcode/issues/208)).
+- `PrematureStop.short_description` returns `p.{pos}ins{alt}*` when
+  `aa_ref` is empty instead of the ambiguous `p.{pos}{alt}*`
+  ([#216](https://github.com/openvax/varcode/issues/216)).
+- `EffectCollection` is sorted by effect priority (most severe first)
+  by default. Pass `sort_key=False` to disable or a custom callable
+  to override ([#227](https://github.com/openvax/varcode/issues/227)).
+- Intronic splice classification is sequence-aware: variants at
+  `+1`/`+2` or `-1`/`-2` with a non-canonical reference base are
+  classified as `IntronicSpliceSite` rather than
+  `SpliceDonor`/`SpliceAcceptor`
+  ([#262](https://github.com/openvax/varcode/issues/262)).
+
+**Fixed**
+- SNV in the stop codon with a stop-prefixed 3' UTR is correctly
+  classified as `StopLoss` instead of `Insertion`
+  ([#250](https://github.com/openvax/varcode/issues/250),
+  [#205](https://github.com/openvax/varcode/issues/205)).
+- Insertion before the stop codon that produces an identical protein
+  is correctly classified as `Silent`
+  ([#201](https://github.com/openvax/varcode/issues/201)).
+- `changes_exonic_splice_site` now applies the mutation before
+  checking the splice pattern ([#262](https://github.com/openvax/varcode/issues/262)).
+- VCF loader skips symbolic alleles (`<DEL>`, `<CN0>`, `<INS:ME:ALU>`,
+  ...) and breakend notation with a visible warning instead of
+  crashing ([#88](https://github.com/openvax/varcode/issues/88)).
+  Full SV support is tracked in [#264](https://github.com/openvax/varcode/issues/264).
+
 ## [v0.5.15](https://github.com/hammerlab/varcode/tree/v0.5.15) (2017-04-28)
 [Full Changelog](https://github.com/hammerlab/varcode/compare/v0.5.14...v0.5.15)
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,22 @@ print(premature_stop_effect.gene.name)
 ### 'TP53'
 ```
 
-If you are looking for a quick start guide, you can check out [this iPython book](./examples/varcode-quick_start.ipynb) that demonstrates simple use cases of Varcode
+If you are looking for a quick start guide, you can check out [this iPython book](./examples/varcode-quick_start.ipynb) that demonstrates simple use cases of Varcode.
+
+## Further reading
+
+Feature guides live in [`docs/`](./docs/):
+
+- [**Genotypes and sample-aware queries**](./docs/genotype.md) — per-sample
+  zygosity on multi-sample VCFs (`Genotype`, `Zygosity`, `VariantCollection.for_sample`,
+  `.heterozygous_in`, `.homozygous_alt_in`). New in 2.3.
+- [**CSV round-trip and metadata headers**](./docs/csv.md) — `to_csv` /
+  `from_csv` on both collection types, with `#`-prefixed provenance
+  headers. New in 2.1, refined in 2.2.
+- [**Error handling**](./docs/errors.md) — `ReferenceMismatchError`,
+  `SampleNotFoundError`, and the `raise_on_error=False` escape hatch.
+
+See [`CHANGELOG.md`](./CHANGELOG.md) for the release history.
 
 ## Effect Types
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,66 @@
+# API reference
+
+Auto-generated from in-source docstrings via
+[mkdocstrings](https://mkdocstrings.github.io/).
+
+## Variants
+
+### `varcode.Variant`
+
+::: varcode.Variant
+
+### `varcode.VariantCollection`
+
+::: varcode.VariantCollection
+
+## Genotypes
+
+### `varcode.Genotype`
+
+::: varcode.Genotype
+
+### `varcode.Zygosity`
+
+::: varcode.Zygosity
+
+## Effects
+
+### `varcode.MutationEffect`
+
+::: varcode.MutationEffect
+
+### `varcode.NonsilentCodingMutation`
+
+::: varcode.NonsilentCodingMutation
+
+### `varcode.EffectCollection`
+
+::: varcode.EffectCollection
+
+### Priority ordering
+
+::: varcode.effect_priority
+
+::: varcode.top_priority_effect
+
+## File loading
+
+### `varcode.load_vcf`
+
+::: varcode.load_vcf
+
+### `varcode.load_maf`
+
+::: varcode.load_maf
+
+::: varcode.load_maf_dataframe
+
+## Exceptions
+
+### `varcode.ReferenceMismatchError`
+
+::: varcode.ReferenceMismatchError
+
+### `varcode.SampleNotFoundError`
+
+::: varcode.SampleNotFoundError

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,5 @@
+---
+title: Changelog
+---
+
+--8<-- "CHANGELOG.md"

--- a/docs/csv.md
+++ b/docs/csv.md
@@ -1,0 +1,113 @@
+# CSV round-trip and metadata headers
+
+*New in varcode 2.1.0, refined in 2.2.0.*
+
+`VariantCollection` and `EffectCollection` can both round-trip through
+CSV. The CSV format is human-readable and easy to inspect in a
+spreadsheet; the JSON format (`to_json` / `from_json`) is the
+byte-for-byte exact round-trip and is considerably faster for large
+collections (it skips re-annotation on read).
+
+## Writing
+
+```python
+from varcode import load_vcf
+
+vc = load_vcf("variants.vcf", genome="GRCh38")
+vc.to_csv("variants.csv")
+
+effects = vc.effects()
+effects.to_csv("effects.csv")
+```
+
+By default, both writers prepend `#`-prefixed provenance lines so the
+file is self-describing:
+
+```
+# varcode_version=2.3.0
+# reference_name=GRCh38
+chr,start,ref,alt,gene_name,gene_id
+17,43082575,C,T,BRCA1,ENSG00000012048
+...
+```
+
+Pass `include_header=False` for legacy consumers that can't tolerate
+comment lines:
+
+```python
+vc.to_csv("plain.csv", include_header=False)
+```
+
+## Reading
+
+When the header is present, `from_csv` recovers the reference genome
+automatically:
+
+```python
+from varcode import VariantCollection, EffectCollection
+
+vc = VariantCollection.from_csv("variants.csv")
+effects = EffectCollection.from_csv("effects.csv")
+```
+
+When the CSV has no header (written by an older varcode or with
+`include_header=False`), pass `genome` explicitly:
+
+```python
+vc = VariantCollection.from_csv("plain.csv", genome="GRCh38")
+```
+
+Missing both the header *and* an explicit `genome` produces a clear error:
+
+```
+ValueError: from_csv needs a reference genome: pass the `genome`
+argument explicitly, or write the CSV with
+`to_csv(include_header=True)` so `# reference_name=...` is recorded
+in the header. Neither was found at plain.csv.
+```
+
+## Column-name flexibility
+
+`VariantCollection` historically writes a `chr` column while
+`EffectCollection` writes `contig`. As of 2.2.0 both readers accept
+either alias, so CSVs from the two sides are interchangeable. Writers
+are unchanged.
+
+## Version drift
+
+Because `EffectCollection.from_csv` re-runs annotation on read, a
+collection serialized by one major varcode version and loaded under
+another can produce different effects. As of 2.2.0, `from_csv` emits
+a `UserWarning` when the header's `varcode_version` differs in major
+version from the currently-installed version. Minor and patch drift
+is silent (semver guarantees compatibility).
+
+## CSV vs JSON
+
+| | CSV | JSON |
+|---|---|---|
+| Human-readable | Yes | No |
+| Byte-for-byte round-trip | **No** (re-annotates on read) | Yes |
+| Speed on large collections | Slow (per-row Variant construction + annotation) | Fast |
+| Carries annotator version header | Yes | (via the serialized object) |
+| Preserves all effect-specific fields | No | Yes |
+
+Use CSV when you want to inspect or edit the output manually. Use
+JSON (`to_json` / `from_json`) for exact round-trip and for large
+collections.
+
+## Custom header fields
+
+`read_metadata_header` is available in `varcode.csv_helpers` for
+tools that want to add their own metadata lines:
+
+```python
+from varcode.csv_helpers import read_metadata_header, write_metadata_header
+
+meta = read_metadata_header("variants.csv")
+# OrderedDict([('varcode_version', '2.3.0'), ('reference_name', 'GRCh38')])
+```
+
+Future additions (`annotator`, `annotator_version`) will use the same
+`# key=value` convention (tracked in
+[#271](https://github.com/openvax/varcode/issues/271)).

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,114 @@
+# Error handling
+
+Varcode raises domain-specific exceptions for the two most common ways
+analysis can fail on real data: the variant doesn't match the
+reference genome, and a sample name doesn't exist in the loaded VCF.
+Both subclass standard Python exception types so callers that already
+catch `ValueError` or `KeyError` keep working.
+
+## `ReferenceMismatchError`
+
+*New in varcode 2.2.1
+([#215](https://github.com/openvax/varcode/issues/215),
+[#246](https://github.com/openvax/varcode/issues/246)).*
+
+Raised when a variant's reported `ref` allele doesn't match the
+reference genome at the variant's position:
+
+```python
+import varcode
+
+v = varcode.Variant("7", 117531114, "T", "A", "GRCh38")
+# The real + strand ref at chr7:117531114 is G, not T.
+v.effects()
+```
+
+Produces:
+
+```
+varcode.errors.ReferenceMismatchError:
+Reference allele mismatch for Variant(contig='7', start=117531114, ref='T', alt='A', reference_name='GRCh38')
+on Transcript(...) at transcript offset 620 (chromosome positions 117531114:117531114):
+variant reports ref='T' but the reference genome has 'G' at this position.
+This usually means the variant was called against a different genome
+build, the ref field was filled in with the patient's germline allele
+rather than the reference, or the variant is on the wrong strand.
+Pass raise_on_error=False to .effects() to receive a Failure effect
+instead of raising.
+```
+
+Subclasses `ValueError`, so `except ValueError` keeps working. For
+programmatic handling, the structured fields are:
+
+```python
+try:
+    v.effects()
+except varcode.ReferenceMismatchError as e:
+    e.variant           # the Variant
+    e.transcript        # the Transcript being compared against
+    e.expected_ref      # what the genome has
+    e.observed_ref      # what the variant claims
+    e.transcript_offset # position in the transcript
+```
+
+### Three common causes
+
+1. **Wrong genome build.** A VCF called against GRCh37 annotated with
+   GRCh38 (or vice versa) produces these errors at positions where
+   the builds differ.
+2. **Germline allele in the `ref` field.** VCF requires `ref` to match
+   the reference genome. Patient-specific germline variants at the
+   position should be encoded as separate variants, not by changing
+   `ref`.
+3. **Strand confusion.** The variant is specified on the negative
+   strand but varcode expects positive-strand coordinates.
+
+### The `raise_on_error=False` escape hatch
+
+If you'd rather continue past these errors instead of surfacing them,
+pass `raise_on_error=False` to `.effects()`. Each mismatched variant
+produces a `Failure` effect instead of raising:
+
+```python
+from varcode.effects import Failure
+
+effects = v.effects(raise_on_error=False)
+assert any(isinstance(e, Failure) for e in effects)
+```
+
+This is the right choice for batch pipelines that would rather log and
+skip a bad row than halt.
+
+## `SampleNotFoundError`
+
+*New in varcode 2.3.0
+([#267](https://github.com/openvax/varcode/issues/267)).*
+
+Raised by `VariantCollection` genotype/filter methods when the sample
+name isn't in the collection's source VCF(s):
+
+```python
+vc = varcode.load_vcf("tumor_normal.vcf", genome="GRCh38")
+vc.samples
+# ['normal', 'tumor']
+
+vc.for_sample("patient_01")
+# SampleNotFoundError: Sample 'patient_01' not found.
+# Available samples: ['normal', 'tumor']
+```
+
+Subclasses `KeyError` for back-compat. The early-fail-on-typo behavior
+is intentional: silently returning an empty collection when a sample
+name is misspelled would hide real bugs in analysis scripts.
+
+## Debugging tips
+
+Both errors include the specific variant and the transcript that
+triggered them. When investigating:
+
+1. Check the genome build. `v.reference_name` (e.g. `"GRCh38"`) should
+   match what the VCF was called against.
+2. Check the strand. If you expect a reverse-strand gene, the cDNA is
+   the reverse complement of the + strand — a common confusion.
+3. For sample errors, the exception message lists the available
+   samples, so misspellings are easy to spot.

--- a/docs/genotype.md
+++ b/docs/genotype.md
@@ -1,0 +1,128 @@
+# Genotypes and sample-aware queries
+
+*New in varcode 2.3.0 ([#267](https://github.com/openvax/varcode/issues/267)).*
+
+When you load a multi-sample VCF, varcode captures each sample's genotype
+(GT, AD, DP, GQ, PS) automatically. As of 2.3.0 this data is available
+as structured `Genotype` objects and via sample-aware filtering helpers
+on `VariantCollection`.
+
+## The basics
+
+```python
+from varcode import load_vcf
+
+vc = load_vcf("tumor_normal.vcf", genome="GRCh38")
+
+vc.samples
+# ['normal', 'tumor']
+
+vc.has_sample_data()
+# True
+```
+
+### One variant, one sample
+
+```python
+variant = vc[0]
+gt = vc.genotype(variant, "tumor")
+# Genotype(raw_gt='0/1', alleles=(0, 1), phased=False, phase_set=None,
+#          allele_depths=(10, 5), total_depth=15, genotype_quality=99)
+
+gt.is_called              # True
+gt.alleles                # (0, 1)
+gt.phased                 # False
+gt.allele_depths          # (10, 5)  —  (ref_depth, alt_depth)
+gt.total_depth            # 15
+gt.depth_for_alt(1)       # 5
+```
+
+### Zygosity is relative to *this variant's* alt
+
+```python
+from varcode import Zygosity
+
+vc.zygosity(variant, "tumor")
+# <Zygosity.HETEROZYGOUS: 'het'>
+
+vc.zygosity(variant, "normal")
+# <Zygosity.ABSENT: 'absent'>  — normal is ref/ref at this site
+```
+
+Four states, relative to the alt of the `Variant` you query:
+
+| State | Meaning |
+|---|---|
+| `HETEROZYGOUS` | Sample has at least one copy of this alt, and not all copies are this alt |
+| `HOMOZYGOUS` | All called copies are this alt |
+| `ABSENT` | Sample was called, but doesn't carry this alt (ref/ref, or a different alt at a multi-allelic site) |
+| `MISSING` | Sample's call was `./.` or the sample wasn't called |
+
+## Filtering
+
+These return filtered `VariantCollection`s:
+
+```python
+# Variants where this sample carries the alt (het or hom).
+vc.for_sample("tumor")
+
+# Finer distinctions:
+vc.heterozygous_in("tumor")
+vc.homozygous_alt_in("tumor")
+```
+
+Typoed sample names fail fast:
+
+```python
+vc.for_sample("typo")
+# SampleNotFoundError: Sample 'typo' not found. Available samples: ['normal', 'tumor']
+```
+
+## Cross-sample queries
+
+Tumor/normal, trio, and cohort queries fall out of set operations on
+the primitives:
+
+```python
+# Somatic candidates: in tumor, not in normal.
+tumor = set(vc.for_sample("tumor"))
+normal = set(vc.for_sample("normal"))
+somatic = tumor - normal
+
+# De novo candidates in a trio.
+de_novo = (set(vc.for_sample("child"))
+           - set(vc.for_sample("mom"))
+           - set(vc.for_sample("dad")))
+```
+
+## Multi-allelic sites
+
+VCF rows like `REF=A ALT=T,G` are split into two `Variant` objects
+(one per alt). `zygosity` is computed relative to the specific alt of
+the variant you query, so a sample with `GT=1/2` is reported as
+heterozygous for both A→T and A→G (one copy of each, with the other
+copy being a *different* alt). A sample with `GT=0/1` (one ref, one T)
+is heterozygous for A→T and `ABSENT` for A→G.
+
+This means `vc.heterozygous_in("tumor")` on a row where tumor is `1/2`
+yields two entries, one per alt — the correct biological
+interpretation.
+
+## What this doesn't do yet
+
+Three capabilities are deliberately out of scope for 2.3.0:
+
+1. **Effect prediction that uses zygosity.** `variant.effects()` still
+   returns the same output regardless of zygosity. Compound-het
+   reasoning and germline-aware effect prediction depend on the
+   `Genotype` API landing first and will arrive in the personal-genome
+   work tracked under [#270](https://github.com/openvax/varcode/issues/270).
+
+2. **Phased effects.** Phased GTs (`0|1`) and `PS` phase-set tags are
+   preserved on `Genotype` but not yet used to predict joint effects
+   of nearby variants on the same haplotype. Tracked in
+   [#269](https://github.com/openvax/varcode/issues/269).
+
+3. **Dedicated joint-analysis helpers** like `vc.de_novo_in(...)` or
+   `vc.somatic(...)`. The set-operation pattern above covers them;
+   built-in shortcuts will be added if a clear use case emerges.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,48 @@
+# varcode
+
+Varcode is a Python library for manipulating genomic variants and
+predicting their effects on protein sequences.
+
+## Install
+
+```bash
+pip install varcode
+```
+
+Reference genome data is managed through
+[PyEnsembl](https://github.com/openvax/pyensembl):
+
+```bash
+pyensembl install --release 75 76
+```
+
+## Quick example
+
+```python
+import varcode
+
+variants = varcode.load_maf("tcga-ovarian-cancer-variants.maf")
+TP53_effects = variants.groupby_gene_name()["TP53"].effects()
+print(TP53_effects.top_priority_effect())
+```
+
+See the [project README](https://github.com/openvax/varcode#readme)
+for a longer walkthrough and the effect-class table.
+
+## Feature guides
+
+- [**Genotypes and sample-aware queries**](genotype.md) — per-sample
+  zygosity on multi-sample VCFs. New in 2.3.
+- [**CSV round-trip and metadata headers**](csv.md) — `to_csv` /
+  `from_csv`, genome recovered from the header. New in 2.1, refined in 2.2.
+- [**Error handling**](errors.md) — `ReferenceMismatchError`,
+  `SampleNotFoundError`, and `raise_on_error=False`.
+
+## API reference
+
+The [API reference](api.md) is auto-generated from docstrings in the
+source.
+
+## Change log
+
+See the [changelog](changelog.md) for release history.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,72 @@
+site_name: varcode
+site_description: Library for manipulating genomic variants and predicting their effects
+site_url: https://openvax.github.io/varcode/
+repo_url: https://github.com/openvax/varcode
+repo_name: openvax/varcode
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - content.action.edit
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to light mode
+
+nav:
+  - Home: index.md
+  - Feature guides:
+      - Genotypes & sample queries: genotype.md
+      - CSV round-trip: csv.md
+      - Error handling: errors.md
+  - API reference: api.md
+  - Changelog: changelog.md
+
+markdown_extensions:
+  - admonition
+  - def_list
+  - footnotes
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      base_path:
+        - .
+        - docs
+  - pymdownx.superfences
+  - tables
+
+plugins:
+  - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          options:
+            show_source: true
+            show_root_heading: true
+            show_signature_annotations: true
+            members_order: source
+            docstring_style: numpy
+            docstring_section_style: spacy
+            merge_init_into_class: true

--- a/varcode/effects/effect_collection.py
+++ b/varcode/effects/effect_collection.py
@@ -260,9 +260,12 @@ class EffectCollection(Collection):
             Dictionary mapping transcript IDs to length-normalized expression
             levels (either FPKM or TPM)
 
-        Returns dictionary mapping each transcript effect to an expression
-        quantity. Effects that don't have an associated transcript
-        (e.g. Intergenic) will not be included.
+        Returns
+        -------
+        OrderedDict
+            Mapping from each transcript effect to an expression quantity.
+            Effects that don't have an associated transcript (e.g. Intergenic)
+            are excluded.
         """
         return OrderedDict(
             (effect, expression_levels.get(effect.transcript.id, 0.0))


### PR DESCRIPTION
## Summary

Varcode had no user-facing docs beyond a README that was out of date and a `CHANGELOG.md` that stopped at v0.5.15 (2017). This PR adds:

- **`docs/`** — mkdocs site with feature guides and an auto-generated API reference
- **`.github/workflows/docs.yml`** — builds on every PR, deploys to GitHub Pages on `main` (pattern matches openvax/vaxrank)
- **`CHANGELOG.md`** — filled in v2.0.0, v2.1.0, v2.2.0, v2.2.1, v2.3.0 entries
- **`README.md`** — short "Further reading" section pointing at the docs

## Why mkdocs-material rather than Sphinx

vaxrank, the most recent openvax repo with a working docs pipeline, uses mkdocs-material with a docs workflow that deploys to GitHub Pages. pyensembl has Sphinx but it isn't wired to CI and appears stale. Matching vaxrank's choice keeps the org's newer docs consistent, lets us write plain markdown (no RST), and uses [mkdocstrings](https://mkdocstrings.github.io/) for auto-generated API reference instead of Sphinx's autodoc.

## Doc structure

| Page | Covers |
|---|---|
| `docs/index.md` | Landing page + quick example |
| `docs/genotype.md` | #267 — `Genotype`, `Zygosity`, multi-sample VCF queries |
| `docs/csv.md` | `to_csv`/`from_csv` with metadata headers (#273, #274, #275, #276) |
| `docs/errors.md` | `ReferenceMismatchError` (#215), `SampleNotFoundError` (#267) |
| `docs/api.md` | Auto-generated API reference via mkdocstrings |
| `docs/changelog.md` | Includes `CHANGELOG.md` via pymdownx-snippets |

## Deploying to GitHub Pages

For the deploy job to succeed after merge, the repo's **Settings → Pages** source needs to be set to "GitHub Actions". The build step runs unconditionally on PRs so broken docs fail the check before merge regardless of Pages config.

## Test plan

- [x] `mkdocs build` succeeds locally with no errors
- [x] `mkdocs serve` renders correctly in a browser (feature guides, API auto-docs, changelog include)
- [x] Existing test suite: 491 passed, 0 regressions
- [x] Lint clean

## Minor side change

`EffectCollection.effect_expression` had a docstring with an ambiguous "Returns dictionary..." paragraph that mkdocstrings/griffe warned on. Rewrote it as a proper `Returns` section. No behavior change.