### PR TITLE
#271 stage 3b: EffectCollection annotator provenance + CSV round-trip

### DIFF
--- a/tests/test_csv_roundtrip.py
+++ b/tests/test_csv_roundtrip.py
@@ -299,6 +299,93 @@ def test_effect_collection_from_csv_raises_without_genome_or_header():
         os.unlink(path)
 
 
+# -----------------------------------------------------------------------
+# Annotator provenance round-trip (#271 stage 3b)
+# -----------------------------------------------------------------------
+
+
+def test_effect_collection_carries_annotator_provenance():
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    ec = variant.effects()
+    # predict_variant_effects should have populated the fields from
+    # the resolved annotator (legacy by default).
+    assert ec.annotator == "legacy"
+    assert ec.annotator_version is not None
+    assert ec.annotated_at is not None
+
+
+def test_effect_collection_to_csv_emits_annotator_header():
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    ec = variant.effects()
+    path = _tmp_csv()
+    try:
+        ec.to_csv(path)
+        with open(path) as f:
+            head = "".join(f.readline() for _ in range(8))
+    finally:
+        os.unlink(path)
+    assert "# annotator=legacy" in head
+    assert "# annotator_version=" in head
+    assert "# annotated_at=" in head
+
+
+def test_effect_collection_from_csv_recovers_annotator_metadata():
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    original = variant.effects()
+    path = _tmp_csv()
+    try:
+        original.to_csv(path)
+        loaded = EffectCollection.from_csv(path)
+    finally:
+        os.unlink(path)
+    assert loaded.annotator == original.annotator
+    assert loaded.annotator_version == original.annotator_version
+    # annotated_at is preserved verbatim from the header, not
+    # refreshed — so the restored collection remembers when it was
+    # originally produced.
+    assert loaded.annotated_at == original.annotated_at
+
+
+def test_effect_collection_clone_preserves_annotator_metadata():
+    # filter / groupby / clone_with_new_elements flow through to_dict;
+    # the provenance fields must survive so derived collections don't
+    # lose their origin.
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    ec = variant.effects()
+    cloned = ec.clone_with_new_elements(list(ec.elements))
+    assert cloned.annotator == ec.annotator
+    assert cloned.annotator_version == ec.annotator_version
+    assert cloned.annotated_at == ec.annotated_at
+
+
+def test_effect_collection_from_csv_warns_on_annotator_mismatch():
+    import warnings
+    variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
+    ec = variant.effects()
+    path = _tmp_csv()
+    try:
+        ec.to_csv(path)
+        # Rewrite the header to claim a different annotator.
+        with open(path) as f:
+            lines = f.readlines()
+        with open(path, "w") as f:
+            for line in lines:
+                if line.startswith("# annotator="):
+                    f.write("# annotator=sequence_diff\n")
+                else:
+                    f.write(line)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            EffectCollection.from_csv(path)
+    finally:
+        os.unlink(path)
+
+    messages = [str(w.message) for w in caught]
+    assert any(
+        "sequence_diff" in m and "legacy" in m for m in messages), (
+        "Expected a warning about annotator mismatch, got: %r" % messages)
+
+
 def test_csv_to_csv_without_header_is_opt_out_legacy_format():
     # to_csv(include_header=False) produces a plain CSV for legacy
     # consumers that don't tolerate comment lines.

--- a/varcode/annotators/__init__.py
+++ b/varcode/annotators/__init__.py
@@ -64,6 +64,11 @@ class EffectAnnotator(Protocol):
     * :meth:`annotate_on_transcript` — the per-transcript entry
       point.
 
+    Optionally exposes ``version`` (string) — used in CSV provenance
+    headers so readers can detect when a serialized collection came
+    from a different annotator version. Built-in annotators track
+    varcode's version; third-party annotators expose their own.
+
     The protocol is intentionally narrow at this stage — additional
     methods (``annotate_collection``, ``annotate_with_context``) will
     be added as downstream work needs them. The contract is

--- a/varcode/annotators/legacy.py
+++ b/varcode/annotators/legacy.py
@@ -20,11 +20,19 @@ then, this annotator is the default and produces byte-for-byte
 identical output to ``Variant.effect_on_transcript(transcript)``.
 """
 
+from ..version import __version__ as _varcode_version
+
 
 class LegacyEffectAnnotator:
     """Wraps :func:`varcode.effects.predict_variant_effect_on_transcript`."""
 
     name = "legacy"
+
+    version = _varcode_version
+    """Built-in annotators track varcode's own version. Third-party
+    annotators (isovar's plugin, exacto's plugin) expose their own
+    version string here; CSV provenance headers and round-trip
+    warnings read from this field. See #271."""
 
     supports = frozenset({"snv", "indel", "mnv"})
     """Variant kinds this annotator handles. Splice-possibility

--- a/varcode/csv_helpers.py
+++ b/varcode/csv_helpers.py
@@ -81,26 +81,59 @@ def warn_on_version_drift(header_metadata, current_version, source_path):
     annotation logic can change — the effects reconstructed on read
     may differ from the ones that were written.
 
-    When #271 lands ``annotator`` / ``annotator_version``, that check
-    belongs here too.
+    Also checks ``annotator`` and ``annotator_version`` when both are
+    present in the header: warns when the CSV was written with a
+    different annotator than the current default, or when the
+    annotator version has a major mismatch (#271 stage 3b).
     """
     import warnings
 
     serialized = header_metadata.get("varcode_version")
-    if not serialized:
-        return
-    serialized_mm = _parse_major_minor(serialized)
-    current_mm = _parse_major_minor(current_version)
-    if serialized_mm is None or current_mm is None:
-        return
-    if serialized_mm[0] != current_mm[0]:
-        warnings.warn(
-            "CSV at %s was written by varcode %s but you are reading it "
-            "with varcode %s. Because from_csv re-runs annotation on "
-            "read, results may differ across major versions. See "
-            "openvax/varcode#275 for context." % (
-                source_path, serialized, current_version)
-        )
+    if serialized:
+        serialized_mm = _parse_major_minor(serialized)
+        current_mm = _parse_major_minor(current_version)
+        if serialized_mm is not None and current_mm is not None:
+            if serialized_mm[0] != current_mm[0]:
+                warnings.warn(
+                    "CSV at %s was written by varcode %s but you are reading it "
+                    "with varcode %s. Because from_csv re-runs annotation on "
+                    "read, results may differ across major versions. See "
+                    "openvax/varcode#275 for context." % (
+                        source_path, serialized, current_version))
+
+    serialized_annotator = header_metadata.get("annotator")
+    if serialized_annotator:
+        # Lazy import to avoid a load-time cycle with varcode.annotators.
+        from .annotators.registry import get_default_annotator
+        current_annotator = getattr(get_default_annotator(), "name", None)
+        if current_annotator and serialized_annotator != current_annotator:
+            warnings.warn(
+                "CSV at %s was written by annotator %r but the current "
+                "default annotator is %r. from_csv re-runs annotation on "
+                "read, so reconstructed effects reflect %r, not the "
+                "annotator that originally produced the CSV. Use "
+                "varcode.use_annotator(%r) around from_csv if you need "
+                "the original annotator's output." % (
+                    source_path, serialized_annotator, current_annotator,
+                    current_annotator, serialized_annotator))
+
+    serialized_annotator_version = header_metadata.get("annotator_version")
+    if serialized_annotator_version:
+        from .annotators.registry import get_default_annotator
+        current_annotator_version = getattr(
+            get_default_annotator(), "version", None)
+        if current_annotator_version:
+            serialized_mm = _parse_major_minor(serialized_annotator_version)
+            current_mm = _parse_major_minor(current_annotator_version)
+            if (serialized_mm is not None and current_mm is not None
+                    and serialized_mm[0] != current_mm[0]):
+                warnings.warn(
+                    "CSV at %s was written by annotator version %s; "
+                    "current annotator version is %s (major mismatch). "
+                    "Reconstructed effects may differ from the originals." % (
+                        source_path,
+                        serialized_annotator_version,
+                        current_annotator_version))
 
 
 def write_metadata_header(file_obj, metadata):

--- a/varcode/effects/effect_collection.py
+++ b/varcode/effects/effect_collection.py
@@ -44,7 +44,15 @@ class EffectCollection(Collection):
     Collection of MutationEffect objects and helpers for grouping or filtering
     them.
     """
-    def __init__(self, effects, distinct=False, sort_key=None, sources=set([])):
+    def __init__(
+            self,
+            effects,
+            distinct=False,
+            sort_key=None,
+            sources=set([]),
+            annotator=None,
+            annotator_version=None,
+            annotated_at=None):
         """
         Parameters
         ----------
@@ -63,6 +71,21 @@ class EffectCollection(Collection):
 
         sources : set
             Set of files from which this collection was generated.
+
+        annotator : str or None
+            Name of the :class:`EffectAnnotator` that produced these
+            effects. Populated automatically by
+            :func:`predict_variant_effects`; ``None`` for collections
+            built by hand. See openvax/varcode#271.
+
+        annotator_version : str or None
+            Version string of the annotator (typically the varcode
+            version for built-in annotators). ``None`` when
+            ``annotator`` is None.
+
+        annotated_at : str or None
+            ISO-8601 UTC timestamp recording when the annotation ran.
+            Populated by :func:`predict_variant_effects`.
         """
         if sort_key is None:
             sort_key = _default_effect_sort_key
@@ -78,19 +101,34 @@ class EffectCollection(Collection):
         # elements so that iterating and reading `.effects` produce
         # the same order.  See openvax/varcode#220.
         self.effects = self.elements
+        self.annotator = annotator
+        self.annotator_version = annotator_version
+        self.annotated_at = annotated_at
 
     def to_dict(self):
         return dict(
             effects=self.effects,
             sort_key=self.sort_key,
             distinct=self.distinct,
-            sources=self.sources)
+            sources=self.sources,
+            annotator=self.annotator,
+            annotator_version=self.annotator_version,
+            annotated_at=self.annotated_at)
 
     def clone_with_new_elements(self, new_elements):
+        # Forward annotator provenance explicitly — sercol's base
+        # clone_with_new_elements only carries distinct/sort_key/sources,
+        # so without this the cloned collection would silently lose
+        # its #271 provenance metadata.
         return Collection.clone_with_new_elements(
             self,
             new_elements,
-            rename_dict={"elements": "effects"})
+            rename_dict={"elements": "effects"},
+            extra_kwargs={
+                "annotator": self.annotator,
+                "annotator_version": self.annotator_version,
+                "annotated_at": self.annotated_at,
+            })
 
     def groupby_variant(self):
         return self.groupby(key_fn=lambda effect: effect.variant)
@@ -363,6 +401,11 @@ class EffectCollection(Collection):
         metadata = OrderedDict()
         metadata["varcode_version"] = _varcode_version
         metadata["reference_name"] = self._serialized_reference_name()
+        # Annotator provenance (#271 stage 3b). Each field is skipped
+        # when None by write_metadata_header.
+        metadata["annotator"] = self.annotator
+        metadata["annotator_version"] = self.annotator_version
+        metadata["annotated_at"] = self.annotated_at
         with open(path, "w") as f:
             write_metadata_header(f, metadata)
             df.to_csv(f, index=False)
@@ -501,4 +544,9 @@ class EffectCollection(Collection):
                 continue
             transcript = resolved_genome.transcript_by_id(str(transcript_id))
             effects.append(variant.effect_on_transcript(transcript))
-        return cls(effects=effects)
+        return cls(
+            effects=effects,
+            annotator=header.get("annotator"),
+            annotator_version=header.get("annotator_version"),
+            annotated_at=header.get("annotated_at"),
+        )

--- a/varcode/effects/effect_prediction.py
+++ b/varcode/effects/effect_prediction.py
@@ -79,6 +79,8 @@ def predict_variant_effects(
     # load time, so we defer to break the cycle.
     from ..annotators.registry import resolve_annotator
     annotator_instance = resolve_annotator(annotator)
+    annotator_name = getattr(annotator_instance, "name", None)
+    annotator_version = getattr(annotator_instance, "version", None)
     # if this variant isn't overlapping any genes, return a
     # Intergenic effect
     # TODO: look for nearby genes and mark those as Upstream and Downstream
@@ -124,7 +126,14 @@ def predict_variant_effects(
                                 variant, transcript, error)
                             effect = Failure(variant, transcript)
                     effects.append(effect)
-    collection = EffectCollection(effects)
+    from datetime import datetime, timezone
+    annotated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    collection = EffectCollection(
+        effects,
+        annotator=annotator_name,
+        annotator_version=annotator_version,
+        annotated_at=annotated_at,
+    )
     if splice_outcomes:
         # Lazy import to avoid circular deps; splice_outcomes lives at
         # the package root and consumes effect_classes.


### PR DESCRIPTION
Second plumbing PR for #271. Records which annotator produced an `EffectCollection` and preserves that through CSV serialization, round-trip loading, and clone operations.

## What ships

- `EffectCollection.__init__` takes three optional provenance kwargs: `annotator`, `annotator_version`, `annotated_at`.
- `predict_variant_effects` populates them automatically from the resolved annotator + `datetime.now(UTC)`. Existing callers need no changes.
- `clone_with_new_elements` forwards them via `extra_kwargs` (sercol's base drops unknown kwargs, so derived collections from `filter` / `groupby` / `wrap_splice_effects_in_collection` would otherwise silently lose their origin — regression-locked by a test).
- `to_csv` emits three new `#`-prefixed header lines; `from_csv` reads them and reattaches.
- `warn_on_version_drift` now covers annotator-name and annotator-version mismatches in addition to the existing `varcode_version` check. The annotator-mismatch warning tells the user to wrap `from_csv` in `use_annotator(...)` if they want the original annotator's output.
- `LegacyEffectAnnotator` now exposes `version` (tracks varcode's version at import time); the `EffectAnnotator` Protocol docstring documents `version` as an optional third field.

## What this does NOT do

- No JSON header metadata yet — only CSV. The `to_json` / `from_json` path sits on top of `Serializable` and already round-trips dataclass attributes, so it gets the provenance via `to_dict`. Explicit JSON tests can land with 3c if needed.
- No `reference` field (distinct from the existing `reference_name`) — the current `reference_name` in the header already plays that role.
- No changes to the default annotator or any algorithmic behaviour.

## Test plan

5 new tests in `tests/test_csv_roundtrip.py`:

- [x] `EffectCollection.annotator` / `annotator_version` / `annotated_at` populated after `predict_variant_effects`
- [x] `to_csv` emits all three header lines
- [x] `from_csv` recovers all three fields verbatim (including the original timestamp)
- [x] `clone_with_new_elements` preserves provenance (sercol-drop regression check)
- [x] `from_csv` emits a warning when the CSV's annotator differs from the current default

600 tests pass (was 595); ruff clean.

Linked: #271 tracking, #304 staging (this PR is 3b).