### PR TITLE
#271 stage 3a: annotator= kwarg + use_annotator context manager

### DIFF
--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -157,3 +157,139 @@ def test_annotator_types_exported_at_package_level():
     assert varcode.get_default_annotator is get_default_annotator
     assert varcode.register_annotator is register_annotator
     assert varcode.set_default_annotator is set_default_annotator
+
+
+# ====================================================================
+# annotator= kwarg on Variant.effects() and VariantCollection.effects()
+# (see #271 stage 3a)
+# ====================================================================
+
+
+def test_variant_effects_default_uses_legacy():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    # No annotator kwarg — should still produce the same output the
+    # legacy annotator produces, since legacy is the default.
+    default_effects = variant.effects()
+    explicit_legacy = variant.effects(annotator="legacy")
+    assert [type(e).__name__ for e in default_effects] == \
+           [type(e).__name__ for e in explicit_legacy]
+
+
+def test_variant_effects_accepts_annotator_name_string():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    effects = variant.effects(annotator="legacy")
+    assert len(effects) > 0
+
+
+def test_variant_effects_accepts_annotator_instance():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    effects = variant.effects(annotator=LegacyEffectAnnotator())
+    assert len(effects) > 0
+
+
+def test_variant_effects_rejects_unknown_annotator_name():
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    with pytest.raises(KeyError) as exc_info:
+        variant.effects(annotator="nonexistent_annotator")
+    # Error message lists known annotators so the caller can fix the typo.
+    assert "legacy" in str(exc_info.value)
+
+
+def test_variant_collection_effects_accepts_annotator():
+    from varcode import VariantCollection
+    vc = VariantCollection([
+        Variant("7", 117531115, "G", "A", ensembl_grch38),
+        Variant("7", 117531114, "G", "T", ensembl_grch38),
+    ])
+    default_effects = vc.effects()
+    with_annotator = vc.effects(annotator="legacy")
+    assert len(default_effects) == len(with_annotator)
+
+
+# ====================================================================
+# use_annotator context manager
+# ====================================================================
+
+
+def test_use_annotator_swaps_default_within_scope():
+    from varcode import use_annotator
+    class Scoped:
+        name = "test_scoped"
+        supports = frozenset({"snv"})
+        def annotate_on_transcript(self, variant, transcript):
+            return None
+    scoped_instance = Scoped()
+    assert get_default_annotator().__class__ is LegacyEffectAnnotator
+    with use_annotator(scoped_instance):
+        assert get_default_annotator() is scoped_instance
+    # On exit, default is restored.
+    assert get_default_annotator().__class__ is LegacyEffectAnnotator
+    # And the scoped-instance registration is cleaned up.
+    from varcode.annotators.registry import _REGISTRY
+    assert "test_scoped" not in _REGISTRY
+
+
+def test_use_annotator_with_registered_name_preserves_registration():
+    from varcode import use_annotator, register_annotator
+    class Persisted:
+        name = "test_persisted"
+        supports = frozenset({"snv"})
+        def annotate_on_transcript(self, variant, transcript):
+            return None
+    persisted = Persisted()
+    register_annotator(persisted)
+    try:
+        with use_annotator("test_persisted"):
+            assert get_default_annotator() is persisted
+        assert get_default_annotator().__class__ is LegacyEffectAnnotator
+        # Registration persists after the context exit since it
+        # wasn't created by the context manager.
+        from varcode.annotators.registry import _REGISTRY
+        assert "test_persisted" in _REGISTRY
+    finally:
+        from varcode.annotators.registry import _REGISTRY
+        _REGISTRY.pop("test_persisted", None)
+
+
+def test_use_annotator_affects_variant_effects_default():
+    from varcode import use_annotator
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+
+    # Capture legacy output inside the context via a wrapping annotator
+    # that records the calls.
+    calls = []
+    class Recording:
+        name = "test_recording"
+        supports = frozenset({"snv", "indel", "mnv"})
+        def annotate_on_transcript(self, variant, transcript):
+            calls.append((variant, transcript))
+            return LegacyEffectAnnotator().annotate_on_transcript(
+                variant, transcript)
+    with use_annotator(Recording()):
+        variant.effects()  # no annotator= kwarg → uses scoped default
+    assert len(calls) > 0, (
+        "Variant.effects() inside use_annotator(...) should have "
+        "dispatched to the scoped annotator")
+
+
+def test_use_annotator_rejects_instance_without_name():
+    from varcode import use_annotator
+    class Unnamed:
+        supports = frozenset()
+        def annotate_on_transcript(self, variant, transcript):
+            return None
+    with pytest.raises(ValueError):
+        with use_annotator(Unnamed()):
+            pass
+
+
+def test_resolve_annotator_passes_through_instance():
+    from varcode import resolve_annotator
+    instance = LegacyEffectAnnotator()
+    assert resolve_annotator(instance) is instance
+
+
+def test_resolve_annotator_resolves_none_to_default():
+    from varcode import resolve_annotator
+    resolved = resolve_annotator(None)
+    assert resolved.__class__ is LegacyEffectAnnotator

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -18,7 +18,9 @@ from .annotators import (
     get_annotator,
     get_default_annotator,
     register_annotator,
+    resolve_annotator,
     set_default_annotator,
+    use_annotator,
 )
 from .errors import ReferenceMismatchError, SampleNotFoundError
 from .genotype import Genotype, Zygosity
@@ -73,7 +75,9 @@ __all__ = [
     "get_annotator",
     "get_default_annotator",
     "register_annotator",
+    "resolve_annotator",
     "set_default_annotator",
+    "use_annotator",
 
     # effects
     "effect_priority",

--- a/varcode/annotators/__init__.py
+++ b/varcode/annotators/__init__.py
@@ -41,7 +41,9 @@ from .registry import (
     get_annotator,
     get_default_annotator,
     register_annotator,
+    resolve_annotator,
     set_default_annotator,
+    use_annotator,
 )
 
 
@@ -83,5 +85,7 @@ __all__ = [
     "get_annotator",
     "get_default_annotator",
     "register_annotator",
+    "resolve_annotator",
     "set_default_annotator",
+    "use_annotator",
 ]

--- a/varcode/annotators/registry.py
+++ b/varcode/annotators/registry.py
@@ -19,6 +19,8 @@ non-default annotator pass one explicitly or call
 :func:`set_default_annotator`. See #271.
 """
 
+from contextlib import contextmanager
+
 from .legacy import LegacyEffectAnnotator
 
 
@@ -79,6 +81,78 @@ def set_default_annotator(name):
             "No annotator registered under %r — call register_annotator() "
             "first or pick from %r." % (name, sorted(_REGISTRY)))
     _DEFAULT_NAME = name
+
+
+def resolve_annotator(annotator_or_name):
+    """Normalize a per-call ``annotator=`` argument to an instance.
+
+    Accepts ``None`` (use the current default), a string (look up in
+    the registry), or an object that already implements the
+    :class:`EffectAnnotator` protocol (used directly without
+    validation — we trust duck-typing).
+
+    Raises :class:`KeyError` for unknown names so callers that
+    mistype a string get an early, legible error rather than an
+    obscure attribute failure downstream.
+    """
+    if annotator_or_name is None:
+        return get_default_annotator()
+    if isinstance(annotator_or_name, str):
+        if annotator_or_name not in _REGISTRY:
+            raise KeyError(
+                "No annotator registered under %r — known annotators: %r. "
+                "Register one with varcode.register_annotator() or pick "
+                "from the list." % (
+                    annotator_or_name, sorted(_REGISTRY)))
+        return _REGISTRY[annotator_or_name]
+    return annotator_or_name
+
+
+@contextmanager
+def use_annotator(name_or_instance):
+    """Context manager that temporarily swaps the default annotator.
+
+    Useful for A/B comparisons and scoped overrides without mutating
+    global state across the codebase::
+
+        with varcode.use_annotator("sequence_diff"):
+            effects = variant_collection.effects()
+
+    Accepts the same argument shape as the ``annotator=`` kwarg:
+    a registered-name string, or an annotator instance. Passing an
+    instance registers it temporarily under its ``.name`` so that
+    name-based lookups inside the block find it; on exit the
+    previous default and any previously-registered annotator under
+    that name are restored.
+    """
+    global _DEFAULT_NAME
+    prior_default = _DEFAULT_NAME
+
+    if isinstance(name_or_instance, str):
+        if name_or_instance not in _REGISTRY:
+            raise KeyError(
+                "No annotator registered under %r — register one first or "
+                "pass an instance." % name_or_instance)
+        _DEFAULT_NAME = name_or_instance
+        prior_registration = None
+    else:
+        name = getattr(name_or_instance, "name", None)
+        if not name:
+            raise ValueError(
+                "Annotator instance has no .name attribute; cannot scope.")
+        prior_registration = _REGISTRY.get(name)
+        _REGISTRY[name] = name_or_instance
+        _DEFAULT_NAME = name
+
+    try:
+        yield
+    finally:
+        _DEFAULT_NAME = prior_default
+        if not isinstance(name_or_instance, str):
+            if prior_registration is None:
+                _REGISTRY.pop(name, None)
+            else:
+                _REGISTRY[name] = prior_registration
 
 
 # Register the legacy annotator at import time so there is always a

--- a/varcode/effects/effect_prediction.py
+++ b/varcode/effects/effect_prediction.py
@@ -43,7 +43,11 @@ from .effect_classes import (
 logger = logging.getLogger(__name__)
 
 
-def predict_variant_effects(variant, raise_on_error=False, splice_outcomes=False):
+def predict_variant_effects(
+        variant,
+        raise_on_error=False,
+        splice_outcomes=False,
+        annotator=None):
     """Determine the effects of a variant on any transcripts it overlaps.
     Returns an EffectCollection object.
 
@@ -63,7 +67,18 @@ def predict_variant_effects(variant, raise_on_error=False, splice_outcomes=False
         plausible outcomes (normal splicing, exon skipping, intron
         retention, cryptic splice). Default False for back-compat.
         See ``varcode.splice_outcomes`` for details.
+
+    annotator : str, EffectAnnotator, or None
+        Which registered :class:`EffectAnnotator` to use per-transcript.
+        ``None`` (default) picks up whatever is currently set via
+        :func:`set_default_annotator` / :func:`use_annotator` — today
+        that's ``"legacy"``. A string is looked up in the registry;
+        an instance is used directly. See openvax/varcode#271.
     """
+    # Lazy import — varcode.annotators depends on varcode.effects at
+    # load time, so we defer to break the cycle.
+    from ..annotators.registry import resolve_annotator
+    annotator_instance = resolve_annotator(annotator)
     # if this variant isn't overlapping any genes, return a
     # Intergenic effect
     # TODO: look for nearby genes and mark those as Upstream and Downstream
@@ -97,13 +112,17 @@ def predict_variant_effects(variant, raise_on_error=False, splice_outcomes=False
                 # gene ID  has transcripts overlapped by this variant
                 for transcript in transcripts_grouped_by_gene[gene_id]:
                     if raise_on_error:
-                        effect = predict_variant_effect_on_transcript(
-                            variant=variant,
-                            transcript=transcript)
+                        effect = annotator_instance.annotate_on_transcript(
+                            variant, transcript)
                     else:
-                        effect = predict_variant_effect_on_transcript_or_failure(
-                            variant=variant,
-                            transcript=transcript)
+                        try:
+                            effect = annotator_instance.annotate_on_transcript(
+                                variant, transcript)
+                        except (AssertionError, ValueError) as error:
+                            logger.warn(
+                                "Encountered error annotating %s for %s: %s",
+                                variant, transcript, error)
+                            effect = Failure(variant, transcript)
                     effects.append(effect)
     collection = EffectCollection(effects)
     if splice_outcomes:

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -443,7 +443,7 @@ class Variant(Serializable):
             if gene.is_protein_coding
         ]
 
-    def effects(self, raise_on_error=True, splice_outcomes=False):
+    def effects(self, raise_on_error=True, splice_outcomes=False, annotator=None):
         """Predict the variant's effects on overlapping transcripts.
 
         Parameters
@@ -459,11 +459,19 @@ class Variant(Serializable):
             skipping, intron retention, cryptic splice). Opt-in;
             default False preserves existing behaviour. See
             openvax/varcode#262.
+
+        annotator : str, EffectAnnotator, or None
+            Per-call annotator override. ``None`` uses the currently
+            configured default (``"legacy"`` today; swappable via
+            :func:`varcode.set_default_annotator` or
+            :func:`varcode.use_annotator`). String names are resolved
+            against the registry. See openvax/varcode#271.
         """
         return predict_variant_effects(
             variant=self,
             raise_on_error=raise_on_error,
             splice_outcomes=splice_outcomes,
+            annotator=annotator,
         )
 
     def effect_on_transcript(self, transcript):

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -114,7 +114,7 @@ class VariantCollection(Collection):
         kwargs["variants"] = new_elements
         return self.from_dict(kwargs)
 
-    def effects(self, raise_on_error=True, splice_outcomes=False):
+    def effects(self, raise_on_error=True, splice_outcomes=False, annotator=None):
         """
         Parameters
         ----------
@@ -128,6 +128,11 @@ class VariantCollection(Collection):
             :class:`varcode.splice_outcomes.SpliceOutcomeSet` carrying
             multiple plausible outcomes. Opt-in; default False
             preserves existing behaviour. See openvax/varcode#262.
+
+        annotator : str, EffectAnnotator, or None
+            Per-call annotator override applied to every variant in
+            the collection. See :meth:`Variant.effects` and
+            openvax/varcode#271.
         """
         return EffectCollection([
             effect
@@ -135,6 +140,7 @@ class VariantCollection(Collection):
             for effect in variant.effects(
                 raise_on_error=raise_on_error,
                 splice_outcomes=splice_outcomes,
+                annotator=annotator,
             )
         ])
 


### PR DESCRIPTION
First plumbing PR for #271 — adds the per-call annotator selection and context manager. **No behaviour change**; legacy stays the only registered annotator and stays the default.

## What ships

- `Variant.effects(annotator=...)` and `VariantCollection.effects(annotator=...)` accept:
  - `None` (default) — uses whatever's currently set as default
  - A string — looked up in the registry (`KeyError` for typos, with the list of known annotators in the message)
  - An `EffectAnnotator` instance — used directly

- `varcode.use_annotator(name_or_instance)` context manager that temporarily swaps the default:

  ```python
  with varcode.use_annotator(\"legacy\"):
      effects = variant_collection.effects()  # uses legacy for the scope

  with varcode.use_annotator(MyCustomAnnotator()):
      ...  # temporarily registers MyCustomAnnotator under its .name and makes it default
  ```

  Instance form registers temporarily under `.name` and cleans up on exit (preserving any prior registration under that name). Name form leaves the registry alone.

- `varcode.resolve_annotator(None | str | instance)` helper exposed for symmetry — it's what `Variant.effects` uses internally to normalize the kwarg.

- `predict_variant_effects` threads the choice through; the per-transcript dispatch now calls `annotator.annotate_on_transcript(...)` instead of `predict_variant_effect_on_transcript(...)` directly. Exception-to-`Failure` conversion moves from the old `predict_variant_effect_on_transcript_or_failure` wrapper to the dispatch site so new annotators don't need to know about the `Failure` contract.

## What this does NOT do

- **No algorithmic change** — legacy is still the only annotator. This is pure plumbing.
- **No provenance** — `EffectCollection` fields (`annotator`, `varcode_version`, ...) come in 3b.
- **No fast-path extraction** — 3c.
- **No `SequenceDiffEffectAnnotator`** — 3d, the one with actual new classifier logic.

## Test plan

- [x] Variant.effects() with no kwarg matches effects(annotator=\"legacy\") output
- [x] String name, instance, and `None` all accepted
- [x] Typo-string raises `KeyError` with known-names list in message
- [x] VariantCollection.effects(annotator=...) threads through
- [x] `use_annotator(instance)` swaps default in scope, registers temporarily, cleans up on exit
- [x] `use_annotator(\"registered_name\")` preserves existing registration after exit
- [x] `use_annotator` affects `Variant.effects()` when no explicit kwarg passed
- [x] `use_annotator(instance_without_name)` raises `ValueError`
- [x] `resolve_annotator` passes instances through, resolves None to current default

595 tests pass (was 584); ruff clean.

## Linked

- #271 tracking issue
- #304 staging discussion (this PR is 3a)