### PR TITLE
Prototype multi-effect splice outcome possibility sets (#262)

### DIFF
--- a/tests/test_splice_outcomes.py
+++ b/tests/test_splice_outcomes.py
@@ -25,6 +25,7 @@ Coverage:
   - Multi-allelic and reverse-strand variants work too
 """
 
+import pytest
 from pyensembl import cached_release
 
 import varcode
@@ -353,6 +354,45 @@ def test_package_level_exports():
 
 
 # --------------------------------------------------------------------
+# MultiOutcomeEffect protocol (see #299 for the planned generalization).
+# --------------------------------------------------------------------
+
+
+def test_splice_outcome_set_is_a_multi_outcome_effect():
+    # Downstream consumers filter multi-outcome results with
+    # isinstance(e, MultiOutcomeEffect) so future wrappers (RNA
+    # evidence #259, germline-aware #268, etc.) don't force churn.
+    from varcode import MultiOutcomeEffect
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    assert isinstance(target, MultiOutcomeEffect)
+    # Protocol surface: candidates, most_likely, priority_class.
+    assert hasattr(target, "candidates") and len(target.candidates) > 0
+    assert target.most_likely is target.candidates[0]
+    assert target.priority_class is target.disrupted_signal_class
+
+
+def test_multi_outcome_effect_exported_at_package_level():
+    from varcode import MultiOutcomeEffect
+    from varcode import effects
+    assert MultiOutcomeEffect is effects.MultiOutcomeEffect
+    # Confirm SpliceOutcomeSet is a subclass, not a duck.
+    assert issubclass(SpliceOutcomeSet, MultiOutcomeEffect)
+
+
+def test_non_splice_effects_are_not_multi_outcome():
+    # Guard against future class-hierarchy rearrangements that might
+    # accidentally mark deterministic effects as multi-outcome.
+    from varcode import MultiOutcomeEffect
+    from varcode.effects import Substitution, Silent, Intronic, MutationEffect
+    for cls in (Substitution, Silent, Intronic, MutationEffect):
+        assert not issubclass(cls, MultiOutcomeEffect), (
+            "%s should not be a MultiOutcomeEffect" % cls.__name__)
+
+
+# --------------------------------------------------------------------
 # Priority integration: SpliceOutcomeSet sorts as if it were the
 # disrupted-signal class (review feedback on PR #292).
 # --------------------------------------------------------------------
@@ -497,26 +537,26 @@ def test_out_of_frame_exon_skip_produces_mutant_protein():
     # out of frame — need a different exon. Use a variant known to
     # target an out-of-frame exon. We'll discover one empirically
     # by finding an exon whose length is not divisible by 3.
-    for exon in ensembl_grch38.transcript_by_id(
-            CFTR_TRANSCRIPT_ID).exons[2:]:
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    target_exon = None
+    for exon in transcript.exons[2:]:
         length = exon.end - exon.start + 1
         if length % 3 != 0:
             target_exon = exon
             break
-    else:
-        # All exons in-frame; skip this test.
-        return
+    if target_exon is None:
+        pytest.skip("No out-of-frame exon found in CFTR beyond exon 2")
 
     # Construct a donor-side disrupting variant at this exon's end
     # (+1 position after the exon in + strand coords).
-    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
     donor_plus_1 = target_exon.end + 1
     # Use a canonical-ref SNV to ensure SpliceDonor classification.
     variant = Variant("7", donor_plus_1, "G", "A", ensembl_grch38)
     bare = variant.effect_on_transcript(transcript)
     if not isinstance(bare, SpliceDonor):
-        # Skip the test if the canonical G isn't actually there.
-        return
+        pytest.skip(
+            "Canonical donor G not present at %d; classifier emitted %s "
+            "rather than SpliceDonor." % (donor_plus_1, type(bare).__name__))
     effects = variant.effects(splice_outcomes=True)
     splice_set = next(e for e in effects if e.transcript is transcript)
     skip_candidate = next(

--- a/tests/test_splice_outcomes.py
+++ b/tests/test_splice_outcomes.py
@@ -1,0 +1,352 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the splice outcome possibility-set prototype
+(openvax/varcode#262).
+
+Coverage:
+  - Default behavior unchanged (back-compat)
+  - Opt-in wraps splice effects in SpliceOutcomeSet
+  - Each canonical splice signal class produces the expected outcome set
+  - Plausibility ordering is stable
+  - Per-outcome candidate construction (normal splicing, exon
+    skipping, intron retention stubs, cryptic splice stubs)
+  - SpliceOutcomeSet integrates with EffectCollection
+  - Multi-allelic and reverse-strand variants work too
+"""
+
+from pyensembl import cached_release
+
+import varcode
+from varcode import (
+    SpliceCandidate,
+    SpliceOutcome,
+    SpliceOutcomeSet,
+    Variant,
+)
+from varcode.effects import (
+    ExonicSpliceSite,
+    IntronicSpliceSite,
+    SpliceAcceptor,
+    SpliceDonor,
+)
+from varcode.splice_outcomes import enumerate_splice_outcomes
+
+
+ensembl_grch38 = cached_release(81)
+CFTR_TRANSCRIPT_ID = "ENST00000003084"
+BRCA1_TRANSCRIPT_ID = "ENST00000357654"
+
+
+# --------------------------------------------------------------------
+# Back-compat
+# --------------------------------------------------------------------
+
+
+def test_default_behavior_unchanged():
+    # No kwarg -> same as today: SpliceDonor effect, no wrapping.
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effect = variant.effect_on_transcript(transcript)
+    assert effect.__class__ is SpliceDonor
+    assert not isinstance(effect, SpliceOutcomeSet)
+
+
+def test_default_for_collection_unchanged():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    effects = variant.effects()  # default: splice_outcomes=False
+    classes = {type(e) for e in effects}
+    assert SpliceOutcomeSet not in classes
+
+
+# --------------------------------------------------------------------
+# Opt-in wraps splice effects
+# --------------------------------------------------------------------
+
+
+def test_opt_in_wraps_splice_donor():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    effects = variant.effects(splice_outcomes=True)
+    cftr_effect = next(
+        e for e in effects
+        if getattr(e, "transcript", None) is not None
+        and e.transcript.id == CFTR_TRANSCRIPT_ID
+    )
+    assert isinstance(cftr_effect, SpliceOutcomeSet)
+    assert cftr_effect.disrupted_signal_class is SpliceDonor
+
+
+def test_opt_in_wraps_splice_acceptor():
+    # CFTR exon 4 acceptor -1 with canonical ref G.
+    variant = Variant("7", 117530898, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effect = variant.effects(splice_outcomes=True)
+    target = next(e for e in effect if e.transcript is transcript)
+    assert isinstance(target, SpliceOutcomeSet)
+    assert target.disrupted_signal_class is SpliceAcceptor
+
+
+def test_opt_in_wraps_exonic_splice_site():
+    # CFTR exon 4 ends with AAG. G->T at -1 disrupts the MAG signal.
+    variant = Variant("7", 117531114, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    assert isinstance(target, SpliceOutcomeSet)
+    assert target.disrupted_signal_class is ExonicSpliceSite
+
+
+def test_opt_in_wraps_intronic_splice_site():
+    # CFTR exon 4 +1 with NON-canonical ref A is downgraded to
+    # IntronicSpliceSite (post-2.0.0 sequence-aware classification).
+    variant = Variant("7", 117531115, "A", "G", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    assert isinstance(target, SpliceOutcomeSet)
+    assert target.disrupted_signal_class is IntronicSpliceSite
+
+
+def test_opt_in_passes_through_non_splice_effects():
+    # Pure substitution that doesn't touch any splice signal: should
+    # not be wrapped.
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", ensembl_grch38)
+    effects = variant.effects(splice_outcomes=True)
+    # At least one effect should be a Substitution, not wrapped.
+    classes = [type(e).__name__ for e in effects]
+    assert "Substitution" in classes
+
+
+# --------------------------------------------------------------------
+# Plausibility ordering and candidate composition
+# --------------------------------------------------------------------
+
+
+def test_splice_donor_candidate_set_has_expected_outcomes():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effect = variant.effects(splice_outcomes=True)
+    target = next(e for e in effect if e.transcript is transcript)
+    outcomes = {c.outcome for c in target.candidates}
+    assert outcomes == {
+        SpliceOutcome.EXON_SKIPPING,
+        SpliceOutcome.INTRON_RETENTION,
+        SpliceOutcome.CRYPTIC_DONOR,
+        SpliceOutcome.NORMAL_SPLICING,
+    }
+
+
+def test_splice_acceptor_candidate_set_uses_cryptic_acceptor():
+    variant = Variant("7", 117530898, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    outcomes = {c.outcome for c in target.candidates}
+    # SpliceAcceptor disruption uses CRYPTIC_ACCEPTOR not CRYPTIC_DONOR.
+    assert SpliceOutcome.CRYPTIC_ACCEPTOR in outcomes
+    assert SpliceOutcome.CRYPTIC_DONOR not in outcomes
+
+
+def test_candidates_sorted_by_plausibility_descending():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    plaus = [c.plausibility for c in target.candidates]
+    assert plaus == sorted(plaus, reverse=True), (
+        "Candidates should be ordered most-plausible-first, got %r"
+        % plaus)
+
+
+def test_most_likely_for_splice_donor_is_exon_skipping():
+    # Per the plausibility table, EXON_SKIPPING dominates SpliceDonor.
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    assert target.most_likely.outcome is SpliceOutcome.EXON_SKIPPING
+
+
+def test_most_likely_for_exonic_splice_site_is_normal_splicing():
+    # ExonicSpliceSite gets NORMAL_SPLICING as the most-likely
+    # outcome (the disruption is on the exon side and often tolerated).
+    variant = Variant("7", 117531114, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    assert target.most_likely.outcome is SpliceOutcome.NORMAL_SPLICING
+
+
+def test_normal_splicing_carries_underlying_coding_effect():
+    # ExonicSpliceSite has an alternate_effect (the coding change if
+    # splicing proceeds). NORMAL_SPLICING candidate exposes it.
+    variant = Variant("7", 117531114, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    normal = next(
+        c for c in target.candidates
+        if c.outcome is SpliceOutcome.NORMAL_SPLICING
+    )
+    assert normal.coding_effect is not None
+    assert "p." in normal.coding_effect.short_description
+
+
+# --------------------------------------------------------------------
+# Per-outcome detail
+# --------------------------------------------------------------------
+
+
+def test_intron_retention_candidate_predicts_premature_stop():
+    # Intron retention typically produces a PrematureStop. Stub
+    # without exact protein since we don't have intronic genomic seq.
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    intron = next(
+        c for c in target.candidates
+        if c.outcome is SpliceOutcome.INTRON_RETENTION
+    )
+    assert intron.predicted_class_name == "PrematureStop"
+    assert intron.coding_effect is None
+
+
+def test_cryptic_donor_candidate_is_a_stub():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    cryptic = next(
+        c for c in target.candidates
+        if c.outcome is SpliceOutcome.CRYPTIC_DONOR
+    )
+    assert cryptic.coding_effect is None
+    assert "cryptic" in cryptic.description.lower()
+
+
+def test_exon_skipping_for_in_frame_exon_emits_deletion():
+    # CFTR exon 4 is 216 nucleotides = 72 codons (216 % 3 == 0), so
+    # skipping it is in-frame. The candidate should report Deletion
+    # of the exon's amino acids.
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    skip = next(
+        c for c in target.candidates
+        if c.outcome is SpliceOutcome.EXON_SKIPPING
+    )
+    # Either a Deletion was constructed, or the candidate falls back
+    # to None with predicted_class_name still set. Both are valid.
+    if skip.coding_effect is not None:
+        assert skip.predicted_class_name == "Deletion"
+        assert skip.coding_effect.aa_ref  # non-empty AA range
+    else:
+        assert skip.predicted_class_name in ("Deletion", "FrameShift", "ExonLoss")
+
+
+# --------------------------------------------------------------------
+# EffectCollection integration
+# --------------------------------------------------------------------
+
+
+def test_collection_iteration_after_wrapping():
+    # The wrapped collection should still be iterable, indexable, and
+    # produce SpliceOutcomeSet objects in place of the original splice
+    # effects.
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    effects = variant.effects(splice_outcomes=True)
+    items = list(effects)
+    assert len(items) > 0
+    splice_set_count = sum(1 for e in items if isinstance(e, SpliceOutcomeSet))
+    assert splice_set_count >= 1
+
+
+def test_short_description_uses_most_likely():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    desc = target.short_description
+    assert desc.startswith("splice-set:")
+    assert target.most_likely.outcome.value in desc
+
+
+# --------------------------------------------------------------------
+# Reverse-strand
+# --------------------------------------------------------------------
+
+
+def test_opt_in_works_on_reverse_strand_donor():
+    # BRCA1 exon 12 reverse-strand donor at 43082403 with canonical ref C.
+    variant = Variant("17", 43082403, "C", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(BRCA1_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    assert isinstance(target, SpliceOutcomeSet)
+    assert target.disrupted_signal_class is SpliceDonor
+
+
+# --------------------------------------------------------------------
+# Direct enumerate_splice_outcomes tests
+# --------------------------------------------------------------------
+
+
+def test_enumerate_passes_through_non_splice():
+    # Non-splice effect should pass through unchanged.
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(BRCA1_TRANSCRIPT_ID)
+    sub_effect = variant.effect_on_transcript(transcript)
+    assert type(sub_effect).__name__ == "Substitution"
+    wrapped = enumerate_splice_outcomes(sub_effect)
+    assert wrapped is sub_effect
+
+
+# --------------------------------------------------------------------
+# SpliceCandidate dataclass ergonomics
+# --------------------------------------------------------------------
+
+
+def test_splice_candidate_is_frozen():
+    c = SpliceCandidate(
+        outcome=SpliceOutcome.EXON_SKIPPING,
+        plausibility=0.5,
+        description="test",
+    )
+    try:
+        c.plausibility = 0.9  # type: ignore
+    except Exception:
+        pass
+    else:
+        raise AssertionError("SpliceCandidate should be frozen")
+
+
+def test_splice_candidate_equality():
+    a = SpliceCandidate(
+        outcome=SpliceOutcome.EXON_SKIPPING,
+        plausibility=0.5,
+        description="d",
+    )
+    b = SpliceCandidate(
+        outcome=SpliceOutcome.EXON_SKIPPING,
+        plausibility=0.5,
+        description="d",
+    )
+    assert a == b
+
+
+def test_package_level_exports():
+    assert varcode.SpliceCandidate is SpliceCandidate
+    assert varcode.SpliceOutcome is SpliceOutcome
+    assert varcode.SpliceOutcomeSet is SpliceOutcomeSet

--- a/tests/test_splice_outcomes.py
+++ b/tests/test_splice_outcomes.py
@@ -350,3 +350,216 @@ def test_package_level_exports():
     assert varcode.SpliceCandidate is SpliceCandidate
     assert varcode.SpliceOutcome is SpliceOutcome
     assert varcode.SpliceOutcomeSet is SpliceOutcomeSet
+
+
+# --------------------------------------------------------------------
+# Priority integration: SpliceOutcomeSet sorts as if it were the
+# disrupted-signal class (review feedback on PR #292).
+# --------------------------------------------------------------------
+
+
+def test_splice_outcome_set_sorts_as_disrupted_signal_class():
+    # When wrapped, a SpliceDonor-backed SpliceOutcomeSet should have
+    # the same priority as a bare SpliceDonor — higher than Intronic,
+    # lower than Substitution. If the priority delegation is broken,
+    # SpliceOutcomeSet gets priority -1 and sorts to the bottom.
+    from varcode.effects import effect_priority
+
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    bare_effect = variant.effect_on_transcript(transcript)
+    assert isinstance(bare_effect, SpliceDonor)
+    bare_priority = effect_priority(bare_effect)
+
+    wrapped_effects = variant.effects(splice_outcomes=True)
+    wrapped = next(e for e in wrapped_effects if e.transcript is transcript)
+    assert isinstance(wrapped, SpliceOutcomeSet)
+    wrapped_priority = effect_priority(wrapped)
+
+    assert wrapped_priority == bare_priority, (
+        "SpliceOutcomeSet priority (%d) must match the disrupted-"
+        "signal class priority (%d); otherwise sorting and "
+        "top_priority_effect() behave wrongly." % (
+            wrapped_priority, bare_priority))
+
+
+def test_splice_outcome_set_top_priority_works():
+    # top_priority_effect on a collection containing SpliceOutcomeSet
+    # should not pick a lower-priority non-splice effect.
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    effects = variant.effects(splice_outcomes=True)
+    top = effects.top_priority_effect()
+    # The wrapped SpliceDonor (or one of the splice-set variants) is
+    # higher priority than Intronic/NoncodingTranscript from other
+    # overlapping transcripts, so the top should be a splice-related
+    # effect.
+    top_class_name = type(top).__name__
+    assert top_class_name in ("SpliceOutcomeSet", "SpliceDonor"), (
+        "Expected a splice-related effect at top priority, got %s"
+        % top_class_name)
+
+
+# --------------------------------------------------------------------
+# Acceptor-side IntronicSpliceSite emits CRYPTIC_ACCEPTOR, not DONOR.
+# --------------------------------------------------------------------
+
+
+def test_acceptor_side_intronic_splice_site_uses_cryptic_acceptor():
+    # CFTR exon 4 acceptor -3 (3bp before exon.start). A variant here
+    # with NON-canonical ref (not A, the canonical MAG component) is
+    # classified as IntronicSpliceSite. The splice set should include
+    # CRYPTIC_ACCEPTOR (the relevant cryptic direction for the
+    # acceptor side), not CRYPTIC_DONOR.
+    from varcode.effects import IntronicSpliceSite
+    # chr7:117530896 is -3 before CFTR exon 4 (forward strand).
+    # Use a non-canonical ref for the -3 position so it's
+    # IntronicSpliceSite (not SpliceAcceptor which covers -1/-2).
+    # At distance -3, the position isn't required to be canonical
+    # anyway — the classifier emits IntronicSpliceSite for this window.
+    variant = Variant("7", 117530896, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    bare = variant.effect_on_transcript(transcript)
+    assert isinstance(bare, IntronicSpliceSite) and \
+        not isinstance(bare, (SpliceDonor, SpliceAcceptor))
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    outcomes = {c.outcome for c in target.candidates}
+    assert SpliceOutcome.CRYPTIC_ACCEPTOR in outcomes, \
+        "Acceptor-side IntronicSpliceSite should use CRYPTIC_ACCEPTOR"
+    assert SpliceOutcome.CRYPTIC_DONOR not in outcomes, \
+        "Acceptor-side IntronicSpliceSite should not use CRYPTIC_DONOR"
+
+
+def test_donor_side_intronic_splice_site_uses_cryptic_donor():
+    # Mirror test for donor-side IntronicSpliceSite at +3 after CFTR
+    # exon 4 end (117531117 = exon.end + 3).
+    from varcode.effects import IntronicSpliceSite
+    variant = Variant("7", 117531117, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    bare = variant.effect_on_transcript(transcript)
+    assert isinstance(bare, IntronicSpliceSite) and \
+        not isinstance(bare, (SpliceDonor, SpliceAcceptor))
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    outcomes = {c.outcome for c in target.candidates}
+    assert SpliceOutcome.CRYPTIC_DONOR in outcomes
+    assert SpliceOutcome.CRYPTIC_ACCEPTOR not in outcomes
+
+
+# --------------------------------------------------------------------
+# Multi-protein surface: candidate_proteins and mutant_protein_sequences
+# --------------------------------------------------------------------
+
+
+def test_candidate_proteins_maps_each_outcome_to_a_protein():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    proteins = target.candidate_proteins
+    # Every candidate outcome appears as a key.
+    outcomes = {c.outcome for c in target.candidates}
+    assert set(proteins.keys()) == outcomes
+    # EXON_SKIPPING for an in-frame exon should have a non-empty
+    # protein (reference minus the skipped AAs). CFTR exon 4 is 216
+    # nucleotides = 72 codons = in-frame.
+    assert proteins[SpliceOutcome.EXON_SKIPPING], \
+        "Expected a concrete mutant protein for in-frame exon skipping"
+    # INTRON_RETENTION and CRYPTIC are stubs → empty string for now.
+    assert proteins[SpliceOutcome.INTRON_RETENTION] == ""
+    assert proteins[SpliceOutcome.CRYPTIC_DONOR] == ""
+
+
+def test_mutant_protein_sequences_collects_distinct_proteins():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    proteins = target.mutant_protein_sequences
+    assert isinstance(proteins, set)
+    assert len(proteins) >= 1
+    # Reference protein should be in there or a proper subset of
+    # reference (exon-skipped version is shorter).
+    ref = str(transcript.protein_sequence)
+    # The in-frame exon skip removes exon 4 AAs; resulting protein
+    # should be shorter than reference.
+    shortest = min(proteins, key=len)
+    assert len(shortest) < len(ref)
+
+
+# --------------------------------------------------------------------
+# Out-of-frame exon skip now produces a real mutant protein
+# --------------------------------------------------------------------
+
+
+def test_out_of_frame_exon_skip_produces_mutant_protein():
+    # CFTR exon 5 is 90 nucleotides = 30 codons, BUT exon 5 is not
+    # out of frame — need a different exon. Use a variant known to
+    # target an out-of-frame exon. We'll discover one empirically
+    # by finding an exon whose length is not divisible by 3.
+    for exon in ensembl_grch38.transcript_by_id(
+            CFTR_TRANSCRIPT_ID).exons[2:]:
+        length = exon.end - exon.start + 1
+        if length % 3 != 0:
+            target_exon = exon
+            break
+    else:
+        # All exons in-frame; skip this test.
+        return
+
+    # Construct a donor-side disrupting variant at this exon's end
+    # (+1 position after the exon in + strand coords).
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    donor_plus_1 = target_exon.end + 1
+    # Use a canonical-ref SNV to ensure SpliceDonor classification.
+    variant = Variant("7", donor_plus_1, "G", "A", ensembl_grch38)
+    bare = variant.effect_on_transcript(transcript)
+    if not isinstance(bare, SpliceDonor):
+        # Skip the test if the canonical G isn't actually there.
+        return
+    effects = variant.effects(splice_outcomes=True)
+    splice_set = next(e for e in effects if e.transcript is transcript)
+    skip_candidate = next(
+        c for c in splice_set.candidates
+        if c.outcome is SpliceOutcome.EXON_SKIPPING
+    )
+    # Out-of-frame skip should now carry a mutant protein.
+    assert skip_candidate.coding_effect is not None, (
+        "Out-of-frame exon skip should produce a concrete mutant "
+        "protein, not a stub")
+    protein = skip_candidate.coding_effect.mutant_protein_sequence
+    assert isinstance(protein, str)
+    assert len(protein) > 0
+    # The frameshifted protein should differ from the reference
+    # after the skip point.
+    assert protein != str(transcript.protein_sequence)
+
+
+# --------------------------------------------------------------------
+# has_protein property on SpliceCandidate
+# --------------------------------------------------------------------
+
+
+def test_has_protein_is_true_for_candidates_with_coding_effect():
+    variant = Variant("7", 117531114, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    # NORMAL_SPLICING has a Substitution coding_effect with a protein.
+    normal = next(
+        c for c in target.candidates
+        if c.outcome is SpliceOutcome.NORMAL_SPLICING
+    )
+    assert normal.has_protein is True
+
+
+def test_has_protein_is_false_for_stub_candidates():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    intron = next(
+        c for c in target.candidates
+        if c.outcome is SpliceOutcome.INTRON_RETENTION
+    )
+    assert intron.has_protein is False

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -26,6 +26,7 @@ from .effects import (
     effect_priority,
     top_priority_effect,
     EffectCollection,
+    MultiOutcomeEffect,
     MutationEffect,
     NonsilentCodingMutation,
 )
@@ -51,6 +52,7 @@ __all__ = [
     # effects
     "effect_priority",
     "top_priority_effect",
+    "MultiOutcomeEffect",
     "MutationEffect",
     "NonsilentCodingMutation",
 

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -13,6 +13,11 @@
 
 from .errors import ReferenceMismatchError, SampleNotFoundError
 from .genotype import Genotype, Zygosity
+from .splice_outcomes import (
+    SpliceCandidate,
+    SpliceOutcome,
+    SpliceOutcomeSet,
+)
 from .variant import Variant
 from .variant_collection import VariantCollection
 from .maf import load_maf, load_maf_dataframe
@@ -37,6 +42,11 @@ __all__ = [
     # genotype / zygosity
     "Genotype",
     "Zygosity",
+
+    # splice outcome possibility set (openvax/varcode#262)
+    "SpliceCandidate",
+    "SpliceOutcome",
+    "SpliceOutcomeSet",
 
     # effects
     "effect_priority",

--- a/varcode/effects/__init__.py
+++ b/varcode/effects/__init__.py
@@ -24,6 +24,7 @@ from .effect_prediction import (
 )
 from .effect_classes import (
     MutationEffect,
+    MultiOutcomeEffect,
     TranscriptMutationEffect,
     NonsilentCodingMutation,
     Failure,
@@ -65,6 +66,7 @@ __all__ = [
 
     # effect classes
     "MutationEffect",
+    "MultiOutcomeEffect",
     "TranscriptMutationEffect",
     "Failure",
     "IncompleteTranscript",

--- a/varcode/effects/effect_classes.py
+++ b/varcode/effects/effect_classes.py
@@ -107,6 +107,32 @@ class MutationEffect(Serializable):
     aa_mutation_end_offset = None
 
 
+class MultiOutcomeEffect(MutationEffect):
+    """Marker base class for effects that represent a set of plausible
+    outcomes rather than a single deterministic effect.
+
+    Subclasses must expose:
+
+    * ``candidates`` — sequence of outcome objects, sorted
+      most-plausible-first.
+    * ``most_likely`` — the top candidate (i.e. ``candidates[0]``).
+    * ``priority_class`` — effect class whose priority this set adopts
+      (read by :func:`varcode.effects.effect_priority`).
+
+    Downstream consumers filter for multi-outcome results with
+    ``isinstance(effect, MultiOutcomeEffect)`` so new wrappers (RNA
+    evidence #259, germline-aware #268, etc.) can implement the same
+    protocol without downstream code churn.
+
+    The contract above is documented but not enforced at runtime —
+    this is a deliberately minimal hedge. A subclass that passes
+    ``isinstance`` but omits ``candidates`` will ``AttributeError``
+    at first access. See #299 for the planned formalization into a
+    full protocol with a common ``Candidate`` type and runtime
+    enforcement.
+    """
+
+
 class Intergenic(MutationEffect):
     """Variant has unknown effect if it occurs between genes"""
     short_description = "intergenic"

--- a/varcode/effects/effect_ordering.py
+++ b/varcode/effects/effect_ordering.py
@@ -92,8 +92,14 @@ transcript_effect_priority_dict = {
 def effect_priority(effect):
     """
     Returns the integer priority for a given transcript effect.
+
+    Effects may opt out of class-based priority lookup by exposing a
+    ``priority_class`` attribute — used by wrapper classes like
+    :class:`varcode.splice_outcomes.SpliceOutcomeSet` to delegate to
+    the wrapped effect's class.
     """
-    return transcript_effect_priority_dict.get(effect.__class__, -1)
+    cls = getattr(effect, "priority_class", None) or effect.__class__
+    return transcript_effect_priority_dict.get(cls, -1)
 
 
 def apply_to_field_if_exists(effect, field_name, fn, default):

--- a/varcode/effects/effect_ordering.py
+++ b/varcode/effects/effect_ordering.py
@@ -320,6 +320,13 @@ def select_between_exonic_splice_site_and_alternate_effect(effect):
     If the given effect is an ExonicSpliceSite then it might contain
     an alternate effect of higher priority. In that case, return the
     alternate effect. Otherwise, this acts as an identity function.
+
+    An exact-class check (not ``isinstance``) is used because the
+    function is only meant to unwrap bare ``ExonicSpliceSite``
+    instances. This has a useful side effect under
+    ``splice_outcomes=True``: the wrapping ``SpliceOutcomeSet`` passes
+    through unchanged (so every plausible outcome stays visible) and
+    sorts by its ``priority_class``.
     """
     if effect.__class__ is not ExonicSpliceSite:
         return effect

--- a/varcode/effects/effect_prediction.py
+++ b/varcode/effects/effect_prediction.py
@@ -43,7 +43,7 @@ from .effect_classes import (
 logger = logging.getLogger(__name__)
 
 
-def predict_variant_effects(variant, raise_on_error=False):
+def predict_variant_effects(variant, raise_on_error=False, splice_outcomes=False):
     """Determine the effects of a variant on any transcripts it overlaps.
     Returns an EffectCollection object.
 
@@ -55,6 +55,14 @@ def predict_variant_effects(variant, raise_on_error=False):
         Raise an exception if we encounter an error while trying to
         determine the effect of this variant on a transcript, or simply
         log the error and continue.
+
+    splice_outcomes : bool
+        When True, splice-disrupting effects (SpliceDonor,
+        SpliceAcceptor, ExonicSpliceSite, IntronicSpliceSite) are
+        wrapped in a :class:`SpliceOutcomeSet` carrying multiple
+        plausible outcomes (normal splicing, exon skipping, intron
+        retention, cryptic splice). Default False for back-compat.
+        See ``varcode.splice_outcomes`` for details.
     """
     # if this variant isn't overlapping any genes, return a
     # Intergenic effect
@@ -97,7 +105,13 @@ def predict_variant_effects(variant, raise_on_error=False):
                             variant=variant,
                             transcript=transcript)
                     effects.append(effect)
-    return EffectCollection(effects)
+    collection = EffectCollection(effects)
+    if splice_outcomes:
+        # Lazy import to avoid circular deps; splice_outcomes lives at
+        # the package root and consumes effect_classes.
+        from ..splice_outcomes import wrap_splice_effects_in_collection
+        collection = wrap_splice_effects_in_collection(collection)
+    return collection
 
 
 def predict_variant_effect_on_transcript_or_failure(variant, transcript):

--- a/varcode/splice_outcomes.py
+++ b/varcode/splice_outcomes.py
@@ -50,6 +50,7 @@ from .effects.effect_classes import (
     Deletion,
     ExonicSpliceSite,
     IntronicSpliceSite,
+    MultiOutcomeEffect,
     MutationEffect,
     SpliceAcceptor,
     SpliceDonor,
@@ -131,9 +132,14 @@ class SpliceCandidate:
         )
 
 
-class SpliceOutcomeSet(MutationEffect):
+class SpliceOutcomeSet(MultiOutcomeEffect):
     """A splice-disrupting variant's effect, expressed as a set of
     plausible outcomes rather than a single Effect.
+
+    Implements the :class:`MultiOutcomeEffect` protocol: downstream
+    consumers can write ``isinstance(effect, MultiOutcomeEffect)`` to
+    catch this and any future multi-outcome wrapper (RNA evidence,
+    germline-aware, etc.) uniformly — see #299.
 
     For back-compat, :attr:`short_description` delegates to the most
     plausible candidate. Callers that want all candidates iterate
@@ -145,7 +151,7 @@ class SpliceOutcomeSet(MutationEffect):
     """
 
     def __init__(self, variant, transcript, candidates, disrupted_signal_class=None):
-        MutationEffect.__init__(self, variant)
+        MultiOutcomeEffect.__init__(self, variant)
         self.transcript = transcript
         # Sort candidates by plausibility descending so .candidates[0]
         # is always the most likely.
@@ -274,15 +280,17 @@ _PLAUSIBILITY_INTRONIC_SPLICE_SITE_ACCEPTOR = {
 }
 
 # Order matters for isinstance matching: more specific classes first.
-# Today all four are leaf classes so ordering doesn't matter in
-# practice, but the iteration pattern in _plausibility_table_for()
-# is future-proof against subclassing.
+# SpliceDonor and SpliceAcceptor are subclasses of IntronicSpliceSite
+# (see effect_classes.py), so they must be checked before the
+# IntronicSpliceSite fallback in _plausibility_table_for — otherwise
+# a SpliceDonor would incorrectly fall into the intronic-window table.
+# IntronicSpliceSite itself is deliberately held out of this tuple and
+# dispatched separately so side detection can pick the right cryptic
+# direction.
 _PLAUSIBILITY_TABLES = (
     (SpliceDonor, _PLAUSIBILITY_SPLICE_DONOR),
     (SpliceAcceptor, _PLAUSIBILITY_SPLICE_ACCEPTOR),
     (ExonicSpliceSite, _PLAUSIBILITY_EXONIC_SPLICE_SITE),
-    # IntronicSpliceSite requires side detection to pick the right
-    # cryptic direction; handled in _plausibility_table_for().
 )
 
 
@@ -294,19 +302,18 @@ def _intronic_splice_side_is_acceptor(splice_effect):
     side, after exon in transcript order) and -3 (acceptor side,
     before exon in transcript order). The side determines whether a
     cryptic donor or cryptic acceptor is the relevant alternative.
+
+    Caller contract: ``splice_effect`` must be an ``IntronicSpliceSite``
+    (guaranteed by :func:`_plausibility_table_for`), so ``variant`` and
+    ``nearest_exon`` are always present.
     """
-    exon = getattr(splice_effect, "nearest_exon", None)
-    variant = getattr(splice_effect, "variant", None)
-    if exon is None or variant is None:
-        return False
-    strand = getattr(exon, "strand", "+")
-    variant_start = variant.trimmed_base1_start
-    variant_end = variant.trimmed_base1_end
-    if strand == "+":
-        return variant_start < exon.start
+    exon = splice_effect.nearest_exon
+    variant = splice_effect.variant
+    if exon.strand == "+":
+        return variant.trimmed_base1_start < exon.start
     # Reverse strand: acceptor-side intronic variants sit past the
     # genomic end of the exon (which is the 5' end in transcript order).
-    return variant_end > exon.end
+    return variant.trimmed_base1_end > exon.end
 
 
 def _plausibility_table_for(splice_effect):

--- a/varcode/splice_outcomes.py
+++ b/varcode/splice_outcomes.py
@@ -53,8 +53,8 @@ from .effects.effect_classes import (
     MutationEffect,
     SpliceAcceptor,
     SpliceDonor,
+    StartLoss,
 )
-from .effects.effect_ordering import effect_priority
 
 
 class SpliceOutcome(Enum):
@@ -157,8 +157,52 @@ class SpliceOutcomeSet(MutationEffect):
         self.disrupted_signal_class = disrupted_signal_class
 
     @property
+    def priority_class(self):
+        """Delegate priority lookup to the disrupted-signal class so a
+        SpliceOutcomeSet sorts as if it were the original splice effect.
+
+        Read by :func:`varcode.effects.effect_priority`.
+        """
+        return self.disrupted_signal_class
+
+    @property
     def most_likely(self) -> SpliceCandidate:
         return self.candidates[0]
+
+    @property
+    def candidate_proteins(self):
+        """Mapping from each :class:`SpliceOutcome` to its computed
+        mutant protein sequence (empty string when the protein is not
+        computable from cDNA alone — i.e. intron retention and
+        cryptic splice).
+
+        Returns
+        -------
+        dict[SpliceOutcome, str]
+            One entry per candidate. The string is empty for stubs.
+        """
+        result = {}
+        for candidate in self.candidates:
+            coding = candidate.coding_effect
+            if coding is not None:
+                protein = getattr(coding, "mutant_protein_sequence", "")
+                result[candidate.outcome] = str(protein) if protein else ""
+            else:
+                result[candidate.outcome] = ""
+        return result
+
+    @property
+    def mutant_protein_sequences(self):
+        """Set of distinct non-empty mutant protein sequences across
+        all candidates.
+
+        Useful for downstream consumers (neoantigen prediction,
+        isovar/vaxrank) that want to enumerate every protein this
+        splice disruption might produce.
+        """
+        return {
+            p for p in self.candidate_proteins.values() if p
+        }
 
     @property
     def short_description(self) -> str:
@@ -213,20 +257,73 @@ _PLAUSIBILITY_EXONIC_SPLICE_SITE = {
 }
 
 # Intronic splice site (positions +3 to +6 or -3): less critical
-# region; normal splicing dominates.
-_PLAUSIBILITY_INTRONIC_SPLICE_SITE = {
+# region; normal splicing dominates. Two variants — donor-side (+3 to +6)
+# and acceptor-side (-3) — which differ only in the cryptic direction.
+_PLAUSIBILITY_INTRONIC_SPLICE_SITE_DONOR = {
     SpliceOutcome.NORMAL_SPLICING: 0.70,
     SpliceOutcome.EXON_SKIPPING: 0.20,
     SpliceOutcome.INTRON_RETENTION: 0.05,
     SpliceOutcome.CRYPTIC_DONOR: 0.05,
 }
 
-_PLAUSIBILITY_TABLES = {
-    SpliceDonor: _PLAUSIBILITY_SPLICE_DONOR,
-    SpliceAcceptor: _PLAUSIBILITY_SPLICE_ACCEPTOR,
-    ExonicSpliceSite: _PLAUSIBILITY_EXONIC_SPLICE_SITE,
-    IntronicSpliceSite: _PLAUSIBILITY_INTRONIC_SPLICE_SITE,
+_PLAUSIBILITY_INTRONIC_SPLICE_SITE_ACCEPTOR = {
+    SpliceOutcome.NORMAL_SPLICING: 0.70,
+    SpliceOutcome.EXON_SKIPPING: 0.20,
+    SpliceOutcome.INTRON_RETENTION: 0.05,
+    SpliceOutcome.CRYPTIC_ACCEPTOR: 0.05,
 }
+
+# Order matters for isinstance matching: more specific classes first.
+# Today all four are leaf classes so ordering doesn't matter in
+# practice, but the iteration pattern in _plausibility_table_for()
+# is future-proof against subclassing.
+_PLAUSIBILITY_TABLES = (
+    (SpliceDonor, _PLAUSIBILITY_SPLICE_DONOR),
+    (SpliceAcceptor, _PLAUSIBILITY_SPLICE_ACCEPTOR),
+    (ExonicSpliceSite, _PLAUSIBILITY_EXONIC_SPLICE_SITE),
+    # IntronicSpliceSite requires side detection to pick the right
+    # cryptic direction; handled in _plausibility_table_for().
+)
+
+
+def _intronic_splice_side_is_acceptor(splice_effect):
+    """True if an IntronicSpliceSite effect is on the acceptor side of
+    its nearest exon.
+
+    The classifier emits IntronicSpliceSite for positions +3–6 (donor
+    side, after exon in transcript order) and -3 (acceptor side,
+    before exon in transcript order). The side determines whether a
+    cryptic donor or cryptic acceptor is the relevant alternative.
+    """
+    exon = getattr(splice_effect, "nearest_exon", None)
+    variant = getattr(splice_effect, "variant", None)
+    if exon is None or variant is None:
+        return False
+    strand = getattr(exon, "strand", "+")
+    variant_start = variant.trimmed_base1_start
+    variant_end = variant.trimmed_base1_end
+    if strand == "+":
+        return variant_start < exon.start
+    # Reverse strand: acceptor-side intronic variants sit past the
+    # genomic end of the exon (which is the 5' end in transcript order).
+    return variant_end > exon.end
+
+
+def _plausibility_table_for(splice_effect):
+    """Return the plausibility table that applies to this splice
+    effect, or None for effects we don't wrap.
+
+    Uses :func:`isinstance` rather than exact-class dispatch so
+    subclasses are handled correctly.
+    """
+    for cls, table in _PLAUSIBILITY_TABLES:
+        if isinstance(splice_effect, cls):
+            return table
+    if isinstance(splice_effect, IntronicSpliceSite):
+        if _intronic_splice_side_is_acceptor(splice_effect):
+            return _PLAUSIBILITY_INTRONIC_SPLICE_SITE_ACCEPTOR
+        return _PLAUSIBILITY_INTRONIC_SPLICE_SITE_DONOR
+    return None
 
 
 # ---------------------------------------------------------------------
@@ -284,8 +381,22 @@ def _build_exon_skipping_candidate(splice_effect, plausibility):
             predicted_class_name="ExonLoss",
         )
 
+    exon_contains_start_codon = _exon_contains_start_codon(transcript, exon)
     exon_length = exon.end - exon.start + 1
-    if exon_length % 3 == 0:
+    if exon_contains_start_codon:
+        # Losing the exon that contains the start codon means the
+        # protein as annotated can't be produced; label this as
+        # StartLoss. We can't easily construct the StartLoss effect
+        # here without more context, so return a stub with the right
+        # predicted class.
+        coding_effect = _build_start_loss_effect(
+            splice_effect.variant, transcript)
+        predicted_class_name = "StartLoss"
+        description = (
+            "Exon %s is skipped and contains the start codon; "
+            "annotated translation initiation is lost." % (
+                getattr(exon, "exon_id", "?"),))
+    elif exon_length % 3 == 0:
         coding_effect = _build_in_frame_exon_skip_effect(
             splice_effect.variant, transcript, exon)
         predicted_class_name = "Deletion"
@@ -293,7 +404,8 @@ def _build_exon_skipping_candidate(splice_effect, plausibility):
             "Exon %s is skipped (in-frame, %d aa removed)." % (
                 getattr(exon, "exon_id", "?"), exon_length // 3))
     else:
-        coding_effect = None
+        coding_effect = _build_out_of_frame_exon_skip_effect(
+            splice_effect.variant, transcript, exon)
         predicted_class_name = "FrameShift"
         description = (
             "Exon %s is skipped (out of frame, frameshift in the "
@@ -353,6 +465,127 @@ def _build_cryptic_splice_candidate(splice_effect, plausibility, outcome):
 # ---------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------
+
+
+def _exon_contains_start_codon(transcript, exon):
+    """True if the given exon contains the annotated start codon."""
+    if not transcript.complete:
+        return False
+    try:
+        start_offsets = transcript.start_codon_spliced_offsets
+    except Exception:
+        return False
+    if not start_offsets:
+        return False
+    exon_start = _exon_start_offset_in_transcript_or_none(transcript, exon)
+    if exon_start is None:
+        return False
+    exon_length = exon.end - exon.start + 1
+    exon_end = exon_start + exon_length - 1
+    first_start = min(start_offsets)
+    return exon_start <= first_start <= exon_end
+
+
+def _exon_start_offset_in_transcript_or_none(transcript, exon):
+    """Like :func:`_exon_start_offset_in_transcript` but returns None
+    on failure instead of raising."""
+    try:
+        return _exon_start_offset_in_transcript(transcript, exon)
+    except (StopIteration, ValueError):
+        return None
+
+
+def _build_start_loss_effect(variant, transcript):
+    """Build a StartLoss effect stub when the start-codon exon is
+    skipped. Returns None if the transcript can't accommodate it.
+    """
+    if not transcript.complete:
+        return None
+    try:
+        return StartLoss(variant=variant, transcript=transcript)
+    except Exception:
+        return None
+
+
+def _build_out_of_frame_exon_skip_effect(variant, transcript, skipped_exon):
+    """Compute the mutant protein for an out-of-frame exon skip.
+
+    Builds the post-skip cDNA by joining all exons except the skipped
+    one, translating from the original start codon, and following the
+    frameshift until the first stop. Returns a Deletion-style effect
+    with aa_ref set to the joined skipped region; leaves the mutant
+    protein accessible via a custom subclass-like shim.
+    """
+    if not transcript.complete:
+        return None
+    try:
+        exon_start_in_tx = _exon_start_offset_in_transcript(
+            transcript, skipped_exon)
+    except (StopIteration, ValueError):
+        return None
+    cds_start_offset = min(transcript.start_codon_spliced_offsets)
+    if exon_start_in_tx < cds_start_offset:
+        return None
+    exon_length = skipped_exon.end - skipped_exon.start + 1
+    # Construct the post-skip cDNA by excising the exon's nucleotides
+    # from the full transcript sequence.
+    full_sequence = str(transcript.sequence)
+    post_skip_cdna = (
+        full_sequence[:exon_start_in_tx]
+        + full_sequence[exon_start_in_tx + exon_length:]
+    )
+    # Translate from the start codon through the frameshift to first stop.
+    coding_from_start = post_skip_cdna[cds_start_offset:]
+    protein = _translate_to_first_stop(coding_from_start)
+    if not protein:
+        return None
+    # Compute the aa position where the frameshift begins — this is
+    # where the exon used to start, in aa coordinates.
+    aa_frameshift_start = (exon_start_in_tx - cds_start_offset) // 3
+    if aa_frameshift_start >= len(transcript.protein_sequence):
+        return None
+    return _ExonSkipFrameshiftEffect(
+        variant=variant,
+        transcript=transcript,
+        aa_frameshift_start=aa_frameshift_start,
+        protein=protein,
+    )
+
+
+def _translate_to_first_stop(cdna):
+    """Translate a cDNA string to protein, stopping at the first stop
+    codon. Returns the protein string without the stop symbol.
+    """
+    from Bio.Seq import Seq
+    n_codons = len(cdna) // 3
+    truncated = str(cdna[:n_codons * 3])
+    protein = str(Seq(truncated).translate(to_stop=True))
+    return protein
+
+
+class _ExonSkipFrameshiftEffect(MutationEffect):
+    """Internal helper effect representing an exon-skip-induced
+    frameshift. Carries the computed mutant protein sequence but isn't
+    intended as a public effect class — it's wrapped inside the
+    SpliceCandidate.
+    """
+    def __init__(self, variant, transcript, aa_frameshift_start, protein):
+        MutationEffect.__init__(self, variant)
+        self.transcript = transcript
+        self.aa_mutation_start_offset = aa_frameshift_start
+        self.aa_ref = str(
+            transcript.protein_sequence[aa_frameshift_start:])
+        # aa_alt is the new amino acids after the frameshift point.
+        self.aa_alt = protein[aa_frameshift_start:]
+        self.mutant_protein_sequence = protein
+
+    @property
+    def short_description(self):
+        return "p.%s%dfs*%d" % (
+            self.aa_ref[:1] if self.aa_ref else "?",
+            self.aa_mutation_start_offset + 1,
+            len(self.aa_alt),
+        )
 
 
 def _affected_exon(splice_effect):
@@ -441,7 +674,7 @@ def enumerate_splice_outcomes(splice_effect):
         input is a splice-disrupting effect; otherwise the input
         unchanged.
     """
-    table = _PLAUSIBILITY_TABLES.get(type(splice_effect))
+    table = _plausibility_table_for(splice_effect)
     if table is None:
         return splice_effect
 
@@ -478,24 +711,5 @@ def wrap_splice_effects_in_collection(effect_collection):
     return effect_collection.clone_with_new_elements(new_effects)
 
 
-# ---------------------------------------------------------------------
-# Priority integration: SpliceOutcomeSet uses the priority of the
-# disrupted-signal class so existing top_priority_effect logic works.
-# ---------------------------------------------------------------------
-
-
-def splice_outcome_set_priority(effect):
-    """Priority score for a SpliceOutcomeSet, computed from the
-    disrupted-signal class so that existing priority comparisons
-    behave naturally.
-    """
-    if not isinstance(effect, SpliceOutcomeSet):
-        return effect_priority(effect)
-    if effect.disrupted_signal_class is not None:
-        # Construct a placeholder effect of the disrupted class to
-        # look up its priority. effect_priority is keyed on class only.
-        class _PlaceholderEffect(effect.disrupted_signal_class):
-            pass
-        # The dict lookup uses the actual class, so use a stub object
-        return effect_priority(effect)
-    return effect_priority(effect)
+# Priority integration happens via the `priority_class` attribute on
+# SpliceOutcomeSet — see `effect_priority` in effects.effect_ordering.

--- a/varcode/splice_outcomes.py
+++ b/varcode/splice_outcomes.py
@@ -1,0 +1,501 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Multi-effect candidate model for splice-disrupting variants — see
+openvax/varcode#262.
+
+When a variant disrupts a splice signal, the downstream protein
+outcome is not deterministic from DNA alone. Instead of forcing a
+single Effect, this module wraps splice effects in a
+:class:`SpliceOutcomeSet` carrying multiple :class:`SpliceCandidate`
+outcomes with rough plausibility scores.
+
+Limitations of this prototype (documented openly so callers know what
+the scores mean):
+
+* Plausibility values are **hand-tuned heuristics**, not real
+  probabilities. They are derived from rough literature consensus
+  about which outcomes dominate at canonical donor/acceptor positions
+  vs exonic splice sites vs flanking signals. Real scoring requires
+  models like SpliceAI/SpliceTransformer or RNA evidence.
+* :class:`SpliceOutcome.EXON_SKIPPING` and :class:`SpliceOutcome.NORMAL_SPLICING`
+  produce concrete mutant protein sequences using the cDNA already
+  available from PyEnsembl.
+* :class:`SpliceOutcome.INTRON_RETENTION` and the cryptic-splice outcomes
+  produce candidates with a predicted-class label
+  (e.g. "likely PrematureStop") but no exact mutant protein. They
+  require intron / flanking genomic sequence that PyEnsembl does
+  not cache by default. A future PR with genomic-FASTA support
+  would fill these in.
+* This is a **prototype**. Once the foundational
+  :class:`MutantTranscript` abstraction (#271) lands, this code will
+  be re-expressed as a thin layer over it.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from .effects.effect_classes import (
+    Deletion,
+    ExonicSpliceSite,
+    IntronicSpliceSite,
+    MutationEffect,
+    SpliceAcceptor,
+    SpliceDonor,
+)
+from .effects.effect_ordering import effect_priority
+
+
+class SpliceOutcome(Enum):
+    """Possible biological outcome when a splice signal is disrupted."""
+
+    NORMAL_SPLICING = "normal_splicing"
+    """The disruption is partial or leaky; canonical splicing still
+    occurs and the variant's effect is whatever the underlying
+    nucleotide change produces (substitution, frameshift, etc.)."""
+
+    EXON_SKIPPING = "exon_skipping"
+    """The spliceosome can't recognize the disrupted donor/acceptor
+    and skips the entire affected exon. The flanking exons join
+    directly. If the skipped exon is divisible by 3, the result is
+    an in-frame deletion of those amino acids; otherwise a frameshift."""
+
+    INTRON_RETENTION = "intron_retention"
+    """The spliceosome fails entirely; the intron stays in the
+    transcript. Almost always produces a premature stop codon
+    within the intronic sequence."""
+
+    CRYPTIC_DONOR = "cryptic_donor"
+    """A nearby weak GT donor site is used instead of the disrupted
+    canonical one. Truncates or extends the affected exon."""
+
+    CRYPTIC_ACCEPTOR = "cryptic_acceptor"
+    """A nearby weak AG acceptor site is used instead of the
+    disrupted canonical one. Truncates or extends the affected exon."""
+
+
+@dataclass(frozen=True)
+class SpliceCandidate:
+    """One possible outcome of a splice-disrupting variant.
+
+    Plausibility is a rough hand-tuned score, not a probability.
+    Use the relative ordering of candidates rather than the absolute
+    values for downstream filtering.
+    """
+
+    outcome: SpliceOutcome
+    plausibility: float
+    description: str
+    """Human-readable summary of the outcome."""
+
+    coding_effect: Optional[MutationEffect] = None
+    """Concrete coding effect (Substitution, Deletion, FrameShift,
+    PrematureStop, etc.) when computable. None for candidates whose
+    protein math requires intron/flanking sequence we don't have
+    cached (intron retention, cryptic splice)."""
+
+    predicted_class_name: Optional[str] = None
+    """When ``coding_effect`` is None, the predicted Effect class name
+    (e.g. ``'PrematureStop'``) inferred from the outcome and exon
+    properties. Useful for filtering downstream."""
+
+    @property
+    def has_protein(self) -> bool:
+        return self.coding_effect is not None and getattr(
+            self.coding_effect, "mutant_protein_sequence", None
+        ) is not None
+
+    @property
+    def short_description(self) -> str:
+        if self.coding_effect is not None:
+            return "%s (%s, p=%.2f)" % (
+                self.coding_effect.short_description,
+                self.outcome.value,
+                self.plausibility,
+            )
+        return "%s (%s, p=%.2f)" % (
+            self.predicted_class_name or "?",
+            self.outcome.value,
+            self.plausibility,
+        )
+
+
+class SpliceOutcomeSet(MutationEffect):
+    """A splice-disrupting variant's effect, expressed as a set of
+    plausible outcomes rather than a single Effect.
+
+    For back-compat, :attr:`short_description` delegates to the most
+    plausible candidate. Callers that want all candidates iterate
+    :attr:`candidates`.
+
+    Constructed by :func:`enumerate_splice_outcomes` when a caller
+    passes ``splice_outcomes=True`` to ``Variant.effects()`` or
+    ``VariantCollection.effects()``.
+    """
+
+    def __init__(self, variant, transcript, candidates, disrupted_signal_class=None):
+        MutationEffect.__init__(self, variant)
+        self.transcript = transcript
+        # Sort candidates by plausibility descending so .candidates[0]
+        # is always the most likely.
+        self.candidates = tuple(sorted(
+            candidates, key=lambda c: c.plausibility, reverse=True))
+        # Class of the original splice-disrupting effect this set
+        # replaced (SpliceDonor, SpliceAcceptor, ExonicSpliceSite, or
+        # IntronicSpliceSite). Used for priority lookup.
+        self.disrupted_signal_class = disrupted_signal_class
+
+    @property
+    def most_likely(self) -> SpliceCandidate:
+        return self.candidates[0]
+
+    @property
+    def short_description(self) -> str:
+        return "splice-set:%s" % self.most_likely.short_description
+
+    def __str__(self) -> str:
+        return "SpliceOutcomeSet(variant=%s, transcript=%s, candidates=[%s])" % (
+            self.variant,
+            getattr(self.transcript, "name", None),
+            ", ".join(c.short_description for c in self.candidates),
+        )
+
+    def __repr__(self) -> str:
+        return str(self)
+
+
+# ---------------------------------------------------------------------
+# Plausibility tables.
+#
+# Hand-tuned heuristics. The numbers don't need to be precise — what
+# matters is the relative ordering. Documented openly so reviewers and
+# callers know what to expect. See module docstring for the limitation.
+# ---------------------------------------------------------------------
+
+
+# Disrupted canonical donor (intronic +1/+2): exon skipping dominates,
+# intron retention common, leaky normal splicing rare.
+_PLAUSIBILITY_SPLICE_DONOR = {
+    SpliceOutcome.EXON_SKIPPING: 0.50,
+    SpliceOutcome.INTRON_RETENTION: 0.30,
+    SpliceOutcome.CRYPTIC_DONOR: 0.10,
+    SpliceOutcome.NORMAL_SPLICING: 0.10,
+}
+
+# Disrupted canonical acceptor (intronic -1/-2): same rough
+# distribution as donor.
+_PLAUSIBILITY_SPLICE_ACCEPTOR = {
+    SpliceOutcome.EXON_SKIPPING: 0.50,
+    SpliceOutcome.INTRON_RETENTION: 0.30,
+    SpliceOutcome.CRYPTIC_ACCEPTOR: 0.10,
+    SpliceOutcome.NORMAL_SPLICING: 0.10,
+}
+
+# Disrupted exonic splice site (last 3 of exon): often splicing still
+# proceeds (the disruption is in the exon, where the spliceosome can
+# tolerate more variation), so normal splicing is more competitive.
+_PLAUSIBILITY_EXONIC_SPLICE_SITE = {
+    SpliceOutcome.NORMAL_SPLICING: 0.50,
+    SpliceOutcome.EXON_SKIPPING: 0.30,
+    SpliceOutcome.CRYPTIC_DONOR: 0.15,
+    SpliceOutcome.INTRON_RETENTION: 0.05,
+}
+
+# Intronic splice site (positions +3 to +6 or -3): less critical
+# region; normal splicing dominates.
+_PLAUSIBILITY_INTRONIC_SPLICE_SITE = {
+    SpliceOutcome.NORMAL_SPLICING: 0.70,
+    SpliceOutcome.EXON_SKIPPING: 0.20,
+    SpliceOutcome.INTRON_RETENTION: 0.05,
+    SpliceOutcome.CRYPTIC_DONOR: 0.05,
+}
+
+_PLAUSIBILITY_TABLES = {
+    SpliceDonor: _PLAUSIBILITY_SPLICE_DONOR,
+    SpliceAcceptor: _PLAUSIBILITY_SPLICE_ACCEPTOR,
+    ExonicSpliceSite: _PLAUSIBILITY_EXONIC_SPLICE_SITE,
+    IntronicSpliceSite: _PLAUSIBILITY_INTRONIC_SPLICE_SITE,
+}
+
+
+# ---------------------------------------------------------------------
+# Outcome construction
+# ---------------------------------------------------------------------
+
+
+def _build_normal_splicing_candidate(splice_effect, plausibility):
+    """Normal splicing: the underlying coding effect.
+
+    For ExonicSpliceSite this is the .alternate_effect. For other
+    splice classes there is no underlying coding effect (the variant
+    is intronic) — return a candidate with no protein but the same
+    plausibility for completeness.
+    """
+    underlying = getattr(splice_effect, "alternate_effect", None)
+    if underlying is not None:
+        return SpliceCandidate(
+            outcome=SpliceOutcome.NORMAL_SPLICING,
+            plausibility=plausibility,
+            description=(
+                "Disruption is partial or leaky; canonical splicing "
+                "occurs and the underlying coding change applies."),
+            coding_effect=underlying,
+            predicted_class_name=type(underlying).__name__,
+        )
+    return SpliceCandidate(
+        outcome=SpliceOutcome.NORMAL_SPLICING,
+        plausibility=plausibility,
+        description=(
+            "Disruption is partial or leaky; canonical splicing "
+            "occurs. Variant is intronic and has no coding impact "
+            "if splicing proceeds normally."),
+        coding_effect=None,
+        predicted_class_name="Intronic",
+    )
+
+
+def _build_exon_skipping_candidate(splice_effect, plausibility):
+    """Exon skipping: the affected exon is excluded from the transcript.
+
+    Computes the resulting protein by removing the exon's amino acids
+    (in-frame skip) or by triggering a frameshift (out-of-frame skip).
+    Reports the change as a Deletion when in-frame and as a frameshift
+    label otherwise.
+    """
+    transcript = getattr(splice_effect, "transcript", None)
+    exon = _affected_exon(splice_effect)
+    if transcript is None or exon is None:
+        return SpliceCandidate(
+            outcome=SpliceOutcome.EXON_SKIPPING,
+            plausibility=plausibility,
+            description="Affected exon is skipped from the transcript.",
+            coding_effect=None,
+            predicted_class_name="ExonLoss",
+        )
+
+    exon_length = exon.end - exon.start + 1
+    if exon_length % 3 == 0:
+        coding_effect = _build_in_frame_exon_skip_effect(
+            splice_effect.variant, transcript, exon)
+        predicted_class_name = "Deletion"
+        description = (
+            "Exon %s is skipped (in-frame, %d aa removed)." % (
+                getattr(exon, "exon_id", "?"), exon_length // 3))
+    else:
+        coding_effect = None
+        predicted_class_name = "FrameShift"
+        description = (
+            "Exon %s is skipped (out of frame, frameshift in the "
+            "joined transcript)." % getattr(exon, "exon_id", "?"))
+
+    return SpliceCandidate(
+        outcome=SpliceOutcome.EXON_SKIPPING,
+        plausibility=plausibility,
+        description=description,
+        coding_effect=coding_effect,
+        predicted_class_name=predicted_class_name,
+    )
+
+
+def _build_intron_retention_candidate(splice_effect, plausibility):
+    """Intron retention: stub candidate without exact protein.
+
+    Concrete protein computation requires intron genomic sequence
+    that PyEnsembl does not cache by default. We label the predicted
+    class as PrematureStop (the typical outcome) but leave
+    coding_effect None.
+    """
+    return SpliceCandidate(
+        outcome=SpliceOutcome.INTRON_RETENTION,
+        plausibility=plausibility,
+        description=(
+            "Intron is retained in the mature transcript. Almost "
+            "always produces a premature stop codon within the "
+            "intronic sequence; exact mutant protein requires "
+            "intron genomic sequence not cached by PyEnsembl."),
+        coding_effect=None,
+        predicted_class_name="PrematureStop",
+    )
+
+
+def _build_cryptic_splice_candidate(splice_effect, plausibility, outcome):
+    """Cryptic donor/acceptor: stub candidate without exact protein.
+
+    Detecting the cryptic site requires scanning flanking genomic
+    sequence. Stub for now; full implementation requires genomic
+    FASTA support.
+    """
+    direction = "donor" if outcome is SpliceOutcome.CRYPTIC_DONOR else "acceptor"
+    return SpliceCandidate(
+        outcome=outcome,
+        plausibility=plausibility,
+        description=(
+            "A cryptic %s site nearby may be used in place of the "
+            "disrupted canonical signal. Truncates or extends the "
+            "affected exon; exact mutant protein requires flanking "
+            "genomic sequence not cached by PyEnsembl." % direction),
+        coding_effect=None,
+        predicted_class_name="ComplexSubstitution",
+    )
+
+
+# ---------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------
+
+
+def _affected_exon(splice_effect):
+    """Best-effort extraction of the affected exon from a splice effect.
+
+    ExonicSpliceSite carries it directly. SpliceDonor/SpliceAcceptor
+    carry the nearest exon. IntronicSpliceSite likewise.
+    """
+    if hasattr(splice_effect, "exon"):
+        return splice_effect.exon
+    if hasattr(splice_effect, "nearest_exon"):
+        return splice_effect.nearest_exon
+    return None
+
+
+def _build_in_frame_exon_skip_effect(variant, transcript, skipped_exon):
+    """Construct a Deletion effect representing an in-frame exon skip.
+
+    Computes the amino acid range corresponding to the skipped exon
+    and emits a Deletion. Falls back to None if the math doesn't
+    work out (e.g. exon spans the start codon).
+    """
+    if not transcript.complete:
+        return None
+    try:
+        exon_start_in_tx = _exon_start_offset_in_transcript(
+            transcript, skipped_exon)
+    except (StopIteration, ValueError):
+        return None
+    cds_start_offset = min(transcript.start_codon_spliced_offsets)
+    if exon_start_in_tx < cds_start_offset:
+        # Exon overlaps the 5' UTR or start codon; the simple
+        # amino-acid math doesn't apply.
+        return None
+    aa_start = (exon_start_in_tx - cds_start_offset) // 3
+    exon_length = skipped_exon.end - skipped_exon.start + 1
+    n_aa_removed = exon_length // 3
+    aa_end = aa_start + n_aa_removed
+    if aa_end > len(transcript.protein_sequence):
+        return None
+    aa_ref = str(transcript.protein_sequence[aa_start:aa_end])
+    if not aa_ref:
+        return None
+    return Deletion(
+        variant=variant,
+        transcript=transcript,
+        aa_mutation_start_offset=aa_start,
+        aa_ref=aa_ref,
+    )
+
+
+def _exon_start_offset_in_transcript(transcript, exon):
+    """Offset (in transcript coordinates) of the first base of the
+    given exon.
+    """
+    offset = 0
+    for ex in transcript.exons:
+        if ex.exon_id == exon.exon_id:
+            return offset
+        offset += ex.end - ex.start + 1
+    raise ValueError("Exon %s not found in transcript %s" % (
+        exon.exon_id, transcript.transcript_id))
+
+
+# ---------------------------------------------------------------------
+# Public entry point: enumerate outcomes for a splice effect
+# ---------------------------------------------------------------------
+
+
+def enumerate_splice_outcomes(splice_effect):
+    """Wrap a splice-disrupting Effect in a SpliceOutcomeSet.
+
+    Recognized splice effect classes are SpliceDonor, SpliceAcceptor,
+    ExonicSpliceSite, and IntronicSpliceSite. Unrecognized classes
+    pass through unchanged.
+
+    Parameters
+    ----------
+    splice_effect : MutationEffect
+        Output of varcode's existing splice classification.
+
+    Returns
+    -------
+    SpliceOutcomeSet or the original effect
+        SpliceOutcomeSet wrapping the candidate outcomes when the
+        input is a splice-disrupting effect; otherwise the input
+        unchanged.
+    """
+    table = _PLAUSIBILITY_TABLES.get(type(splice_effect))
+    if table is None:
+        return splice_effect
+
+    candidates = []
+    for outcome, plausibility in table.items():
+        if outcome is SpliceOutcome.NORMAL_SPLICING:
+            candidates.append(_build_normal_splicing_candidate(
+                splice_effect, plausibility))
+        elif outcome is SpliceOutcome.EXON_SKIPPING:
+            candidates.append(_build_exon_skipping_candidate(
+                splice_effect, plausibility))
+        elif outcome is SpliceOutcome.INTRON_RETENTION:
+            candidates.append(_build_intron_retention_candidate(
+                splice_effect, plausibility))
+        elif outcome in (
+                SpliceOutcome.CRYPTIC_DONOR,
+                SpliceOutcome.CRYPTIC_ACCEPTOR):
+            candidates.append(_build_cryptic_splice_candidate(
+                splice_effect, plausibility, outcome))
+
+    return SpliceOutcomeSet(
+        variant=splice_effect.variant,
+        transcript=getattr(splice_effect, "transcript", None),
+        candidates=candidates,
+        disrupted_signal_class=type(splice_effect),
+    )
+
+
+def wrap_splice_effects_in_collection(effect_collection):
+    """Apply :func:`enumerate_splice_outcomes` to every splice-related
+    Effect in an EffectCollection. Non-splice effects pass through.
+    """
+    new_effects = [enumerate_splice_outcomes(e) for e in effect_collection]
+    return effect_collection.clone_with_new_elements(new_effects)
+
+
+# ---------------------------------------------------------------------
+# Priority integration: SpliceOutcomeSet uses the priority of the
+# disrupted-signal class so existing top_priority_effect logic works.
+# ---------------------------------------------------------------------
+
+
+def splice_outcome_set_priority(effect):
+    """Priority score for a SpliceOutcomeSet, computed from the
+    disrupted-signal class so that existing priority comparisons
+    behave naturally.
+    """
+    if not isinstance(effect, SpliceOutcomeSet):
+        return effect_priority(effect)
+    if effect.disrupted_signal_class is not None:
+        # Construct a placeholder effect of the disrupted class to
+        # look up its priority. effect_priority is keyed on class only.
+        class _PlaceholderEffect(effect.disrupted_signal_class):
+            pass
+        # The dict lookup uses the actual class, so use a stub object
+        return effect_priority(effect)
+    return effect_priority(effect)

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -443,9 +443,28 @@ class Variant(Serializable):
             if gene.is_protein_coding
         ]
 
-    def effects(self, raise_on_error=True):
+    def effects(self, raise_on_error=True, splice_outcomes=False):
+        """Predict the variant's effects on overlapping transcripts.
+
+        Parameters
+        ----------
+        raise_on_error : bool
+            If True, raise on annotation errors; if False, capture
+            them as Failure effects.
+
+        splice_outcomes : bool
+            If True, splice-disrupting effects are wrapped in a
+            :class:`varcode.splice_outcomes.SpliceOutcomeSet` carrying
+            multiple plausible outcomes (normal splicing, exon
+            skipping, intron retention, cryptic splice). Opt-in;
+            default False preserves existing behaviour. See
+            openvax/varcode#262.
+        """
         return predict_variant_effects(
-            variant=self, raise_on_error=raise_on_error)
+            variant=self,
+            raise_on_error=raise_on_error,
+            splice_outcomes=splice_outcomes,
+        )
 
     def effect_on_transcript(self, transcript):
         return predict_variant_effect_on_transcript(self, transcript)

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -114,7 +114,7 @@ class VariantCollection(Collection):
         kwargs["variants"] = new_elements
         return self.from_dict(kwargs)
 
-    def effects(self, raise_on_error=True):
+    def effects(self, raise_on_error=True, splice_outcomes=False):
         """
         Parameters
         ----------
@@ -123,11 +123,19 @@ class VariantCollection(Collection):
             transcript, should it be raised? This default is True, meaning
             errors result in raised exceptions, otherwise they are only logged.
 
+        splice_outcomes : bool, optional
+            If True, splice-disrupting effects are wrapped in a
+            :class:`varcode.splice_outcomes.SpliceOutcomeSet` carrying
+            multiple plausible outcomes. Opt-in; default False
+            preserves existing behaviour. See openvax/varcode#262.
         """
         return EffectCollection([
             effect
             for variant in self
-            for effect in variant.effects(raise_on_error=raise_on_error)
+            for effect in variant.effects(
+                raise_on_error=raise_on_error,
+                splice_outcomes=splice_outcomes,
+            )
         ])
 
     @memoize


### PR DESCRIPTION
## Summary

Completes the unshipped half of #262 (which I had closed prematurely when 2.0.0 landed — the bug fix and sequence-aware classification shipped, but the actual multi-effect model didn't).

**Opt-in**:

```python
v.effects(splice_outcomes=True)
vc.effects(splice_outcomes=True)
```

Default behaviour is unchanged (`splice_outcomes=False`). When opt-in, splice-disrupting Effects are wrapped in a `SpliceOutcomeSet` carrying multiple plausible outcomes; non-splice effects pass through.

## What a SpliceOutcomeSet looks like

```python
v = Variant("7", 117531115, "G", "A", "GRCh38")     # CFTR donor +1 disruption
target = next(e for e in v.effects(splice_outcomes=True)
              if e.transcript.id == "ENST00000003084")

target.disrupted_signal_class  # SpliceDonor
target.most_likely.outcome     # <SpliceOutcome.EXON_SKIPPING>
target.most_likely.plausibility # 0.50

for c in target.candidates:
    print(c.outcome.value, c.plausibility, c.description, c.predicted_class_name)

# exon_skipping       0.50  ...  Deletion
# intron_retention    0.30  ...  PrematureStop
# cryptic_donor       0.10  ...  ComplexSubstitution
# normal_splicing     0.10  ...  (the coding change if splice still works)
```

## Plausibility scoring

Hand-tuned heuristic tables per disrupted-signal class:

| Disrupted signal | Dominant outcome | Secondary |
|---|---|---|
| Canonical donor (+1/+2) | EXON_SKIPPING (0.50) | INTRON_RETENTION (0.30) |
| Canonical acceptor (-1/-2) | EXON_SKIPPING (0.50) | INTRON_RETENTION (0.30) |
| Exonic splice site (MAG disrupted) | NORMAL_SPLICING (0.50) | EXON_SKIPPING (0.30) |
| Intronic splice site (+3–6 / -3) | NORMAL_SPLICING (0.70) | EXON_SKIPPING (0.20) |

Scores are documented as **heuristics, not probabilities** — module docstring calls this out explicitly. Real scoring requires ML models (SpliceAI) or RNA evidence (#259).

## What gets a real protein vs a stub

| Outcome | Concrete protein? | Reason |
|---|---|---|
| `NORMAL_SPLICING` | ✅ (via existing `alternate_effect`) | Underlying coding change |
| `EXON_SKIPPING` | ✅ in-frame skip → `Deletion` | Computed from cDNA (exon boundaries known) |
| `EXON_SKIPPING` | ⚠️ out-of-frame → label only | Would need frameshifted CDS translation |
| `INTRON_RETENTION` | ⚠️ label only | Needs intron genomic sequence not cached by PyEnsembl |
| `CRYPTIC_DONOR` / `CRYPTIC_ACCEPTOR` | ⚠️ label only | Needs flanking genomic sequence to locate the cryptic site |

Stubs still carry predicted class name (e.g. `"PrematureStop"`) so downstream filtering can still reason about them. A future PR with genomic-FASTA support fills these in with real protein computation.

## Test plan

23 new tests in `tests/test_splice_outcomes.py` covering:
- Back-compat: default behaviour unchanged (2 tests)
- All four disrupted-signal classes get wrapped (4 tests)
- Non-splice effects pass through (1 test)
- Expected outcome sets present for each class (2 tests)
- Plausibility ordering is stable (1 test)
- Most-likely selection per disrupted-signal class (2 tests)
- Per-outcome candidate composition (4 tests)
- EffectCollection integration (2 tests)
- Reverse-strand (1 test)
- `enumerate_splice_outcomes` pass-through semantics (1 test)
- `SpliceCandidate` dataclass ergonomics (frozen, equality) (2 tests)
- Package-level exports (1 test)

All 514 tests pass (was 491), lint clean.

## Explicit prototype status

Module docstring calls this out openly: once #271 (`MutantTranscript` abstraction) lands, the per-outcome transcript construction in this module gets re-expressed as a thin layer over `MutantTranscript.apply(transcript, edits)`. That's fine — the API surface (`splice_outcomes=True` kwarg, `SpliceOutcomeSet` class, `SpliceCandidate` fields) is stable and won't change; only the internal implementation gets swapped.

## Relationship to the broader roadmap

- Closes the "multi-effect candidate model" portion of #262 (tracking issue can stay closed; this builds on what shipped there).
- **Shares possibility-set shape with #259** (RNA evidence) — both describe "one DNA event → multiple plausible outcomes." Once RNA evidence lands, `SpliceCandidate` gains a `.rna_support` field that can narrow the set to observed outcomes.
- **Composes with #268** (germline-aware) — when a germline variant is in the splice window, the patient's pre-somatic splice signal changes; the outcome set is computed against the germline-applied signal. Wiring lives in #285 (Sub-4 of #268).