### PR TITLE
#271 stage 2: apply_variant_to_transcript builds MutantTranscript

### DIFF
--- a/tests/test_mutant_transcript.py
+++ b/tests/test_mutant_transcript.py
@@ -10,12 +10,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the MutantTranscript data model (openvax/varcode#271)."""
+"""Tests for the MutantTranscript data model and construction
+helpers (openvax/varcode#271)."""
 
 import pytest
+from pyensembl import cached_release
 
 import varcode
-from varcode import MutantTranscript, TranscriptEdit
+from varcode import (
+    MutantTranscript,
+    TranscriptEdit,
+    Variant,
+    apply_variant_to_transcript,
+)
+
+
+ensembl_grch38 = cached_release(81)
+CFTR_TRANSCRIPT_ID = "ENST00000003084"  # forward strand, chr7
+BRCA1_TRANSCRIPT_ID = "ENST00000357654"  # reverse strand, chr17
+MT_CO1_TRANSCRIPT_ID = "ENST00000361624"  # mitochondrial, forward strand
 
 
 def test_transcript_edit_substitution_shape():
@@ -110,3 +123,132 @@ def test_mutant_transcript_carries_sequences_when_producer_supplies_them():
 def test_mutant_transcript_is_exported_at_package_root():
     assert varcode.MutantTranscript is MutantTranscript
     assert varcode.TranscriptEdit is TranscriptEdit
+    assert varcode.apply_variant_to_transcript is apply_variant_to_transcript
+
+
+# ====================================================================
+# apply_variant_to_transcript — SNVs, insertions, deletions across
+# both strands and the mitochondrial codon table.
+# ====================================================================
+
+
+def test_apply_snv_to_forward_strand_coding_variant():
+    # CFTR: pick a known coding SNV. CFTR exon 4 is at 117531048-117531263.
+    # A simple substitution inside the CDS.
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    variant = Variant("7", 117531100, "T", "A", ensembl_grch38)
+    mt = apply_variant_to_transcript(variant, transcript)
+    assert mt is not None
+    assert mt.reference_transcript is transcript
+    assert mt.annotator_name == "sequence_diff"
+    assert len(mt.edits) == 1
+    edit = mt.edits[0]
+    assert edit.cdna_end - edit.cdna_start == 1
+    assert edit.alt_bases == "A"
+    # mutant cDNA differs from reference at exactly one position.
+    ref_cdna = str(transcript.sequence)
+    assert len(mt.cdna_sequence) == len(ref_cdna)
+    diffs = [i for i in range(len(ref_cdna)) if ref_cdna[i] != mt.cdna_sequence[i]]
+    assert len(diffs) == 1
+    # Translated mutant protein populated for in-CDS variants.
+    assert mt.mutant_protein_sequence is not None
+    assert len(mt.mutant_protein_sequence) > 0
+
+
+def test_apply_to_reverse_strand_transcript_complements_bases():
+    # BRCA1 is on the reverse strand. Reuse the known-good coding
+    # variant from test_splice_site_effects.py: Variant('17', 43082570,
+    # 'CCT', 'GGG') is a 3-base substitution in BRCA1 exon 12. On the
+    # reverse strand this appears in the cDNA as AGG (ref)/CCC (alt).
+    transcript = ensembl_grch38.transcript_by_id(BRCA1_TRANSCRIPT_ID)
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", ensembl_grch38)
+    mt = apply_variant_to_transcript(variant, transcript)
+    assert mt is not None, "Known-good BRCA1 coding variant should apply"
+    assert transcript.on_backward_strand
+    edit = mt.edits[0]
+    assert edit.alt_bases == "CCC", (
+        "alt_bases should be reverse-complement of genomic alt 'GGG', got %r"
+        % edit.alt_bases)
+    ref_cdna = str(transcript.sequence)
+    assert ref_cdna[edit.cdna_start:edit.cdna_end] == "AGG", (
+        "Reference cDNA slice should be reverse-complement of genomic ref 'CCT'")
+
+
+def test_apply_insertion_in_cds():
+    # Insertion: ref of length 1, alt of length > 1 is a substitution+insert.
+    # For a pure insertion in varcode coords, the trimmed_ref is empty.
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    # Construct a 3-base in-frame insertion inside CFTR. We'll insert
+    # AAA after a base in the CDS.
+    variant = Variant("7", 117531100, "T", "TAAA", ensembl_grch38)
+    mt = apply_variant_to_transcript(variant, transcript)
+    if mt is None:
+        pytest.skip("Insertion didn't pass single-exon containment check.")
+    # Net length delta is +3 (insertion of 3 bases).
+    assert mt.total_length_delta == 3
+    assert len(mt.cdna_sequence) == len(str(transcript.sequence)) + 3
+
+
+def test_apply_deletion_in_cds():
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    # CFTR cDNA at genomic 117531100 is 'T', 117531101 onwards is 'TGA'.
+    # A 3-base in-frame deletion: ref='TTGA' at 117531100, alt='T'
+    # drops 'TGA' (3 bases) while anchoring at the leading T.
+    variant = Variant("7", 117531100, "TTGA", "T", ensembl_grch38)
+    mt = apply_variant_to_transcript(variant, transcript)
+    assert mt is not None
+    assert mt.total_length_delta == -3
+    assert len(mt.cdna_sequence) == len(str(transcript.sequence)) - 3
+
+
+def test_apply_returns_none_for_intronic_variant():
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    # Position deep in a CFTR intron — between exons.
+    # CFTR exon 1 ends at ~117480148; intron 1 follows.
+    intronic_pos = 117500000  # well inside an intron
+    variant = Variant("7", intronic_pos, "T", "A", ensembl_grch38)
+    mt = apply_variant_to_transcript(variant, transcript)
+    assert mt is None, (
+        "Intronic variant must return None so caller falls back to legacy")
+
+
+def test_apply_returns_none_for_non_protein_coding_transcript():
+    # Pick a non-coding transcript on chr1
+    nc_transcripts = [
+        t for t in ensembl_grch38.transcripts(contig="1")
+        if not t.is_protein_coding
+    ][:1]
+    if not nc_transcripts:
+        pytest.skip("No non-coding chr1 transcripts available locally")
+    nc = nc_transcripts[0]
+    variant = Variant("1", nc.start + 100, "T", "A", ensembl_grch38)
+    mt = apply_variant_to_transcript(variant, nc)
+    assert mt is None
+
+
+def test_apply_variant_to_mitochondrial_transcript_uses_mt_codon_table():
+    # MT-CO1 6739 C>G: TCA -> TGA. Standard table => stop; mt table => Trp.
+    # apply_variant_to_transcript should use mt translation, so the
+    # mutant_protein_sequence should NOT be truncated at this codon.
+    transcript = ensembl_grch38.transcript_by_id(MT_CO1_TRANSCRIPT_ID)
+    variant = Variant("MT", 6739, "C", "G", ensembl_grch38)
+    mt = apply_variant_to_transcript(variant, transcript)
+    assert mt is not None
+    # The reference protein at this codon position is S (Ser) — the
+    # mutant should be W (Trp) at the same position, NOT truncated.
+    ref_protein = str(transcript.protein_sequence)
+    aa_pos = 278  # known from #294 test
+    assert ref_protein[aa_pos] == "S"
+    assert mt.mutant_protein_sequence[aa_pos] == "W"
+    # Length is preserved (no premature stop introduced under mt table).
+    assert len(mt.mutant_protein_sequence) >= aa_pos + 1
+
+
+def test_apply_variant_returns_none_on_reference_mismatch():
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    # Wrong reference base at this position — should return None
+    # (not raise; caller decides whether to surface the error).
+    variant = Variant("7", 117531100, "X", "A", ensembl_grch38,
+                      allow_extended_nucleotides=True)
+    mt = apply_variant_to_transcript(variant, transcript)
+    assert mt is None

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -22,7 +22,11 @@ from .annotators import (
 )
 from .errors import ReferenceMismatchError, SampleNotFoundError
 from .genotype import Genotype, Zygosity
-from .mutant_transcript import MutantTranscript, TranscriptEdit
+from .mutant_transcript import (
+    MutantTranscript,
+    TranscriptEdit,
+    apply_variant_to_transcript,
+)
 from .splice_outcomes import (
     SpliceCandidate,
     SpliceOutcome,
@@ -62,6 +66,7 @@ __all__ = [
     # MutantTranscript data model + pluggable annotators (openvax/varcode#271)
     "MutantTranscript",
     "TranscriptEdit",
+    "apply_variant_to_transcript",
     "EffectAnnotator",
     "LegacyEffectAnnotator",
     "UnsupportedVariantError",

--- a/varcode/mutant_transcript.py
+++ b/varcode/mutant_transcript.py
@@ -147,3 +147,129 @@ class MutantTranscript:
         edits — how much longer or shorter the mutant cDNA is than
         the reference."""
         return sum(e.length_delta for e in self.edits)
+
+
+# ---------------------------------------------------------------------
+# Construction (#271 stage 2)
+# ---------------------------------------------------------------------
+
+
+_COMPLEMENT = {"A": "T", "T": "A", "G": "C", "C": "G", "N": "N"}
+
+
+def _reverse_complement(seq: str) -> str:
+    return "".join(_COMPLEMENT.get(b, b) for b in reversed(seq.upper()))
+
+
+def apply_variant_to_transcript(variant, transcript):
+    """Construct a :class:`MutantTranscript` by applying ``variant``
+    to ``transcript``'s spliced cDNA.
+
+    Returns a :class:`MutantTranscript` whose ``cdna_sequence`` is
+    populated, plus ``mutant_protein_sequence`` when the variant
+    lies after the start codon (so translation from the canonical
+    start is well-defined). The codon table is selected from the
+    transcript's contig — mitochondrial transcripts use NCBI table
+    2 automatically (see :func:`varcode.effects.codon_tables.codon_table_for_transcript`).
+
+    Returns ``None`` when the variant can't be cleanly applied:
+
+    * Transcript is not protein-coding or is incomplete.
+    * Variant doesn't overlap the transcript at all.
+    * Variant spans more than one exon (splice-junction-crossing
+      variants need the splice-aware path; not handled here).
+    * Reference allele doesn't match the transcript's cDNA at the
+      computed offset.
+
+    Callers that get ``None`` should fall back to the legacy
+    :class:`EffectAnnotator`. The forthcoming sequence-diff annotator
+    layers effect classification on top of this builder.
+    """
+    # Lazy imports to keep module-level deps light.
+    from pyensembl import Transcript
+    from .effects.codon_tables import (
+        codon_table_for_transcript,
+        translate_sequence,
+    )
+    from .effects.transcript_helpers import interval_offset_on_transcript
+
+    if not isinstance(transcript, Transcript):
+        return None
+    if not transcript.is_protein_coding or not transcript.complete:
+        return None
+
+    variant_start = variant.trimmed_base1_start
+    variant_end = variant.trimmed_base1_end
+
+    # Variant must overlap exactly one exon — we don't handle
+    # splice-junction-spanning edits at this stage.
+    overlapping = [
+        ex for ex in transcript.exons
+        if variant_start >= ex.start and variant_end <= ex.end
+    ]
+    if len(overlapping) != 1:
+        return None
+
+    try:
+        cdna_offset = interval_offset_on_transcript(
+            variant_start, variant_end, transcript)
+    except (ValueError, KeyError):
+        return None
+
+    # Strand-flip ref/alt for reverse-strand transcripts.
+    genome_ref = variant.trimmed_ref
+    genome_alt = variant.trimmed_alt
+    if transcript.on_backward_strand:
+        cdna_ref = _reverse_complement(genome_ref)
+        cdna_alt = _reverse_complement(genome_alt)
+    else:
+        cdna_ref = genome_ref
+        cdna_alt = genome_alt
+
+    # Validate reference matches.
+    full_sequence = str(transcript.sequence)
+    n_ref = len(cdna_ref)
+    expected_ref = full_sequence[cdna_offset:cdna_offset + n_ref]
+    if cdna_ref != expected_ref:
+        return None
+
+    edit = TranscriptEdit(
+        cdna_start=cdna_offset,
+        cdna_end=cdna_offset + n_ref,
+        alt_bases=cdna_alt,
+        source_variant=variant,
+    )
+
+    mutant_cdna = (
+        full_sequence[:cdna_offset]
+        + cdna_alt
+        + full_sequence[cdna_offset + n_ref:]
+    )
+
+    mutant_protein = None
+    cds_start = min(transcript.start_codon_spliced_offsets)
+    if cdna_offset >= cds_start:
+        # Variant lands in or after the CDS — translate the new
+        # coding sequence from the canonical start to the first
+        # stop. The codon table is mt-aware via the transcript's
+        # contig.
+        codon_table = codon_table_for_transcript(transcript)
+        coding = mutant_cdna[cds_start:]
+        truncated = coding[:(len(coding) // 3) * 3]
+        try:
+            mutant_protein = translate_sequence(
+                truncated, codon_table=codon_table, to_stop=True)
+        except ValueError:
+            mutant_protein = None
+    # If cdna_offset < cds_start the variant is in the 5' UTR; we
+    # don't attempt translation here since it might (depending on the
+    # exact variant) preserve, lose, or shift the start codon — that
+    # interpretation is the legacy annotator's responsibility for now.
+
+    return MutantTranscript(
+        reference_transcript=transcript,
+        edits=(edit,),
+        cdna_sequence=mutant_cdna,
+        mutant_protein_sequence=mutant_protein,
+        annotator_name="sequence_diff",
+    )


### PR DESCRIPTION
Second PR in the staged #271 refactor. Adds the first concrete `MutantTranscript` producer; **no changes to user-facing effect prediction yet**.

## What this ships

`varcode.apply_variant_to_transcript(variant, transcript)` — takes a `Variant` and a pyensembl `Transcript` and returns a `MutantTranscript` with:

- The applied `TranscriptEdit` (reverse-complemented automatically for `-` strand transcripts)
- The full mutant cDNA
- The translated mutant protein (when the variant lands after the start codon; codon table is mt-aware via `codon_table_for_transcript`)

Returns `None` for cases the stage-2 builder does not handle — intronic variants, variants spanning a splice junction, non-coding / incomplete transcripts, reference mismatches. Callers fall back to the legacy annotator in those cases.

A local `_reverse_complement` helper avoids pulling in `Bio.Seq.reverse_complement`, continuing the BioPython-removal trend from #294.

## Why this shape

The coming `sequence_diff` `EffectAnnotator` (stage 3) will use this as its first step:

```python
mt = apply_variant_to_transcript(variant, transcript)
if mt is None:
    return legacy_annotator.annotate_on_transcript(variant, transcript)
return classify_effect_from_protein_diff(
    reference=transcript.protein_sequence,
    mutant=mt.mutant_protein_sequence,
    variant=variant,
    transcript=transcript,
)
```

Separating the builder from the classifier keeps the \"construct mutant sequence\" primitive reusable for:
- Isovar (consumes assembled RNA `MutantTranscript`s directly — no builder needed)
- Splice outcome possibility sets (one `MutantTranscript` per outcome)
- Germline-aware annotation (apply germline variants first, then somatic)
- Phasing (one `MutantTranscript` per haplotype)

## Non-goals

- No changes to `Variant.effects()` or `VariantCollection.effects()` — still fully legacy.
- No effect classification — the helper returns a `MutantTranscript`, not an `Effect`.
- No fast-path SNV short-circuit — that lives on the `sequence_diff` annotator.
- No SV / fusion / multi-exon edit support.

## Test plan

8 new end-to-end tests in `tests/test_mutant_transcript.py`:

- [x] SNV on forward-strand CFTR (edit + protein populated)
- [x] 3-base MNV on reverse-strand BRCA1 (ref/alt reverse-complemented correctly)
- [x] In-frame insertion in CFTR CDS (`total_length_delta == +3`)
- [x] In-frame deletion in CFTR CDS (`total_length_delta == -3`)
- [x] Intronic variant returns `None`
- [x] Non-coding transcript returns `None`
- [x] Reference-mismatch variant returns `None` (does not raise)
- [x] MT-CO1 TCA->TGA variant yields Trp at aa 278 with no truncation (mt codon table auto-selected)

584 total tests pass; ruff clean.