### PR TITLE
Fix #294, #295, #298: MT codon table, SpliceOutcomeSet serialization, exon-skip boundary reconstruction

### DIFF
--- a/tests/test_mitochondrial.py
+++ b/tests/test_mitochondrial.py
@@ -1,0 +1,235 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for mitochondrial codon table handling (openvax/varcode#294).
+
+Covers the four codon differences between NCBI table 1 (Standard) and
+NCBI table 2 (Vertebrate Mitochondrial):
+
+  * TGA: standard stop -> mt Trp
+  * AGA: standard Arg  -> mt stop
+  * AGG: standard Arg  -> mt stop
+  * ATA: standard Ile  -> mt Met
+
+Also covers the local codon-table data structures (which exist so that
+varcode doesn't need BioPython just to enumerate 64 codons — see #293).
+"""
+
+from pyensembl import cached_release
+
+from varcode import Variant
+from varcode.effects.codon_tables import (
+    STANDARD,
+    VERTEBRATE_MITOCHONDRIAL,
+    codon_table_for_transcript,
+    is_mitochondrial_contig,
+    translate_sequence,
+)
+
+
+ensembl_grch38 = cached_release(81)
+
+# MT-CO1-201: complete protein-coding transcript on MT (+ strand),
+# uses TAA as stop (so pyensembl considers it complete, unlike MT-ND1
+# which stops on AGA). Exon 5904-7445, start codon at 5904-5906.
+MT_CO1_TRANSCRIPT_ID = "ENST00000361624"
+
+
+# ====================================================================
+# Codon-table data structures
+# ====================================================================
+
+
+def test_standard_and_mt_tables_cover_all_64_codons():
+    for table in (STANDARD, VERTEBRATE_MITOCHONDRIAL):
+        seen = set(table.forward_table) | set(table.stop_codons)
+        assert len(seen) == 64, (
+            "Table %s covers %d codons; expected 64" % (table.name, len(seen)))
+
+
+def test_standard_table_stops():
+    assert STANDARD.stop_codons == frozenset({"TAA", "TAG", "TGA"})
+
+
+def test_mt_table_stops():
+    # Key difference: TGA is NOT a stop, AGA/AGG ARE stops.
+    assert VERTEBRATE_MITOCHONDRIAL.stop_codons == frozenset({
+        "TAA", "TAG", "AGA", "AGG",
+    })
+
+
+def test_tga_codes_trp_in_mt():
+    assert STANDARD.forward_table.get("TGA") is None  # it's a stop
+    assert VERTEBRATE_MITOCHONDRIAL.forward_table["TGA"] == "W"
+
+
+def test_aga_agg_are_stops_in_mt():
+    assert STANDARD.forward_table["AGA"] == "R"
+    assert STANDARD.forward_table["AGG"] == "R"
+    assert "AGA" in VERTEBRATE_MITOCHONDRIAL.stop_codons
+    assert "AGG" in VERTEBRATE_MITOCHONDRIAL.stop_codons
+
+
+def test_ata_codes_met_in_mt():
+    assert STANDARD.forward_table["ATA"] == "I"
+    assert VERTEBRATE_MITOCHONDRIAL.forward_table["ATA"] == "M"
+
+
+def test_mt_start_codons():
+    assert VERTEBRATE_MITOCHONDRIAL.start_codons == frozenset({
+        "ATT", "ATC", "ATA", "ATG", "GTG",
+    })
+
+
+def test_standard_start_codons():
+    assert STANDARD.start_codons == frozenset({"TTG", "CTG", "ATG"})
+
+
+# ====================================================================
+# Contig-name detection
+# ====================================================================
+
+
+def test_mitochondrial_contig_detection():
+    for name in ("MT", "chrMT", "chrM", "M", "mt", "chrmt", "mtDNA", "mito"):
+        assert is_mitochondrial_contig(name), (
+            "Expected %r to be recognized as mitochondrial" % name)
+
+
+def test_non_mitochondrial_contigs():
+    for name in ("1", "chr1", "X", "chrX", "Y", None, ""):
+        assert not is_mitochondrial_contig(name)
+
+
+def test_codon_table_for_mt_transcript_is_vertebrate_mt():
+    mt_t = ensembl_grch38.transcript_by_id(MT_CO1_TRANSCRIPT_ID)
+    assert codon_table_for_transcript(mt_t) is VERTEBRATE_MITOCHONDRIAL
+
+
+def test_codon_table_for_nuclear_transcript_is_standard():
+    # CFTR is on chr7
+    nuclear_t = ensembl_grch38.transcript_by_id("ENST00000003084")
+    assert codon_table_for_transcript(nuclear_t) is STANDARD
+
+
+# ====================================================================
+# Sequence translation
+# ====================================================================
+
+
+def test_translate_sequence_standard_tga_stops():
+    # ATG + TGG + TGA stops at TGA under standard
+    assert translate_sequence("ATGTGGTGA") == "MW"
+
+
+def test_translate_sequence_mt_tga_becomes_trp():
+    # Same sequence under mt: TGA -> W, no stop here
+    assert translate_sequence(
+        "ATGTGGTGA", codon_table=VERTEBRATE_MITOCHONDRIAL) == "MWW"
+
+
+def test_translate_sequence_mt_aga_stops():
+    # Under mt, AGA is a stop; standard keeps translating
+    assert translate_sequence(
+        "ATGAGATTT", codon_table=VERTEBRATE_MITOCHONDRIAL) == "M"
+    assert translate_sequence("ATGAGATTT") == "MRF"
+
+
+def test_translate_sequence_to_stop_false_emits_star():
+    assert translate_sequence("ATGTAAGGG", to_stop=False) == "M*G"
+
+
+def test_translate_sequence_rejects_non_multiple_of_three():
+    try:
+        translate_sequence("ATGT")
+    except ValueError:
+        return
+    raise AssertionError("Expected ValueError for non-multiple-of-3 input")
+
+
+# ====================================================================
+# End-to-end variant effect prediction on MT
+# ====================================================================
+
+
+def test_mt_tga_creation_is_substitution_not_premature_stop():
+    """MT-CO1 aa_pos 278 is encoded by TCA (Ser). A C>G at the middle
+    base (genome position 6739) changes it to TGA. Under the standard
+    codon table that would be a PrematureStop; under the correct
+    vertebrate mitochondrial table it's a Ser->Trp substitution.
+    """
+    variant = Variant("MT", 6739, "C", "G", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(MT_CO1_TRANSCRIPT_ID)
+    effect = variant.effect_on_transcript(transcript)
+    assert type(effect).__name__ == "Substitution", (
+        "Expected Substitution, got %s (%s). Under mt codon table, "
+        "TGA is Trp not stop." % (type(effect).__name__, effect.short_description))
+    assert effect.aa_ref == "S"
+    assert effect.aa_alt == "W"
+
+
+def test_mt_aga_creation_is_premature_stop():
+    """MT-CO1 aa_pos 37 is encoded by CGA (Arg in both tables). A
+    C>A at the first base of that codon (genome 6015) makes AGA.
+    Under the standard table, AGA is still Arg (Silent). Under the
+    vertebrate mitochondrial table, AGA is a stop (PrematureStop).
+    """
+    variant = Variant("MT", 6015, "C", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(MT_CO1_TRANSCRIPT_ID)
+    effect = variant.effect_on_transcript(transcript)
+    assert type(effect).__name__ == "PrematureStop", (
+        "Expected PrematureStop, got %s (%s). Under mt codon table, "
+        "AGA is a stop." % (type(effect).__name__, effect.short_description))
+
+
+def test_mt_ata_reference_is_met_not_ile():
+    """MT-CO1 aa_pos 64 is encoded by ATA. Under standard that's Ile;
+    under mt it's Met (matches the Ensembl-provided protein_sequence,
+    which confirms varcode's effect annotation must also use Met).
+
+    Changing ATA to ATT (which is Ile in both tables) is therefore a
+    Met->Ile Substitution under mt, but would look Silent under
+    standard.
+    """
+    transcript = ensembl_grch38.transcript_by_id(MT_CO1_TRANSCRIPT_ID)
+    # Sanity: the reference protein has Met at aa 64.
+    assert transcript.protein_sequence[64] == "M"
+
+    variant = Variant("MT", 6098, "A", "T", ensembl_grch38)
+    effect = variant.effect_on_transcript(transcript)
+    assert type(effect).__name__ == "Substitution", (
+        "Expected Substitution, got %s (%s). Under mt codon table, "
+        "ATA is Met, so ATA->ATT is Met->Ile."
+        % (type(effect).__name__, effect.short_description))
+    assert effect.aa_ref == "M"
+    assert effect.aa_alt == "I"
+
+
+# ====================================================================
+# Back-compat: module-level constants still point at standard table
+# ====================================================================
+
+
+def test_legacy_translate_module_constants_are_standard():
+    from varcode.effects.translate import (
+        DNA_CODON_TABLE,
+        START_CODONS,
+        STOP_CODONS,
+    )
+    # Back-compat: callers that imported these directly still see the
+    # standard (nuclear) table.
+    assert "ATG" in START_CODONS
+    assert "TTG" in START_CODONS  # alternate start in standard
+    assert "ATA" not in START_CODONS  # only in mt
+    assert "TGA" in STOP_CODONS
+    assert "AGA" not in STOP_CODONS  # not a stop in standard
+    assert DNA_CODON_TABLE["AGA"] == "R"

--- a/tests/test_splice_outcomes.py
+++ b/tests/test_splice_outcomes.py
@@ -438,6 +438,97 @@ def test_codon_aligned_exon_skip_still_pure_deletion():
     assert type(skip_candidate.coding_effect).__name__ == "Deletion"
 
 
+# --------------------------------------------------------------------
+# Serialization round-trip (see #295)
+# --------------------------------------------------------------------
+
+
+def test_splice_candidate_round_trip_with_coding_effect():
+    variant = Variant("7", 117531114, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    normal = next(
+        c for c in target.candidates
+        if c.outcome is SpliceOutcome.NORMAL_SPLICING
+    )
+    d = normal.to_dict()
+    rt = SpliceCandidate.from_dict(d)
+    assert rt.outcome is SpliceOutcome.NORMAL_SPLICING
+    assert rt.plausibility == normal.plausibility
+    assert rt.description == normal.description
+    assert type(rt.coding_effect).__name__ == type(normal.coding_effect).__name__
+    assert rt.coding_effect.aa_ref == normal.coding_effect.aa_ref
+
+
+def test_splice_candidate_round_trip_stub():
+    # Intron retention candidate has coding_effect=None but carries a
+    # predicted_class_name.
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    intron = next(
+        c for c in target.candidates
+        if c.outcome is SpliceOutcome.INTRON_RETENTION
+    )
+    d = intron.to_dict()
+    rt = SpliceCandidate.from_dict(d)
+    assert rt.outcome is SpliceOutcome.INTRON_RETENTION
+    assert rt.coding_effect is None
+    assert rt.predicted_class_name == "PrematureStop"
+
+
+def test_splice_outcome_set_json_round_trip():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+
+    payload = target.to_json()
+    restored = SpliceOutcomeSet.from_json(payload)
+
+    assert type(restored) is SpliceOutcomeSet
+    assert len(restored.candidates) == len(target.candidates)
+    assert restored.disrupted_signal_class is target.disrupted_signal_class
+    assert restored.most_likely.outcome is target.most_likely.outcome
+    # Pairwise candidate comparison — tuple equality via __eq__ on the
+    # frozen dataclass + the underlying effect's structural equality.
+    for rt_c, og_c in zip(restored.candidates, target.candidates):
+        assert rt_c.outcome is og_c.outcome
+        assert rt_c.plausibility == og_c.plausibility
+        assert rt_c.predicted_class_name == og_c.predicted_class_name
+        assert (rt_c.coding_effect is None) == (og_c.coding_effect is None)
+        if rt_c.coding_effect is not None:
+            assert type(rt_c.coding_effect) is type(og_c.coding_effect)
+
+
+def test_splice_outcome_set_dict_round_trip_is_idempotent():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+
+    d = target.to_dict()
+    restored = SpliceOutcomeSet.from_dict(d)
+    # Serializable's to_dict is stable across round-trip — the restored
+    # object's to_dict should match the original's.
+    assert restored.to_dict() == d
+
+
+def test_splice_outcome_set_round_trip_preserves_priority_class():
+    # priority_class is a property derived from disrupted_signal_class,
+    # so round-trip correctness depends on the class being rehydrated
+    # to a class object (not a bare string).
+    from varcode.effects import effect_priority
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    target = next(e for e in effects if e.transcript is transcript)
+    restored = SpliceOutcomeSet.from_json(target.to_json())
+    assert effect_priority(restored) == effect_priority(target)
+
+
 def test_non_splice_effects_are_not_multi_outcome():
     # Guard against future class-hierarchy rearrangements that might
     # accidentally mark deterministic effects as multi-outcome.

--- a/tests/test_splice_outcomes.py
+++ b/tests/test_splice_outcomes.py
@@ -382,6 +382,62 @@ def test_multi_outcome_effect_exported_at_package_level():
     assert issubclass(SpliceOutcomeSet, MultiOutcomeEffect)
 
 
+# --------------------------------------------------------------------
+# Boundary-codon reconstruction when in-frame exon skip starts
+# mid-codon (see #298). CFTR exon 6 (cDNA 875-1000, length 126) is
+# in-frame but starts at codon phase 2, so the preceding exon
+# contributes 2 bases to the boundary codon. Skipping it reshapes
+# that codon from two flanking-exon bases.
+# --------------------------------------------------------------------
+
+
+def test_mid_codon_in_frame_exon_skip_reshapes_boundary():
+    # Donor +1 disruption at CFTR exon 6's 3' end.
+    variant = Variant("7", 117536674, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    bare = variant.effect_on_transcript(transcript)
+    if not isinstance(bare, SpliceDonor):
+        pytest.skip(
+            "Canonical donor G not present at 117536674; "
+            "classifier emitted %s." % type(bare).__name__)
+    effects = variant.effects(splice_outcomes=True)
+    splice_set = next(e for e in effects if e.transcript is transcript)
+    skip_candidate = next(
+        c for c in splice_set.candidates
+        if c.outcome is SpliceOutcome.EXON_SKIPPING
+    )
+    # Pre-#298, this returned a plain Deletion with an aa_ref that
+    # didn't account for the reshaped boundary codon. Post-#298, the
+    # effect is a Deletion / Substitution / ComplexSubstitution
+    # depending on what the reshaped codon translates to.
+    assert skip_candidate.coding_effect is not None, (
+        "Expected a concrete coding_effect for mid-codon in-frame skip, "
+        "got stub with predicted_class_name=%s"
+        % skip_candidate.predicted_class_name)
+    effect_class = type(skip_candidate.coding_effect).__name__
+    assert effect_class in ("Deletion", "Substitution", "ComplexSubstitution"), (
+        "Expected Deletion/Substitution/ComplexSubstitution, got %s"
+        % effect_class)
+    # Whichever class it is, the predicted_class_name label matches.
+    assert skip_candidate.predicted_class_name == effect_class
+
+
+def test_codon_aligned_exon_skip_still_pure_deletion():
+    # CFTR exon 3 (cDNA 405-620, length 216) starts AND ends at codon
+    # boundaries (phase 0, in-frame). No boundary reshaping needed;
+    # result should stay a pure Deletion.
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effects = variant.effects(splice_outcomes=True)
+    splice_set = next(e for e in effects if e.transcript is transcript)
+    skip_candidate = next(
+        c for c in splice_set.candidates
+        if c.outcome is SpliceOutcome.EXON_SKIPPING
+    )
+    # CFTR exon 3 is codon-aligned, so we expect a clean Deletion.
+    assert type(skip_candidate.coding_effect).__name__ == "Deletion"
+
+
 def test_non_splice_effects_are_not_multi_outcome():
     # Guard against future class-hierarchy rearrangements that might
     # accidentally mark deterministic effects as multi-outcome.

--- a/varcode/effects/codon_tables.py
+++ b/varcode/effects/codon_tables.py
@@ -1,0 +1,154 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Codon translation tables as simple dict/frozenset lookups.
+
+Built by hand from NCBI Translation Tables 1 (Standard) and 2
+(Vertebrate Mitochondrial). Keeps codon translation inside varcode so
+that downstream callers don't need BioPython just to enumerate 64
+codons. See openvax/varcode#293 for the broader move to drop the
+biopython dependency.
+
+Refs:
+  https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi?mode=t#SG1
+  https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi?mode=t#SG2
+"""
+
+from dataclasses import dataclass
+
+_BASES = "TCAG"
+_CODONS = tuple(b1 + b2 + b3 for b1 in _BASES for b2 in _BASES for b3 in _BASES)
+
+# AA strings are in NCBI codon order (base1 = T,T,...,G ; base2 cycles
+# T,C,A,G within each base1 ; base3 cycles T,C,A,G within each base2).
+# So zip(_CODONS, _AA_STRING) gives the forward mapping.
+
+_STANDARD_AAS = \
+    "FFLLSSSSYY**CC*WLLLLPPPPHHQQRRRRIIIMTTTTNNKKSSRRVVVVAAAADDEEGGGG"
+
+# Vertebrate mitochondrial (table 2) differs from standard at four codons:
+#   TGA: * -> W (Trp)
+#   ATA: I -> M (Met)
+#   AGA: R -> * (stop)
+#   AGG: R -> * (stop)
+_VERT_MT_AAS = \
+    "FFLLSSSSYY**CCWWLLLLPPPPHHQQRRRRIIMMTTTTNNKKSS**VVVVAAAADDEEGGGG"
+
+
+def _build_forward_table(aa_string):
+    return {codon: aa for codon, aa in zip(_CODONS, aa_string) if aa != "*"}
+
+
+def _build_stop_codons(aa_string):
+    return frozenset(codon for codon, aa in zip(_CODONS, aa_string) if aa == "*")
+
+
+@dataclass(frozen=True)
+class CodonTable:
+    """Codon table with amino acid lookup + start/stop sets.
+
+    ``forward_table`` maps sense codons to single-letter AAs; stop
+    codons are omitted (consult ``stop_codons`` for those). Matches
+    the BioPython ``CodonTable.unambiguous_dna_by_id[n]`` shape so
+    callers can be ported in-place.
+    """
+    name: str
+    ncbi_id: int
+    forward_table: dict
+    start_codons: frozenset
+    stop_codons: frozenset
+
+
+STANDARD = CodonTable(
+    name="Standard",
+    ncbi_id=1,
+    forward_table=_build_forward_table(_STANDARD_AAS),
+    start_codons=frozenset({"TTG", "CTG", "ATG"}),
+    stop_codons=_build_stop_codons(_STANDARD_AAS),
+)
+
+VERTEBRATE_MITOCHONDRIAL = CodonTable(
+    name="Vertebrate Mitochondrial",
+    ncbi_id=2,
+    forward_table=_build_forward_table(_VERT_MT_AAS),
+    start_codons=frozenset({"ATT", "ATC", "ATA", "ATG", "GTG"}),
+    stop_codons=_build_stop_codons(_VERT_MT_AAS),
+)
+
+
+# Names commonly used for the mitochondrial contig across genome builds
+# and VCF dialects: Ensembl "MT", UCSC "chrM", occasionally "chrMT" or
+# "M". Lowercased for case-insensitive matching.
+_MITOCHONDRIAL_CONTIG_NAMES = frozenset({
+    "mt", "chrmt", "m", "chrm", "mtdna", "mito",
+})
+
+
+def is_mitochondrial_contig(contig):
+    """True if the given contig name refers to a mitochondrial sequence."""
+    if contig is None:
+        return False
+    return str(contig).lower() in _MITOCHONDRIAL_CONTIG_NAMES
+
+
+def codon_table_for_transcript(transcript):
+    """Select the codon table for a transcript based on its contig.
+
+    Vertebrate mitochondrial genes use NCBI translation table 2;
+    every other transcript uses the standard table.
+    """
+    if transcript is None:
+        return STANDARD
+    contig = getattr(transcript, "contig", None)
+    if is_mitochondrial_contig(contig):
+        return VERTEBRATE_MITOCHONDRIAL
+    return STANDARD
+
+
+def translate_sequence(
+        nucleotide_sequence,
+        codon_table=STANDARD,
+        to_stop=True):
+    """Translate a cDNA string to amino acids using ``codon_table``.
+
+    Parameters
+    ----------
+    nucleotide_sequence : str or convertible-to-str
+        cDNA. Length must be a multiple of 3.
+    codon_table : CodonTable
+        Defaults to the standard table.
+    to_stop : bool
+        If True (default), stop translation at the first stop codon and
+        return the protein up to (but not including) the stop. If False,
+        include ``'*'`` characters for in-sequence stops.
+    """
+    seq = str(nucleotide_sequence).upper()
+    if len(seq) % 3 != 0:
+        raise ValueError(
+            "Expected nucleotide sequence length to be a multiple of 3, "
+            "got %d (sequence=%r...)" % (len(seq), seq[:30]))
+    forward = codon_table.forward_table
+    stops = codon_table.stop_codons
+    result = []
+    for i in range(0, len(seq), 3):
+        codon = seq[i:i + 3]
+        if codon in stops:
+            if to_stop:
+                break
+            result.append("*")
+            continue
+        aa = forward.get(codon)
+        if aa is None:
+            raise ValueError(
+                "Unknown codon %r at position %d of sequence" % (codon, i))
+        result.append(aa)
+    return "".join(result)

--- a/varcode/effects/effect_prediction_coding_frameshift.py
+++ b/varcode/effects/effect_prediction_coding_frameshift.py
@@ -24,6 +24,7 @@ from .effect_classes import (
     StopLoss,
     Silent
 )
+from .codon_tables import codon_table_for_transcript
 from .mutate import substitute
 from .translate import translate
 
@@ -62,7 +63,8 @@ def create_frameshift_effect(
         nucleotide_sequence=sequence_from_mutated_codon,
         first_codon_is_start=False,
         to_stop=True,
-        truncate=True)
+        truncate=True,
+        codon_table=codon_table_for_transcript(transcript))
 
     if mutated_codon_index == 0:
         # TODO: scan through sequence_from_mutated_codon for

--- a/varcode/effects/effect_prediction_coding_in_frame.py
+++ b/varcode/effects/effect_prediction_coding_in_frame.py
@@ -27,7 +27,8 @@ from .effect_classes import (
     StartLoss,
     StopLoss,
 )
-from .translate import translate_in_frame_mutation, START_CODONS
+from .codon_tables import codon_table_for_transcript
+from .translate import translate_in_frame_mutation
 
 
 def get_codons(
@@ -145,8 +146,9 @@ def predict_in_frame_coding_effect(
         cds_offset=cds_offset)
 
     mutation_affects_start_codon = (ref_codon_start_offset == 0)
+    codon_table = codon_table_for_transcript(transcript)
 
-    if mutation_affects_start_codon and mutant_codons[:3] not in START_CODONS:
+    if mutation_affects_start_codon and mutant_codons[:3] not in codon_table.start_codons:
         # if we changed a start codon to something else then
         # we no longer know where the protein begins (or even in
         # what frame).

--- a/varcode/effects/translate.py
+++ b/varcode/effects/translate.py
@@ -12,86 +12,96 @@
 
 """Helpers for cDNA -> protein translation.
 
-TODO: generalize this to work with the mitochondrial codon table.
+Codon tables live in :mod:`varcode.effects.codon_tables` as plain
+Python dicts/frozensets — no BioPython dependency for codon lookup.
+Mitochondrial transcripts are routed to NCBI translation table 2 via
+:func:`codon_table_for_transcript`; everything else uses table 1.
 """
 
-from Bio.Data import CodonTable
-from Bio.Seq import Seq
+from .codon_tables import (
+    STANDARD,
+    codon_table_for_transcript,
+    translate_sequence,
+)
 
-DNA_CODON_TABLE = CodonTable.standard_dna_table.forward_table
-START_CODONS = set(CodonTable.standard_dna_table.start_codons)
-STOP_CODONS = set(CodonTable.standard_dna_table.stop_codons)
+# Back-compat module-level constants — callers that imported these
+# names directly still get the standard (nuclear) table. Code paths
+# that need mitochondrial handling look up the per-transcript table
+# through codon_table_for_transcript().
+DNA_CODON_TABLE = STANDARD.forward_table
+START_CODONS = STANDARD.start_codons
+STOP_CODONS = STANDARD.stop_codons
 
 
-def translate_codon(codon, aa_pos):
-    """Translate a single codon into a single amino acid or stop '*'
+def translate_codon(codon, aa_pos, codon_table=STANDARD):
+    """Translate a single codon into a single amino acid or stop '*'.
 
     Parameters
     ----------
     codon : str
-        Expected to be of length 3
+        Expected to be of length 3.
     aa_pos : int
-        Codon/amino acid offset into the protein (starting from 0)
+        Codon/amino acid offset into the protein (starting from 0).
+    codon_table : CodonTable
+        Defaults to the standard nuclear table. Pass
+        :data:`VERTEBRATE_MITOCHONDRIAL` for mt transcripts.
     """
     # not handling rare Leucine or Valine starts!
-    if aa_pos == 0 and codon in START_CODONS:
+    if aa_pos == 0 and codon in codon_table.start_codons:
         return "M"
-    elif codon in STOP_CODONS:
+    elif codon in codon_table.stop_codons:
         return "*"
     else:
-        return DNA_CODON_TABLE[codon]
+        return codon_table.forward_table[codon]
 
 
 def translate(
         nucleotide_sequence,
         first_codon_is_start=True,
         to_stop=True,
-        truncate=False):
-    """Translates cDNA coding sequence into amino acid protein sequence.
-
-    Should typically start with a start codon but allowing non-methionine
-    first residues since the CDS we're translating might have been affected
-    by a start loss mutation.
-
-    The sequence may include the 3' UTR but will stop translation at the first
-    encountered stop codon.
+        truncate=False,
+        codon_table=STANDARD):
+    """Translate a cDNA coding sequence into an amino acid string.
 
     Parameters
     ----------
-    nucleotide_sequence : BioPython Seq
-        cDNA sequence
-
+    nucleotide_sequence : str or convertible-to-str
+        cDNA sequence.
     first_codon_is_start : bool
-        Treat the beginning of nucleotide_sequence (translates methionin)
-
+        Treat the first codon as a start codon (translates to 'M' even
+        when the codon is a non-ATG alternate start like TTG/GTG).
+    to_stop : bool
+        Stop translation at the first stop codon.
     truncate : bool
-        Truncate sequence if it's not a multiple of 3 (default = False)
-    Returns BioPython Seq of amino acids
-    """
-    if not isinstance(nucleotide_sequence, Seq):
-        nucleotide_sequence = Seq(nucleotide_sequence)
+        Truncate the sequence to a multiple of 3 before translating.
+    codon_table : CodonTable
+        Defaults to standard. For mt transcripts pass the vertebrate
+        mitochondrial table.
 
+    Returns
+    -------
+    str
+        Amino acid sequence (previously returned a ``Bio.Seq.Seq``;
+        now a plain string — all in-repo callers already use string
+        semantics).
+    """
+    seq = str(nucleotide_sequence)
     if truncate:
-        # if sequence isn't a multiple of 3, truncate it so BioPython
-        # doesn't complain
-        n_nucleotides = int(len(nucleotide_sequence) / 3) * 3
-        nucleotide_sequence = nucleotide_sequence[:n_nucleotides]
+        n_nucleotides = (len(seq) // 3) * 3
+        seq = seq[:n_nucleotides]
     else:
-        n_nucleotides = len(nucleotide_sequence)
+        n_nucleotides = len(seq)
 
     assert n_nucleotides % 3 == 0, \
         ("Expected nucleotide sequence to be multiple of 3"
-         " but got %s of length %d") % (
-            nucleotide_sequence,
-            n_nucleotides)
+         " but got %s of length %d") % (seq[:30], n_nucleotides)
 
-    # passing cds=False to translate since we may want to deal with premature
-    # stop codons
-    protein_sequence = nucleotide_sequence.translate(to_stop=to_stop, cds=False)
+    protein_sequence = translate_sequence(
+        seq, codon_table=codon_table, to_stop=to_stop)
 
     if first_codon_is_start and (
             len(protein_sequence) == 0 or protein_sequence[0] != "M"):
-        if nucleotide_sequence[:3] in START_CODONS:
+        if seq[:3].upper() in codon_table.start_codons:
             # TODO: figure out when these should be made into methionines
             # and when left as whatever amino acid they normally code for
             # e.g. Leucine start codons
@@ -102,21 +112,25 @@ def translate(
                 ("Expected first codon of %s to be start codon"
                  " (one of %s) but got %s") % (
                     protein_sequence[:10],
-                    START_CODONS,
-                    nucleotide_sequence))
+                    sorted(codon_table.start_codons),
+                    seq[:30]))
 
     return protein_sequence
 
 
-def find_first_stop_codon(nucleotide_sequence):
+def find_first_stop_codon(nucleotide_sequence, codon_table=STANDARD):
     """
     Given a sequence of codons (expected to have length multiple of three),
-    return index of first stop codon, or -1 if none is in the sequence.
+    return the codon offset of the first stop codon, or -1 if none is in
+    the sequence. The meaning of "stop" depends on ``codon_table`` — in
+    the vertebrate mitochondrial table, AGA and AGG are stops.
     """
-    n_mutant_codons = len(nucleotide_sequence) // 3
+    seq = str(nucleotide_sequence).upper()
+    n_mutant_codons = len(seq) // 3
+    stops = codon_table.stop_codons
     for i in range(n_mutant_codons):
-        codon = nucleotide_sequence[3 * i:3 * i + 3]
-        if codon in STOP_CODONS:
+        codon = seq[3 * i:3 * i + 3]
+        if codon in stops:
             return i
     return -1
 
@@ -131,6 +145,11 @@ def translate_in_frame_mutation(
         - mutant amino acid sequence
         - offset of first stop codon in the mutant sequence (or -1 if there was none)
         - boolean flag indicating whether any codons from the 3' UTR were used
+
+    The codon table is selected automatically from the transcript's
+    contig — mitochondrial transcripts use NCBI table 2 (AGA/AGG as
+    stops, TGA as Trp, ATA as Met); everything else uses the standard
+    table.
 
     Parameters
     ----------
@@ -149,7 +168,10 @@ def translate_in_frame_mutation(
         Nucleotide sequence to replace the reference codons with
         (expected to have length that is a multiple of three)
     """
-    mutant_stop_codon_index = find_first_stop_codon(mutant_codons)
+    codon_table = codon_table_for_transcript(transcript)
+
+    mutant_stop_codon_index = find_first_stop_codon(
+        mutant_codons, codon_table=codon_table)
 
     using_three_prime_utr = False
 
@@ -166,7 +188,8 @@ def translate_in_frame_mutation(
 
         # note the offset of the first stop codon in the combined
         # nucleotide sequence of both the end of the CDS and the 3' UTR
-        first_utr_stop_codon_index = find_first_stop_codon(truncated_utr_sequence)
+        first_utr_stop_codon_index = find_first_stop_codon(
+            truncated_utr_sequence, codon_table=codon_table)
 
         if first_utr_stop_codon_index >= 0:
             # if there is a stop codon in the 3' UTR sequence (including the
@@ -186,6 +209,7 @@ def translate_in_frame_mutation(
 
     amino_acids = translate(
         mutant_codons,
-        first_codon_is_start=(ref_codon_start_offset == 0))
+        first_codon_is_start=(ref_codon_start_offset == 0),
+        codon_table=codon_table)
 
     return amino_acids, mutant_stop_codon_index, using_three_prime_utr

--- a/varcode/splice_outcomes.py
+++ b/varcode/splice_outcomes.py
@@ -135,6 +135,43 @@ class SpliceCandidate:
             self.plausibility,
         )
 
+    def to_dict(self):
+        """JSON-friendly dict for persistence and round-trip (see #295).
+
+        ``outcome`` is encoded as its enum value (string); the optional
+        ``coding_effect`` is nested via its own Serializable ``to_dict``
+        and tagged with ``__effect_class__`` (a bare effect class name
+        the registry knows how to resolve; using ``__class__`` would
+        collide with the ``python-serializable`` polymorphic-dispatch
+        key).
+        """
+        coding = None
+        if self.coding_effect is not None:
+            coding = self.coding_effect.to_dict()
+            coding["__effect_class__"] = type(self.coding_effect).__name__
+        return {
+            "outcome": self.outcome.value,
+            "plausibility": self.plausibility,
+            "description": self.description,
+            "coding_effect": coding,
+            "predicted_class_name": self.predicted_class_name,
+        }
+
+    @classmethod
+    def from_dict(cls, state):
+        """Rehydrate from the dict produced by :meth:`to_dict`."""
+        coding_effect = None
+        coding_state = state.get("coding_effect")
+        if coding_state is not None:
+            coding_effect = _rehydrate_coding_effect(coding_state)
+        return cls(
+            outcome=SpliceOutcome(state["outcome"]),
+            plausibility=state["plausibility"],
+            description=state["description"],
+            coding_effect=coding_effect,
+            predicted_class_name=state.get("predicted_class_name"),
+        )
+
 
 class SpliceOutcomeSet(MultiOutcomeEffect):
     """A splice-disrupting variant's effect, expressed as a set of
@@ -165,6 +202,39 @@ class SpliceOutcomeSet(MultiOutcomeEffect):
         # replaced (SpliceDonor, SpliceAcceptor, ExonicSpliceSite, or
         # IntronicSpliceSite). Used for priority lookup.
         self.disrupted_signal_class = disrupted_signal_class
+
+    def to_dict(self):
+        """JSON-friendly dict for persistence and round-trip (see #295).
+
+        ``candidates`` serialize as a list of :class:`SpliceCandidate`
+        dicts. ``disrupted_signal_class`` encodes as a bare class name
+        string that :meth:`_reconstruct_nested_objects` resolves back
+        to the class object via the splice-class registry.
+        """
+        return {
+            "variant": self.variant,
+            "transcript": self.transcript,
+            "candidates": [c.to_dict() for c in self.candidates],
+            "disrupted_signal_class": (
+                self.disrupted_signal_class.__name__
+                if self.disrupted_signal_class is not None
+                else None),
+        }
+
+    @classmethod
+    def _reconstruct_nested_objects(cls, state_dict):
+        """Rehydrate candidates and disrupted_signal_class before
+        :meth:`Serializable.from_dict` expands kwargs.
+        """
+        state_dict = dict(state_dict)
+        if "candidates" in state_dict:
+            state_dict["candidates"] = tuple(
+                SpliceCandidate.from_dict(c) for c in state_dict["candidates"])
+        if "disrupted_signal_class" in state_dict:
+            name = state_dict["disrupted_signal_class"]
+            state_dict["disrupted_signal_class"] = (
+                _SPLICE_SIGNAL_CLASS_REGISTRY.get(name) if name else None)
+        return state_dict
 
     @property
     def priority_class(self):
@@ -832,3 +902,88 @@ def wrap_splice_effects_in_collection(effect_collection):
 
 # Priority integration happens via the `priority_class` attribute on
 # SpliceOutcomeSet — see `effect_priority` in effects.effect_ordering.
+
+
+# ---------------------------------------------------------------------
+# Serialization helpers (see #295).
+#
+# to_dict on SpliceCandidate / SpliceOutcomeSet encodes the enum as
+# its string value, the coding_effect via its own Serializable
+# to_dict (tagged with __class__ name), and disrupted_signal_class
+# as a bare class name. Rehydration looks class names up in these
+# registries and calls from_dict on the resolved class.
+# ---------------------------------------------------------------------
+
+
+# Eagerly-populated registry of effect classes we might encounter as
+# the coding_effect of a SpliceCandidate. Built lazily on first use to
+# avoid import-time cycles with effect_classes.
+_CODING_EFFECT_CLASS_REGISTRY = None
+
+
+def _coding_effect_class_registry():
+    global _CODING_EFFECT_CLASS_REGISTRY
+    if _CODING_EFFECT_CLASS_REGISTRY is None:
+        from .effects import effect_classes as ec
+        _CODING_EFFECT_CLASS_REGISTRY = {
+            cls.__name__: cls
+            for cls in (
+                ec.Substitution,
+                ec.Silent,
+                ec.Insertion,
+                ec.Deletion,
+                ec.ComplexSubstitution,
+                ec.AlternateStartCodon,
+                ec.FrameShift,
+                ec.FrameShiftTruncation,
+                ec.PrematureStop,
+                ec.StartLoss,
+                ec.StopLoss,
+                ec.ExonLoss,
+                ec.IntronicSpliceSite,
+                ec.ExonicSpliceSite,
+                ec.SpliceDonor,
+                ec.SpliceAcceptor,
+                ec.Intronic,
+                ec.FivePrimeUTR,
+                ec.ThreePrimeUTR,
+                ec.NoncodingTranscript,
+                ec.IncompleteTranscript,
+                ec.Intragenic,
+                ec.Intergenic,
+            )
+        }
+    return _CODING_EFFECT_CLASS_REGISTRY
+
+
+_SPLICE_SIGNAL_CLASS_REGISTRY = {
+    "SpliceDonor": SpliceDonor,
+    "SpliceAcceptor": SpliceAcceptor,
+    "ExonicSpliceSite": ExonicSpliceSite,
+    "IntronicSpliceSite": IntronicSpliceSite,
+}
+
+
+def _rehydrate_coding_effect(state):
+    """Resolve a coding-effect dict (with ``__effect_class__`` tag) to a
+    concrete instance. ``_ExonSkipFrameshiftEffect`` (the internal
+    shim from out-of-frame exon skip math) is handled separately
+    since it isn't in the public effect-class registry.
+    """
+    state = dict(state)
+    class_name = state.pop("__effect_class__", None)
+    if class_name == "_ExonSkipFrameshiftEffect":
+        # Internal shim — reconstruct minimally via its __init__.
+        return _ExonSkipFrameshiftEffect(
+            variant=state["variant"],
+            transcript=state["transcript"],
+            aa_frameshift_start=state["aa_mutation_start_offset"],
+            protein=state["mutant_protein_sequence"],
+        )
+    registry = _coding_effect_class_registry()
+    effect_cls = registry.get(class_name)
+    if effect_cls is None:
+        raise ValueError(
+            "Unknown coding_effect class %r when rehydrating "
+            "SpliceCandidate" % class_name)
+    return effect_cls.from_dict(state)

--- a/varcode/splice_outcomes.py
+++ b/varcode/splice_outcomes.py
@@ -48,6 +48,7 @@ from typing import Optional
 
 from .effects.codon_tables import codon_table_for_transcript, translate_sequence
 from .effects.effect_classes import (
+    ComplexSubstitution,
     Deletion,
     ExonicSpliceSite,
     IntronicSpliceSite,
@@ -56,7 +57,9 @@ from .effects.effect_classes import (
     SpliceAcceptor,
     SpliceDonor,
     StartLoss,
+    Substitution,
 )
+from .string_helpers import trim_shared_flanking_strings
 
 
 class SpliceOutcome(Enum):
@@ -407,7 +410,14 @@ def _build_exon_skipping_candidate(splice_effect, plausibility):
     elif exon_length % 3 == 0:
         coding_effect = _build_in_frame_exon_skip_effect(
             splice_effect.variant, transcript, exon)
-        predicted_class_name = "Deletion"
+        # The in-frame-skip helper now returns Deletion, Substitution,
+        # or ComplexSubstitution depending on whether the skip touches
+        # a codon-straddling boundary (see #298). Derive the label
+        # from the actual effect class when available.
+        predicted_class_name = (
+            type(coding_effect).__name__
+            if coding_effect is not None
+            else "Deletion")
         description = (
             "Exon %s is skipped (in-frame, %d aa removed)." % (
                 getattr(exon, "exon_id", "?"), exon_length // 3))
@@ -616,11 +626,23 @@ def _affected_exon(splice_effect):
 
 
 def _build_in_frame_exon_skip_effect(variant, transcript, skipped_exon):
-    """Construct a Deletion effect representing an in-frame exon skip.
+    """Construct the coding effect of an in-frame exon skip.
 
-    Computes the amino acid range corresponding to the skipped exon
-    and emits a Deletion. Falls back to None if the math doesn't
-    work out (e.g. exon spans the start codon).
+    When the skipped exon's first base sits at a codon boundary, the
+    skip is a clean :class:`Deletion` of ``exon_length / 3`` amino
+    acids. When the exon starts mid-codon (phase 1 or 2), the boundary
+    codon is reshaped from flanking bases of the preceding and
+    following exons — so the skip touches ``exon_length / 3 + 1``
+    original codons and replaces them with one new codon. Depending
+    on whether that new codon's amino acid matches either flanking
+    residue, the effect is :class:`Deletion`, :class:`Substitution`,
+    or :class:`ComplexSubstitution` — we compute each candidate and
+    let :func:`trim_shared_flanking_strings` collapse it to the
+    minimal edit. See openvax/varcode#298.
+
+    Returns ``None`` when the math can't be completed (e.g. the
+    skipped exon overlaps the 5' UTR or extends past the reference
+    protein's end).
     """
     if not transcript.complete:
         return None
@@ -634,20 +656,103 @@ def _build_in_frame_exon_skip_effect(variant, transcript, skipped_exon):
         # Exon overlaps the 5' UTR or start codon; the simple
         # amino-acid math doesn't apply.
         return None
+
     aa_start = (exon_start_in_tx - cds_start_offset) // 3
+    cds_offset_in_exon = (exon_start_in_tx - cds_start_offset) % 3
     exon_length = skipped_exon.end - skipped_exon.start + 1
-    n_aa_removed = exon_length // 3
-    aa_end = aa_start + n_aa_removed
+
+    if cds_offset_in_exon == 0:
+        # Codon-aligned skip: exon_length / 3 codons are cleanly
+        # removed with no boundary reshaping.
+        n_aa_removed = exon_length // 3
+        aa_end = aa_start + n_aa_removed
+        if aa_end > len(transcript.protein_sequence):
+            return None
+        aa_ref = str(transcript.protein_sequence[aa_start:aa_end])
+        if not aa_ref:
+            return None
+        return Deletion(
+            variant=variant,
+            transcript=transcript,
+            aa_mutation_start_offset=aa_start,
+            aa_ref=aa_ref,
+        )
+
+    # Mid-codon skip: exon starts at phase 1 or 2 of codon aa_start.
+    # The original codons touched are aa_start through aa_start + n,
+    # where n = exon_length / 3 (the two boundary codons plus the
+    # fully-internal ones; n + 1 codons total). After skipping, those
+    # n+1 codons are replaced by ONE reshaped codon composed of the
+    # preceding exon's trailing bases plus the following exon's
+    # leading bases.
+    n_aa_touched = exon_length // 3 + 1
+    aa_end = aa_start + n_aa_touched
     if aa_end > len(transcript.protein_sequence):
         return None
+
     aa_ref = str(transcript.protein_sequence[aa_start:aa_end])
     if not aa_ref:
         return None
-    return Deletion(
+
+    full_sequence = str(transcript.sequence)
+    pre_bases = cds_offset_in_exon                # 1 or 2
+    post_bases = 3 - cds_offset_in_exon           # 2 or 1
+    boundary_codon_start = exon_start_in_tx - pre_bases
+    post_exon_offset = exon_start_in_tx + exon_length
+    if (boundary_codon_start < 0
+            or post_exon_offset + post_bases > len(full_sequence)):
+        # Not enough flanking sequence to reconstruct the boundary
+        # codon (e.g. skipping the terminal exon).
+        return None
+    new_codon = (
+        full_sequence[boundary_codon_start:exon_start_in_tx]
+        + full_sequence[post_exon_offset:post_exon_offset + post_bases]
+    )
+    if len(new_codon) != 3:
+        return None
+    try:
+        aa_alt = translate_sequence(
+            new_codon,
+            codon_table=codon_table_for_transcript(transcript),
+            to_stop=False)
+    except ValueError:
+        return None
+    # aa_alt may contain '*' if the reshaped codon is a stop; leave
+    # that to the caller to interpret (the next candidate builder
+    # that specializes on premature stops can pick it up later).
+
+    trimmed_ref, trimmed_alt, shared_prefix, _ = trim_shared_flanking_strings(
+        aa_ref, aa_alt)
+    # Shared prefix shifts the effective mutation start forward.
+    aa_mutation_start_offset = aa_start + len(shared_prefix)
+
+    if not trimmed_alt and not trimmed_ref:
+        # Reshaped codon happens to match the boundary exactly — the
+        # skip is effectively silent at the protein level. Return None
+        # so the caller falls back to the predicted-class-name stub
+        # (exceedingly rare in practice).
+        return None
+    if not trimmed_alt:
+        return Deletion(
+            variant=variant,
+            transcript=transcript,
+            aa_mutation_start_offset=aa_mutation_start_offset,
+            aa_ref=trimmed_ref,
+        )
+    if len(trimmed_ref) == 1 and len(trimmed_alt) == 1:
+        return Substitution(
+            variant=variant,
+            transcript=transcript,
+            aa_mutation_start_offset=aa_mutation_start_offset,
+            aa_ref=trimmed_ref,
+            aa_alt=trimmed_alt,
+        )
+    return ComplexSubstitution(
         variant=variant,
         transcript=transcript,
-        aa_mutation_start_offset=aa_start,
-        aa_ref=aa_ref,
+        aa_mutation_start_offset=aa_mutation_start_offset,
+        aa_ref=trimmed_ref,
+        aa_alt=trimmed_alt,
     )
 
 

--- a/varcode/splice_outcomes.py
+++ b/varcode/splice_outcomes.py
@@ -46,6 +46,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
+from .effects.codon_tables import codon_table_for_transcript, translate_sequence
 from .effects.effect_classes import (
     Deletion,
     ExonicSpliceSite,
@@ -543,7 +544,8 @@ def _build_out_of_frame_exon_skip_effect(variant, transcript, skipped_exon):
     )
     # Translate from the start codon through the frameshift to first stop.
     coding_from_start = post_skip_cdna[cds_start_offset:]
-    protein = _translate_to_first_stop(coding_from_start)
+    protein = _translate_to_first_stop(
+        coding_from_start, codon_table=codon_table_for_transcript(transcript))
     if not protein:
         return None
     # Compute the aa position where the frameshift begins — this is
@@ -559,15 +561,20 @@ def _build_out_of_frame_exon_skip_effect(variant, transcript, skipped_exon):
     )
 
 
-def _translate_to_first_stop(cdna):
+def _translate_to_first_stop(cdna, codon_table=None):
     """Translate a cDNA string to protein, stopping at the first stop
     codon. Returns the protein string without the stop symbol.
+
+    ``codon_table`` defaults to the standard nuclear table; pass the
+    vertebrate mitochondrial table for mt transcripts so AGA/AGG act
+    as stops and TGA codes for Trp.
     """
-    from Bio.Seq import Seq
+    if codon_table is None:
+        from .effects.codon_tables import STANDARD
+        codon_table = STANDARD
     n_codons = len(cdna) // 3
     truncated = str(cdna[:n_codons * 3])
-    protein = str(Seq(truncated).translate(to_stop=True))
-    return protein
+    return translate_sequence(truncated, codon_table=codon_table, to_stop=True)
 
 
 class _ExonSkipFrameshiftEffect(MutationEffect):


### PR DESCRIPTION
Three independent follow-ups from 2.4.0 review.

## #294 — Mitochondrial codon table

varcode translated every variant with NCBI table 1 (standard nuclear). Mitochondrial protein-coding genes use NCBI table 2, which differs at four codons:

| codon | standard | mt |
|---|---|---|
| TGA | stop | Trp |
| AGA | Arg | stop |
| AGG | Arg | stop |
| ATA | Ile | Met |

New `varcode/effects/codon_tables.py` with local `STANDARD` and `VERTEBRATE_MITOCHONDRIAL` tables as plain Python literals — no BioPython needed for codon lookup. `codon_table_for_transcript(transcript)` dispatches on `transcript.contig` (matches `MT` / `chrMT` / `chrM` / `M` / `mt` / `mtDNA` / `mito`). The coding-effect prediction path (in-frame + frameshift) and `splice_outcomes._translate_to_first_stop` all thread the per-transcript table through. Module-level `DNA_CODON_TABLE` / `START_CODONS` / `STOP_CODONS` exports stay pointed at the standard table for back-compat.

11 of 13 human mt protein-coding transcripts now annotate correctly end-to-end. The other two (MT-ND1, MT-ND2) still fall through to `IncompleteTranscript` because pyensembl doesn't recognize AGA/AGG as `stop_codon` GFF features — separate bug worth its own follow-up.

Also nudges #293 (drop biopython) forward: this commit replaces `Bio.Data.CodonTable` and `Bio.Seq.Seq.translate()` inside `translate.py` and `splice_outcomes.py`.

## #295 — `SpliceOutcomeSet` / `SpliceCandidate` JSON round-trip

2.4.0's default `to_json` / `from_json` raised because the nested `SpliceOutcome` enum, frozen `SpliceCandidate` dataclasses, and bare class object in `disrupted_signal_class` didn't survive the default path.

`SpliceCandidate` gets `to_dict` / `from_dict`; enum encodes as its `.value` string, nested `coding_effect` is tagged with `__effect_class__` (not `__class__` — that collides with python-serializable's own polymorphic-dispatch key). `SpliceOutcomeSet.to_dict` and `_reconstruct_nested_objects` rehydrate candidates and resolve the class name via a local splice-signal registry. Internal `_ExonSkipFrameshiftEffect` shim is special-cased.

## #298 — Boundary-codon reconstruction on mid-codon in-frame exon skip

When the skipped exon starts or ends mid-codon, the new boundary codon is reassembled from bases of both flanking exons — so the skip touches `exon_length/3 + 1` original codons and replaces them with one new codon, not `exon_length/3` cleanly deleted codons. 2.4.0 emitted a plain `Deletion` in all cases, which silently misreports both the offset and the boundary residue.

Now: `_build_in_frame_exon_skip_effect` branches on `(exon_start_in_tx - cds_start_offset) % 3`. Phase 0 keeps the aligned-deletion path. Phase 1/2 reconstructs the new boundary codon from `transcript.sequence` flanks, translates with the transcript's codon table (mt-aware after #294), and uses `trim_shared_flanking_strings` to collapse `(aa_ref, aa_alt)` to the minimal edit. The caller's `predicted_class_name` now derives from `type(coding_effect).__name__` rather than hard-coding `"Deletion"`.

## Test plan

- 21 new tests in `tests/test_mitochondrial.py` (codon tables, contig detection, three MT-CO1 variants that would each be wrong under the standard table, back-compat of legacy exports)
- 5 new tests in `tests/test_splice_outcomes.py` for serialization round-trip (candidate with coding_effect, candidate stub, full SpliceOutcomeSet JSON round-trip, dict idempotence, priority preservation after round-trip)
- 2 new tests for boundary codon reconstruction (mid-codon CFTR exon 6, phase 0 CFTR exon 3 regression)
- 554 total tests pass (was 526); ruff clean.