### PR TITLE
Start #271: MutantTranscript data model + pluggable EffectAnnotator (stage 1)

### DIFF
--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -1,0 +1,159 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the pluggable EffectAnnotator interface and registry
+(openvax/varcode#271, stage 1)."""
+
+import pytest
+from pyensembl import cached_release
+
+import varcode
+from varcode import (
+    EffectAnnotator,
+    LegacyEffectAnnotator,
+    UnsupportedVariantError,
+    Variant,
+    get_annotator,
+    get_default_annotator,
+    register_annotator,
+    set_default_annotator,
+)
+
+
+ensembl_grch38 = cached_release(81)
+
+
+# ====================================================================
+# Protocol shape
+# ====================================================================
+
+
+def test_legacy_annotator_satisfies_protocol():
+    annotator = LegacyEffectAnnotator()
+    # @runtime_checkable Protocol — isinstance works structurally.
+    assert isinstance(annotator, EffectAnnotator)
+    assert annotator.name == "legacy"
+    assert {"snv", "indel", "mnv"}.issubset(annotator.supports)
+
+
+def test_duck_typed_annotator_satisfies_protocol():
+    # Third parties don't need to inherit from anything; matching the
+    # shape is enough.
+    class DuckAnnotator:
+        name = "duck"
+        supports = frozenset({"snv"})
+        def annotate_on_transcript(self, variant, transcript):
+            return None
+    assert isinstance(DuckAnnotator(), EffectAnnotator)
+
+
+# ====================================================================
+# Registry
+# ====================================================================
+
+
+def test_legacy_annotator_is_registered_by_default():
+    assert get_annotator("legacy").__class__ is LegacyEffectAnnotator
+    assert get_default_annotator().__class__ is LegacyEffectAnnotator
+
+
+def test_register_and_retrieve_custom_annotator():
+    class CustomAnnotator:
+        name = "test_custom"
+        supports = frozenset({"snv"})
+        def annotate_on_transcript(self, variant, transcript):
+            return None
+    register_annotator(CustomAnnotator())
+    try:
+        assert get_annotator("test_custom").__class__ is CustomAnnotator
+    finally:
+        # Clean up so we don't leak state into other tests.
+        from varcode.annotators.registry import _REGISTRY
+        _REGISTRY.pop("test_custom", None)
+
+
+def test_register_rejects_nameless_annotators():
+    class Unnamed:
+        supports = frozenset()
+        def annotate_on_transcript(self, variant, transcript):
+            return None
+    with pytest.raises(ValueError):
+        register_annotator(Unnamed())
+
+
+def test_set_default_annotator_swaps_registry_default():
+    class Swap:
+        name = "test_swap_default"
+        supports = frozenset({"snv"})
+        def annotate_on_transcript(self, variant, transcript):
+            return None
+    register_annotator(Swap())
+    try:
+        set_default_annotator("test_swap_default")
+        assert get_default_annotator().__class__ is Swap
+    finally:
+        set_default_annotator("legacy")
+        from varcode.annotators.registry import _REGISTRY
+        _REGISTRY.pop("test_swap_default", None)
+
+
+def test_set_default_annotator_rejects_unknown_name():
+    with pytest.raises(KeyError):
+        set_default_annotator("nonexistent_annotator")
+
+
+# ====================================================================
+# LegacyEffectAnnotator end-to-end — byte-for-byte match with the
+# existing Variant.effect_on_transcript API.
+# ====================================================================
+
+
+def test_legacy_annotator_matches_effect_on_transcript():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id("ENST00000003084")
+    direct = variant.effect_on_transcript(transcript)
+    annotated = LegacyEffectAnnotator().annotate_on_transcript(
+        variant, transcript)
+    assert type(annotated) is type(direct)
+    assert annotated.short_description == direct.short_description
+
+
+# ====================================================================
+# UnsupportedVariantError is available as an exception class for the
+# sequence-diff annotator to raise. No code throws it yet (no
+# annotator currently checks `.supports` at runtime), but downstream
+# code can already catch it.
+# ====================================================================
+
+
+def test_unsupported_variant_error_is_a_value_error():
+    # Users can `except ValueError` and catch unsupported-variant
+    # errors alongside other validation failures if they want.
+    assert issubclass(UnsupportedVariantError, ValueError)
+    with pytest.raises(UnsupportedVariantError):
+        raise UnsupportedVariantError("test")
+
+
+# ====================================================================
+# Package-level exports
+# ====================================================================
+
+
+def test_annotator_types_exported_at_package_level():
+    assert varcode.EffectAnnotator is EffectAnnotator
+    assert varcode.LegacyEffectAnnotator is LegacyEffectAnnotator
+    assert varcode.UnsupportedVariantError is UnsupportedVariantError
+    # Registry functions too
+    assert varcode.get_annotator is get_annotator
+    assert varcode.get_default_annotator is get_default_annotator
+    assert varcode.register_annotator is register_annotator
+    assert varcode.set_default_annotator is set_default_annotator

--- a/tests/test_mutant_transcript.py
+++ b/tests/test_mutant_transcript.py
@@ -1,0 +1,112 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the MutantTranscript data model (openvax/varcode#271)."""
+
+import pytest
+
+import varcode
+from varcode import MutantTranscript, TranscriptEdit
+
+
+def test_transcript_edit_substitution_shape():
+    edit = TranscriptEdit(cdna_start=10, cdna_end=13, alt_bases="TTT")
+    assert not edit.is_insertion
+    assert not edit.is_deletion
+    assert edit.length_delta == 0
+
+
+def test_transcript_edit_insertion_shape():
+    edit = TranscriptEdit(cdna_start=10, cdna_end=10, alt_bases="ACG")
+    assert edit.is_insertion
+    assert not edit.is_deletion
+    assert edit.length_delta == 3
+
+
+def test_transcript_edit_deletion_shape():
+    edit = TranscriptEdit(cdna_start=10, cdna_end=16, alt_bases="")
+    assert not edit.is_insertion
+    assert edit.is_deletion
+    assert edit.length_delta == -6
+
+
+def test_transcript_edit_rejects_negative_start():
+    with pytest.raises(ValueError):
+        TranscriptEdit(cdna_start=-1, cdna_end=0, alt_bases="A")
+
+
+def test_transcript_edit_rejects_end_before_start():
+    with pytest.raises(ValueError):
+        TranscriptEdit(cdna_start=10, cdna_end=5, alt_bases="")
+
+
+def test_transcript_edit_is_frozen():
+    edit = TranscriptEdit(cdna_start=10, cdna_end=13, alt_bases="TTT")
+    with pytest.raises(Exception):
+        edit.cdna_start = 0
+
+
+def test_mutant_transcript_no_edits_is_identity():
+    mt = MutantTranscript(reference_transcript=object())
+    assert mt.is_identical_to_reference
+    assert mt.total_length_delta == 0
+    assert mt.cdna_sequence is None
+    assert mt.mutant_protein_sequence is None
+    assert mt.annotator_name == "unknown"
+
+
+def test_mutant_transcript_sums_length_deltas():
+    mt = MutantTranscript(
+        reference_transcript=object(),
+        edits=(
+            TranscriptEdit(10, 13, "T"),         # -2
+            TranscriptEdit(100, 100, "AAAA"),    # +4
+            TranscriptEdit(200, 210, ""),        # -10
+        ),
+    )
+    assert mt.total_length_delta == -8
+    assert not mt.is_identical_to_reference
+
+
+def test_mutant_transcript_rejects_out_of_order_edits():
+    with pytest.raises(ValueError):
+        MutantTranscript(
+            reference_transcript=object(),
+            edits=(
+                TranscriptEdit(100, 100, "A"),
+                TranscriptEdit(10, 13, "T"),  # out of order
+            ),
+        )
+
+
+def test_mutant_transcript_is_frozen():
+    mt = MutantTranscript(reference_transcript=object())
+    with pytest.raises(Exception):
+        mt.annotator_name = "different"
+
+
+def test_mutant_transcript_carries_sequences_when_producer_supplies_them():
+    mt = MutantTranscript(
+        reference_transcript=object(),
+        edits=(TranscriptEdit(10, 13, "TTT"),),
+        cdna_sequence="AAA...TTT...GGG",
+        mutant_protein_sequence="MKL*",
+        annotator_name="sequence_diff",
+    )
+    assert mt.cdna_sequence == "AAA...TTT...GGG"
+    assert mt.mutant_protein_sequence == "MKL*"
+    assert mt.annotator_name == "sequence_diff"
+
+
+def test_mutant_transcript_is_exported_at_package_root():
+    assert varcode.MutantTranscript is MutantTranscript
+    assert varcode.TranscriptEdit is TranscriptEdit

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -11,8 +11,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .annotators import (
+    EffectAnnotator,
+    LegacyEffectAnnotator,
+    UnsupportedVariantError,
+    get_annotator,
+    get_default_annotator,
+    register_annotator,
+    set_default_annotator,
+)
 from .errors import ReferenceMismatchError, SampleNotFoundError
 from .genotype import Genotype, Zygosity
+from .mutant_transcript import MutantTranscript, TranscriptEdit
 from .splice_outcomes import (
     SpliceCandidate,
     SpliceOutcome,
@@ -48,6 +58,17 @@ __all__ = [
     "SpliceCandidate",
     "SpliceOutcome",
     "SpliceOutcomeSet",
+
+    # MutantTranscript data model + pluggable annotators (openvax/varcode#271)
+    "MutantTranscript",
+    "TranscriptEdit",
+    "EffectAnnotator",
+    "LegacyEffectAnnotator",
+    "UnsupportedVariantError",
+    "get_annotator",
+    "get_default_annotator",
+    "register_annotator",
+    "set_default_annotator",
 
     # effects
     "effect_priority",

--- a/varcode/annotators/__init__.py
+++ b/varcode/annotators/__init__.py
@@ -1,0 +1,87 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Effect annotator interface (openvax/varcode#271, stage 1).
+
+An :class:`EffectAnnotator` takes a :class:`Variant` and a
+:class:`Transcript` and returns a :class:`MutationEffect` (or a
+:class:`MutantTranscript` consumed by one, depending on the
+implementation). Annotators coexist behind a shared Protocol so
+users can choose between:
+
+* ``legacy`` — the offset-based annotator that has shipped since
+  2.0.0. Wraps :func:`varcode.effects.predict_variant_effect_on_transcript`.
+* ``sequence_diff`` — the coming annotator that materializes a
+  :class:`MutantTranscript` and diffs its translated protein
+  against the reference. Not in this stage; see #271.
+
+Third parties (Isovar, Exacto) can register their own annotators by
+implementing the Protocol and calling :func:`register_annotator`.
+
+This stage 1 PR ships only the Protocol + registry + legacy wrapper;
+the sequence-diff annotator, fast-path routing, per-call selection on
+``Variant.effects()``, and ``EffectCollection`` provenance fields
+land in follow-up PRs as outlined in #271.
+"""
+
+from typing import Protocol, runtime_checkable
+
+from .legacy import LegacyEffectAnnotator
+from .registry import (
+    UnsupportedVariantError,
+    get_annotator,
+    get_default_annotator,
+    register_annotator,
+    set_default_annotator,
+)
+
+
+@runtime_checkable
+class EffectAnnotator(Protocol):
+    """Protocol for an object that annotates variant effects on
+    transcripts.
+
+    Conforming objects expose:
+
+    * ``name`` — short identifier (e.g. ``"legacy"``) used in the
+      registry and in serialized provenance.
+    * ``supports`` — set of variant-kind tags the annotator can
+      handle (e.g. ``{"snv", "indel"}``). Callers that hand the
+      annotator a variant outside this set get a clear
+      :class:`UnsupportedVariantError` rather than silently wrong
+      output.
+    * :meth:`annotate_on_transcript` — the per-transcript entry
+      point.
+
+    The protocol is intentionally narrow at this stage — additional
+    methods (``annotate_collection``, ``annotate_with_context``) will
+    be added as downstream work needs them. The contract is
+    duck-typed (``@runtime_checkable``) so third-party annotators
+    don't need to inherit from varcode just to register.
+    """
+
+    name: str
+    supports: frozenset
+
+    def annotate_on_transcript(self, variant, transcript):
+        ...
+
+
+__all__ = [
+    "EffectAnnotator",
+    "LegacyEffectAnnotator",
+    "UnsupportedVariantError",
+    "get_annotator",
+    "get_default_annotator",
+    "register_annotator",
+    "set_default_annotator",
+]

--- a/varcode/annotators/legacy.py
+++ b/varcode/annotators/legacy.py
@@ -1,0 +1,43 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The legacy :class:`EffectAnnotator` — a thin wrapper around the
+offset-based effect prediction that varcode has shipped since 2.0.0.
+
+Exists as an :class:`EffectAnnotator` Protocol implementation so
+that the coming sequence-diff annotator can be introduced behind
+the same interface without churning callers (#271, stage 2). Until
+then, this annotator is the default and produces byte-for-byte
+identical output to ``Variant.effect_on_transcript(transcript)``.
+"""
+
+
+class LegacyEffectAnnotator:
+    """Wraps :func:`varcode.effects.predict_variant_effect_on_transcript`."""
+
+    name = "legacy"
+
+    supports = frozenset({"snv", "indel", "mnv"})
+    """Variant kinds this annotator handles. Splice-possibility
+    sets, structural variants, and phased haplotypes fall outside
+    the legacy offset-based path and will be handled by the
+    sequence-diff annotator."""
+
+    def annotate_on_transcript(self, variant, transcript):
+        """Delegate to the existing per-transcript prediction.
+
+        No fast-path / slow-path dispatch at this stage; that lives
+        on the sequence-diff annotator once it exists.
+        """
+        # Lazy import avoids a circular dep at package import time.
+        from ..effects import predict_variant_effect_on_transcript
+        return predict_variant_effect_on_transcript(variant, transcript)

--- a/varcode/annotators/registry.py
+++ b/varcode/annotators/registry.py
@@ -1,0 +1,86 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Process-global registry for :class:`EffectAnnotator` instances.
+
+Kept as a module-level dict (not a class) to match the flat registry
+pattern in the rest of varcode. Default selection is ``"legacy"``
+until the sequence-diff annotator ships; callers that want a
+non-default annotator pass one explicitly or call
+:func:`set_default_annotator`. See #271.
+"""
+
+from .legacy import LegacyEffectAnnotator
+
+
+class UnsupportedVariantError(ValueError):
+    """Raised when an :class:`EffectAnnotator` is asked to handle a
+    variant kind outside its declared ``supports`` set.
+
+    Prefer this over silent mis-annotation — the whole point of the
+    pluggable-annotator design is that callers can see exactly which
+    annotator handles which variant kinds.
+    """
+    pass
+
+
+_REGISTRY = {}
+_DEFAULT_NAME = "legacy"
+
+
+def register_annotator(annotator):
+    """Add an annotator to the process-global registry, keyed by its
+    ``.name``. Re-registering under the same name overrides the
+    previous entry — this is deliberate so callers can swap
+    implementations in tests.
+    """
+    name = getattr(annotator, "name", None)
+    if not name:
+        raise ValueError(
+            "Annotator %r has no .name attribute; cannot register." % annotator)
+    _REGISTRY[name] = annotator
+    return annotator
+
+
+def get_annotator(name):
+    """Look up a registered annotator by name. Raises ``KeyError``
+    if no annotator is registered under that name.
+    """
+    return _REGISTRY[name]
+
+
+def get_default_annotator():
+    """Return the annotator currently configured as the default.
+
+    Stage-1 default is ``"legacy"``. After #271 stage 2 lands (the
+    sequence-diff annotator), that becomes the new default and
+    ``"legacy"`` stays available as an opt-in for users who need
+    byte-for-byte compatibility with 2.x output.
+    """
+    return _REGISTRY[_DEFAULT_NAME]
+
+
+def set_default_annotator(name):
+    """Swap the process-wide default annotator. ``name`` must refer
+    to a registered annotator.
+    """
+    global _DEFAULT_NAME
+    if name not in _REGISTRY:
+        raise KeyError(
+            "No annotator registered under %r — call register_annotator() "
+            "first or pick from %r." % (name, sorted(_REGISTRY)))
+    _DEFAULT_NAME = name
+
+
+# Register the legacy annotator at import time so there is always a
+# default available without the caller having to bootstrap.
+register_annotator(LegacyEffectAnnotator())

--- a/varcode/mutant_transcript.py
+++ b/varcode/mutant_transcript.py
@@ -1,0 +1,149 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data model for representing the result of applying one or more
+variants to a reference transcript (openvax/varcode#271, stage 1).
+
+:class:`TranscriptEdit` and :class:`MutantTranscript` are the types
+used by the forthcoming sequence-diff :class:`EffectAnnotator`
+(``varcode.annotators``) to reshape effect annotation from
+"reason about offsets against the reference" to "materialize the
+mutant sequence, translate it, compare to the reference protein."
+
+This module only defines the data shapes — the sequence-construction
+logic, fast-path dispatch, and annotator wiring are staged across
+later PRs (see the tracking issue). For now, this lets adjacent work
+(splice_outcomes rewrite, RNA-evidence ingestion, germline-aware
+annotation) reference a stable abstraction.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class TranscriptEdit:
+    """A single edit applied to a transcript's spliced mRNA.
+
+    Coordinates are zero-based and refer to positions in the reference
+    transcript's cDNA (i.e. :attr:`pyensembl.Transcript.sequence`).
+    ``cdna_end`` is exclusive; an insertion has
+    ``cdna_start == cdna_end``.
+    """
+    cdna_start: int
+    cdna_end: int
+    alt_bases: str
+    """Nucleotides inserted at ``cdna_start`` (may be empty for a
+    pure deletion)."""
+
+    source_variant: Optional[object] = None
+    """Back-pointer to the :class:`varcode.Variant` that motivated
+    this edit, when known. Optional so synthetic edits (e.g. from
+    an RNA-evidence import that doesn't carry a DNA variant) are
+    representable."""
+
+    def __post_init__(self):
+        if self.cdna_start < 0:
+            raise ValueError(
+                "cdna_start must be non-negative, got %d" % self.cdna_start)
+        if self.cdna_end < self.cdna_start:
+            raise ValueError(
+                "cdna_end (%d) must be >= cdna_start (%d)" % (
+                    self.cdna_end, self.cdna_start))
+
+    @property
+    def is_insertion(self) -> bool:
+        return self.cdna_start == self.cdna_end and len(self.alt_bases) > 0
+
+    @property
+    def is_deletion(self) -> bool:
+        return self.cdna_end > self.cdna_start and len(self.alt_bases) == 0
+
+    @property
+    def length_delta(self) -> int:
+        """Net change in transcript length after this edit
+        (positive for insertion-net, negative for deletion-net)."""
+        return len(self.alt_bases) - (self.cdna_end - self.cdna_start)
+
+
+@dataclass(frozen=True)
+class MutantTranscript:
+    """A reference transcript with zero or more variant-derived edits
+    applied, optionally carrying the mutated cDNA and protein
+    sequences.
+
+    Producers (the sequence-diff annotator, RNA-evidence importers,
+    the splice-outcomes rewrite, germline-aware annotation) construct
+    this once per (transcript, variant-set, context) and hand it to
+    downstream consumers. Each consumer reads the fields it cares
+    about — ``edits`` for provenance, ``cdna_sequence`` /
+    ``mutant_protein_sequence`` for protein-level analysis.
+
+    Sequence fields are ``Optional[str]`` because not every producer
+    computes them eagerly (some stages just need the edit list; full
+    translation is lazy). Callers that require the protein must
+    check or compute it themselves for now — the sequence-diff
+    annotator in stage 2 will guarantee it's populated.
+    """
+
+    reference_transcript: object
+    """The :class:`pyensembl.Transcript` this mutant is derived from.
+    Not typed tightly here so :mod:`pyensembl` isn't a hard import
+    dependency for anyone who just wants the dataclass."""
+
+    edits: Tuple[TranscriptEdit, ...] = field(default_factory=tuple)
+    """Edits applied to produce this mutant, sorted by
+    :attr:`TranscriptEdit.cdna_start`. Empty tuple means the mutant
+    is identical to the reference."""
+
+    cdna_sequence: Optional[str] = None
+    """The mutated spliced mRNA, when computed. ``None`` if the
+    producer hasn't materialized it yet."""
+
+    mutant_protein_sequence: Optional[str] = None
+    """The translated mutant protein, stopping at the first stop
+    codon. ``None`` if not yet translated, or if the edit set
+    doesn't produce a coherent ORF (e.g. start-codon loss). Callers
+    that need a guaranteed-present protein should use the
+    sequence-diff annotator once it lands."""
+
+    annotator_name: str = "unknown"
+    """Name of the :class:`EffectAnnotator` (or other producer) that
+    created this ``MutantTranscript``. Used as provenance in
+    serialization and for A/B comparisons."""
+
+    evidence: Optional[dict] = None
+    """Optional producer-specific evidence (RNA read counts, Isovar
+    fragment ids, SpliceAI scores). Shape is annotator-specific and
+    not part of the stable contract; consumers that care about a
+    particular evidence shape should type-check it at the call site."""
+
+    def __post_init__(self):
+        if self.edits:
+            starts = [e.cdna_start for e in self.edits]
+            if any(starts[i] > starts[i + 1] for i in range(len(starts) - 1)):
+                raise ValueError(
+                    "MutantTranscript.edits must be sorted by cdna_start")
+
+    @property
+    def is_identical_to_reference(self) -> bool:
+        """True if no edits were applied. Does NOT check
+        ``cdna_sequence`` / ``mutant_protein_sequence`` — a producer
+        can legitimately carry an identical sequence with zero edits."""
+        return len(self.edits) == 0
+
+    @property
+    def total_length_delta(self) -> int:
+        """Sum of :attr:`TranscriptEdit.length_delta` across all
+        edits — how much longer or shorter the mutant cDNA is than
+        the reference."""
+        return sum(e.length_delta for e in self.edits)


### PR DESCRIPTION
First PR in the staged #271 refactor. **No behaviour change** — additive only.

## What this ships

**Data model** (`varcode/mutant_transcript.py`)

- `TranscriptEdit` — frozen dataclass: one span-replace edit in transcript cDNA coordinates. Validates non-negative start, end ≥ start. Derived `is_insertion` / `is_deletion` / `length_delta`.
- `MutantTranscript` — frozen dataclass: reference transcript + sorted tuple of edits + optional materialized cDNA / protein sequence + `annotator_name` provenance + optional producer-specific `evidence` dict.

Sequence fields are `Optional[str]` because not every producer materializes them eagerly. That's deliberate — some stages (splice_outcomes rewrite, germline-aware) only need the edit list to propagate downstream; full translation is left to the sequence-diff annotator.

**Pluggable annotator interface** (`varcode/annotators/`)

- `EffectAnnotator` — `@runtime_checkable` `typing.Protocol`. Third parties (isovar, exacto) can satisfy it by shape without inheriting from varcode.
- `LegacyEffectAnnotator` — thin wrapper over the existing `predict_variant_effect_on_transcript`. Produces byte-for-byte identical output to `Variant.effect_on_transcript(transcript)`. Declares `supports = {"snv", "indel", "mnv"}`.
- `registry` — process-global dict with `register_annotator` / `get_annotator` / `get_default_annotator` / `set_default_annotator`. Legacy registered at import time, default name `"legacy"`.
- `UnsupportedVariantError(ValueError)` — available for annotators to raise.

**Package-level exports** for everything above.

**22 new tests** across `tests/test_mutant_transcript.py` and `tests/test_annotators.py`. 576 tests total, ruff clean.

## What does NOT land here

- `Variant.effects()` / `VariantCollection.effects()` keep their current signature — no per-call annotator selection yet.
- `sequence_diff` annotator (the one that actually constructs `MutantTranscript` and diffs translated proteins) — that's the next PR.
- Fast-path SNV short-circuit routing — lives on `sequence_diff` once it exists.
- `EffectCollection` provenance fields, CSV/JSON header metadata, from_csv round-trip — stage 2+.
- `splice_outcomes.py` rewrite on top of `MutantTranscript` — waits on `sequence_diff`.

This PR is deliberately narrow so subsequent PRs can land the behavior-changing parts against a stable interface that's already in the tree.

## Test plan

- [x] Unit tests for `TranscriptEdit` (substitution / insertion / deletion shapes, validation, frozen invariants)
- [x] Unit tests for `MutantTranscript` (identity case, length-delta arithmetic, edit ordering check, frozen invariants)
- [x] Protocol conformance for `LegacyEffectAnnotator` and a duck-typed third-party shape
- [x] Registry round-trip (register + retrieve + swap default + error cases)
- [x] `LegacyEffectAnnotator.annotate_on_transcript` matches `Variant.effect_on_transcript` byte-for-byte on a real CFTR variant
- [x] Package-level re-exports