### PR TITLE
[WIP #271 stage 3d] SequenceDiffEffectAnnotator scaffolding + SV design notes

### DIFF
--- a/docs/effect_annotation.md
+++ b/docs/effect_annotation.md
@@ -1,0 +1,291 @@
+# Effect annotation
+
+How varcode turns a variant into one or more `MutationEffect`
+objects, and how the pieces fit together across the basic case,
+splice-disrupting variants, and (eventually) structural variants.
+
+## The pipeline
+
+```
+Variant ─(Annotator)─> MutantTranscript(s) ─(Classifier)─> Effect(s)
+                              │
+                              └── wrapped in MultiOutcomeEffect
+                                   when >1 plausible outcome
+                                       │
+                                       └── narrowed by RNA evidence
+                                           (isovar / Exacto plug-ins)
+```
+
+Single DNA event can produce one or more plausible mutant
+proteins. varcode represents each concrete mutant as a
+`MutantTranscript`. When the DNA alone is ambiguous, the
+possibility set is wrapped in a `MultiOutcomeEffect`. RNA
+evidence (when available) narrows the set.
+
+## The four primitives
+
+| Primitive | What it represents | Module |
+|---|---|---|
+| `MutationEffect` (and subclasses) | One deterministic consequence: `Substitution`, `Silent`, `FrameShift`, `PrematureStop`, ... | `varcode.effects.effect_classes` |
+| `MutantTranscript` | One concrete mutant protein with edit provenance and the annotator that produced it | `varcode.mutant_transcript` |
+| `MultiOutcomeEffect` | Possibility set: a sequence of candidate outcomes ordered by a prior (most likely first) | `varcode.effects.effect_classes` |
+| `EffectAnnotator` | How a variant becomes effects or mutant transcripts | `varcode.annotators` |
+
+Everything in effect annotation is an implementation or consumer
+of one of those four.
+
+## Basic usage
+
+```python
+import varcode
+
+variants = varcode.load_maf("my_variants.maf")
+
+# Simplest path: get an EffectCollection.
+effects = variants.effects()
+effects.top_priority_effect()
+
+# Filter by transcript consequence.
+nonsilent = effects.drop_silent_and_noncoding()
+```
+
+`variants.effects()` calls the current default annotator
+(`"legacy"`) on every `(variant, transcript)` pair and returns
+an `EffectCollection`. Each element is a `MutationEffect`
+subclass — `Substitution`, `Silent`, `PrematureStop`, and so
+on.
+
+## Splice-disrupting variants: two representations
+
+When a variant sits in the canonical splice window (last 3
+exonic bases, first 3–6 intronic, canonical donor/acceptor),
+varcode recognizes it as splice-disrupting. Two ways the
+effect is expressed, at different richness levels.
+
+### Default: lightweight 2-outcome form
+
+```python
+variant = Variant("17", 43082575 - 5, "C", "T", "GRCh38")
+effect = variant.effect_on_transcript(transcript)
+# ExonicSpliceSite(...)
+#   .alternate_effect -> Substitution(...)  # if splicing proceeds
+```
+
+`ExonicSpliceSite` carries `alternate_effect`: the coding
+consequence that applies *if splicing still works*. Exactly
+two outcomes, represented as a primary effect + one
+alternate field. Cheap. Ships unconditionally.
+
+`SpliceDonor`, `SpliceAcceptor`, and `IntronicSpliceSite`
+don't expose `alternate_effect` today because the variant
+is intronic — there's no coding consequence to attach.
+
+### Opt-in: full possibility set
+
+```python
+effects = variant.effects(splice_outcomes=True)
+# SpliceOutcomeSet(...) replaces the splice effect
+#   .candidates ordered most-plausible-first:
+#     SpliceCandidate(NORMAL_SPLICING, plausibility=0.1,
+#                     coding_effect=Substitution(...))
+#     SpliceCandidate(EXON_SKIPPING, plausibility=0.5,
+#                     coding_effect=Deletion(...))
+#     SpliceCandidate(INTRON_RETENTION, plausibility=0.3)
+#     SpliceCandidate(CRYPTIC_DONOR, plausibility=0.1)
+```
+
+`SpliceOutcomeSet` replaces the splice effect with a set of
+candidate outcomes, each carrying a plausibility score
+(hand-tuned heuristic, not a probability) and — where
+computable from cDNA — a concrete `coding_effect`. The
+`NORMAL_SPLICING` candidate carries the same information as
+`alternate_effect` in the default form.
+
+When you opt in, `SpliceDonor` / `SpliceAcceptor` /
+`IntronicSpliceSite` also get wrapped, so every splice-
+disrupting variant produces a `SpliceOutcomeSet`.
+
+### Relationship between the two
+
+`SpliceOutcomeSet` is the N-outcome case of the same idea
+`alternate_effect` expresses with 2 outcomes. The
+`NORMAL_SPLICING` candidate is `alternate_effect` promoted to
+first-class; the other candidates express alternatives you
+don't see from the default form. Both are progressions of
+the same pattern:
+
+| # candidates | Class |
+|---|---|
+| 1 | plain `Substitution` / `Silent` / etc. — not wrapped |
+| 2 | `ExonicSpliceSite` with `alternate_effect` |
+| N (≥3) | `SpliceOutcomeSet` (opt-in via `splice_outcomes=True`) |
+
+After the planned `ExonicSpliceSite` retrofit in [#299][i299],
+all three will be `MultiOutcomeEffect` subclasses. Downstream
+code will be able to write `isinstance(e, MultiOutcomeEffect)`
+and iterate `.candidates` uniformly, regardless of richness
+level. `alternate_effect` becomes a derived property available
+on both `ExonicSpliceSite` (the 2-outcome case) and
+`SpliceOutcomeSet` (where it resolves to the
+`NORMAL_SPLICING` candidate's `coding_effect`). Same field,
+same meaning, works on both shapes — no parallel mechanism.
+
+### Variants in the CDS and in the splice window simultaneously
+
+A missense at the last exonic base is biologically *both* a
+splice effect (disrupts the splice signal) AND a protein-level
+coding effect (changes a residue). This is exactly what
+`ExonicSpliceSite` exists for:
+
+```python
+# Default: 2 outcomes
+effect = ExonicSpliceSite
+effect.alternate_effect      # the coding change, if splicing proceeds
+
+# Opt-in: N outcomes including the coding change as NORMAL_SPLICING
+for c in SpliceOutcomeSet.candidates:
+    if c.outcome is SpliceOutcome.NORMAL_SPLICING:
+        coding_change = c.coding_effect
+```
+
+Both representations encode the "splice + coding" case; the
+richer `SpliceOutcomeSet` just adds the other candidates
+(exon skipping, intron retention, cryptic splice).
+
+### What varcode does NOT classify as splice-affecting today
+
+The splice classifier is **position-based** — it fires on the
+canonical window and nothing else. Variants that affect
+splicing through *sequence-based* signals aren't flagged:
+
+- **Exonic splicing enhancer / silencer (ESE / ESS) disruption**
+  mid-exon: ~6–10 nt motifs that recruit or repel SR proteins.
+  A missense that disrupts an ESE can cause exon skipping but
+  gets classified as plain `Substitution` today.
+- **Branch points** ~20–50 nt upstream of the acceptor.
+- **Deep intronic cryptic splice sites** far from canonical
+  boundaries.
+
+Detecting these needs ML predictors (SpliceAI, Pangolin,
+MMSplice, SpliceTransformer) trained on RNA-seq, or direct RNA
+evidence. Tracked as [#297][i297].
+
+## Annotator selection
+
+Two annotators coexist behind the `EffectAnnotator` protocol:
+
+| Annotator | Algorithm | Status |
+|---|---|---|
+| `LegacyEffectAnnotator` | Offset arithmetic against the reference CDS | Default |
+| `SequenceDiffEffectAnnotator` | Materializes `MutantTranscript`, translates, diffs against reference protein | [#309][i309] — WIP |
+
+Both emit the same `MutationEffect` classes, share a fast path
+for trivial SNVs, and are interchangeable at the output level.
+The difference is internal: sequence-diff catches
+boundary-codon cases and frameshift realignments that offset
+arithmetic can miss.
+
+```python
+# Default (legacy):
+effects = variant.effects()
+
+# Opt into sequence-diff (once available):
+effects = variant.effects(annotator="sequence_diff")
+
+# Scoped default swap:
+with varcode.use_annotator("sequence_diff"):
+    effects = variant_collection.effects()
+```
+
+Third-party annotators (isovar, Exacto) register via the
+registry:
+
+```python
+varcode.register_annotator(my_annotator)
+variant.effects(annotator=my_annotator.name)
+```
+
+Any object exposing `name` / `supports` / `version` /
+`annotate_on_transcript` satisfies the protocol.
+
+## Provenance
+
+Every `EffectCollection` produced by `predict_variant_effects`
+records:
+
+- `annotator` — name of the annotator that ran (`"legacy"`,
+  `"sequence_diff"`, etc.)
+- `annotator_version` — version string
+- `annotated_at` — ISO-8601 UTC timestamp
+
+Fields are preserved through `clone_with_new_elements`
+(so `filter` / `groupby` keep them), written to CSV headers
+(`# annotator=legacy`, etc.), and recovered by `from_csv`
+verbatim — restored collections remember *when* they were
+originally produced.
+
+A mismatch between the CSV's annotator and the current default
+raises a warning on load; wrap `from_csv` in
+`use_annotator(<csv's annotator>)` if you need the original
+annotator's output specifically.
+
+## Structural variants (roadmap)
+
+The current `MutantTranscript` handles point variants and
+indels. Fusions, translocations, inversions, and large
+duplications need a multi-source generalization — a
+`reference_segments` alternative to the single
+`reference_transcript` field, where a fusion is two segments
+from two transcripts and a translocation-to-intergenic is one
+transcript segment plus a genomic-interval segment.
+
+One DNA event can produce many candidate ORFs that only RNA
+evidence can resolve (long-read transcript assembly from
+Exacto, assembled contigs from isovar). SV annotators return
+`List[MutantTranscript]` wrapped in a `MultiOutcomeEffect`;
+each class gets a prior over outcomes so DNA-only callers can
+still read `.most_likely`:
+
+- Splice outcomes → existing plausibility tables.
+- Fusions → canonical-transcript preferred, known recurrent
+  junctions short-circuit to possibility-set size 1.
+- Translocations → rank by `(in-frame, ORF length,
+  canonical-transcript involvement)`.
+
+`classify_from_protein_diff` (the 3d classifier) is unchanged
+for SVs — once the mutant protein is materialized,
+classification is the same. The difference is upstream: how
+you build the `MutantTranscript`.
+
+Tracked across [#252][i252] (fusions), [#257][i257] (SV
+types), [#259][i259] (RNA evidence), [#299][i299]
+(MultiOutcomeEffect formalization), [#305][i305]
+(splice_outcomes rewrite on MutantTranscript).
+
+## Downstream consumers
+
+- **topiary** consumes mutant proteins as `ProteinFragment`.
+  The `MutantTranscript` → `ProteinFragment` conversion is 1:1
+  at the prediction boundary: `fragment.sequence =
+  mt.mutant_protein_sequence`; provenance fields carry through
+  as fragment metadata. Use `MutantTranscript` for
+  transcript-level reasoning (splicing, UTR readthrough,
+  codon tables); convert at the prediction boundary.
+- **vaxrank** consumes the `EffectCollection` +
+  `ProteinFragment` pair to score neoantigens. After
+  [#305][i305], splice outcomes deliver `MutantTranscript`s
+  directly; after fusion support, SV events deliver
+  `MultiOutcomeEffect[List[MutantTranscript]]` consumable the
+  same way.
+- **isovar** / **Exacto** plug in as registered annotators,
+  producing `MutantTranscript`s from assembled RNA evidence
+  rather than inferred from DNA alone.
+
+[i252]: https://github.com/openvax/varcode/issues/252
+[i257]: https://github.com/openvax/varcode/issues/257
+[i259]: https://github.com/openvax/varcode/issues/259
+[i271]: https://github.com/openvax/varcode/issues/271
+[i297]: https://github.com/openvax/varcode/issues/297
+[i299]: https://github.com/openvax/varcode/issues/299
+[i305]: https://github.com/openvax/varcode/issues/305
+[i309]: https://github.com/openvax/varcode/issues/309

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,10 @@ for a longer walkthrough and the effect-class table.
 
 ## Feature guides
 
+- [**Effect annotation**](effect_annotation.md) — how variants
+  become effects, splice outcome representations, pluggable
+  annotators, possibility sets for ambiguous outcomes, and the
+  SV-extensibility roadmap. Start here.
 - [**Genotypes and sample-aware queries**](genotype.md) — per-sample
   zygosity on multi-sample VCFs. New in 2.3.
 - [**CSV round-trip and metadata headers**](csv.md) — `to_csv` /

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ include = ["varcode", "varcode.*"]
 varcode-genes = "varcode.cli.genes_script:main"
 varcode = "varcode.cli.effects_script:main"
 
+[tool.pytest.ini_options]
+markers = [
+    "parity: parity harness for SequenceDiffEffectAnnotator (WIP #271 stage 3d, #309). Run explicitly with `pytest -m parity` once the classifier lands.",
+]
+
 [tool.ruff.lint]
 select = ["E", "F"]
 ignore = ["F821", "E501", "F841", "E731", "E741", "E722", "E721"]

--- a/tests/test_sequence_diff_parity.py
+++ b/tests/test_sequence_diff_parity.py
@@ -1,0 +1,59 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parity harness for SequenceDiffEffectAnnotator vs LegacyEffectAnnotator
+(openvax/varcode#271 stage 3d, #309).
+
+**WIP — skipped in CI.** The harness skeleton is in place so the
+validation corpus and assertion shape can be discussed before the
+classifier lands. The target gate for 3d merge is:
+
+    for variant in CORPUS:
+        for transcript in variant.transcripts:
+            legacy = LegacyEffectAnnotator().annotate_on_transcript(
+                variant, transcript)
+            sdiff = SequenceDiffEffectAnnotator().annotate_on_transcript(
+                variant, transcript)
+            assert type(legacy) is type(sdiff)
+            assert legacy.short_description == sdiff.short_description
+
+Any intentional divergence (a legacy bug that sequence_diff corrects)
+must be called out explicitly in ``EXPECTED_DIFFS`` with a comment
+linking the issue that documents it.
+"""
+
+import pytest
+
+
+pytest.skip(
+    "SequenceDiffEffectAnnotator is scaffolding only; parity harness "
+    "activates with #309's classifier PR.",
+    allow_module_level=True,
+)
+
+
+# Placeholder corpus — 3d will populate from:
+#   * tests/data/somatic_hg19_14muts.vcf
+#   * the BRCA1/CFTR fixtures used in test_effect_classes.py
+#   * the splice-site corpus from test_splice_site_effects.py
+#   * the MT cases from tests/test_mitochondrial.py
+CORPUS = []
+
+# Variants where sequence_diff and legacy intentionally differ. Each
+# entry is a (variant_key, reason_issue_url) pair. Keep empty at merge
+# time — any real disagreements must be triaged, not silently accepted.
+EXPECTED_DIFFS = {}
+
+
+def test_sequence_diff_matches_legacy_on_corpus():
+    """Byte-for-byte parity on the validation corpus. Gate for 3d merge."""
+    pass  # filled in by #309

--- a/tests/test_sequence_diff_parity.py
+++ b/tests/test_sequence_diff_parity.py
@@ -26,13 +26,71 @@ classifier lands. The target gate for 3d merge is:
             assert type(legacy) is type(sdiff)
             assert legacy.short_description == sdiff.short_description
 
-Any intentional divergence (a legacy bug that sequence_diff corrects)
-must be called out explicitly in ``EXPECTED_DIFFS`` with a comment
-linking the issue that documents it.
+Rollout policy
+--------------
+
+During the **initial corpus build** (before 3d merges), parity
+deltas are logged as INFO via ``logging.info`` rather than asserted.
+The goal at that stage is to **review the parity contract** — each
+delta is either:
+
+  (a) a sequence-diff bug that needs fixing before merge, or
+  (b) a legacy bug that sequence-diff corrects (pinned in
+      ``EXPECTED_DIFFS`` with an issue link).
+
+Only after every delta has been triaged does the harness flip to
+``assert``. At that point the parity contract is committed: any
+new delta is a regression.
+
+Each entry in ``EXPECTED_DIFFS`` is a
+``(variant_key, issue_url, reason)`` tuple. Empty at merge
+time — any real disagreement must be resolved before the harness
+becomes a gate.
+
+Corpus composition
+------------------
+
+~500 variants pulled from existing test fixtures plus targeted
+edge cases from the PR #310 review:
+
+  Existing fixtures:
+    * tests/data/somatic_hg19_14muts.vcf (14 somatic SNVs)
+    * BRCA1/CFTR coding SNVs / MNVs from test_effect_classes.py
+    * Splice-site corpus from test_splice_site_effects.py
+    * MT cases from test_mitochondrial.py
+
+  Edge cases to pin (from vaxrank feedback):
+    * AlternateStartCodon + downstream missense in the same
+      variant — verifies the "only taken when the only change
+      is at codon 0" rule.
+    * MT PrematureStop and MT StopLoss — verifies the codon
+      table routes through apply_variant_to_transcript correctly
+      end-to-end.
+    * StopLoss with short downstream stop (the extension hits a
+      stop a few residues into the 3'UTR) — verifies the bounded
+      readthrough case, not just the unbounded one.
+    * Pure insertion of 3 residues that match flanking residues —
+      verifies trim_shared_flanking_strings doesn't over-trim.
+      Legacy regressed on this pre-#201.
+    * Phased MNP where two SNVs hit the same codon — verifies
+      the classifier when (ref_delta, alt_delta) are both length
+      1 but represent a compound substitution.
+    * Variant at last exonic base that also changes an amino
+      acid — verifies the splice-adjacency gate's dual-dispatch
+      behaviour (see sequence_diff._variant_is_splice_adjacent
+      docstring for the contract).
+    * A variant whose effect_type changed across varcode major
+      versions (legacy ComplexSubstitution ↔ Substitution) —
+      pinned explicitly so parity deltas are intentional.
 """
 
 import pytest
 
+
+# The parity harness is expensive and WIP. Mark it so it can be
+# selected explicitly (`pytest -m parity`) once populated, without
+# slowing the default suite run.
+pytestmark = pytest.mark.parity
 
 pytest.skip(
     "SequenceDiffEffectAnnotator is scaffolding only; parity harness "
@@ -41,16 +99,14 @@ pytest.skip(
 )
 
 
-# Placeholder corpus — 3d will populate from:
-#   * tests/data/somatic_hg19_14muts.vcf
-#   * the BRCA1/CFTR fixtures used in test_effect_classes.py
-#   * the splice-site corpus from test_splice_site_effects.py
-#   * the MT cases from tests/test_mitochondrial.py
+# Placeholder corpus — 3d will populate from the sources documented
+# in the module docstring.
 CORPUS = []
 
 # Variants where sequence_diff and legacy intentionally differ. Each
-# entry is a (variant_key, reason_issue_url) pair. Keep empty at merge
-# time — any real disagreements must be triaged, not silently accepted.
+# entry: (variant_key, reason_issue_url, reason_description).
+# Empty at merge time — any real disagreements must be triaged, not
+# silently accepted.
 EXPECTED_DIFFS = {}
 
 

--- a/varcode/annotators/sequence_diff.py
+++ b/varcode/annotators/sequence_diff.py
@@ -1,0 +1,173 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SequenceDiffEffectAnnotator — classify effects from protein diff
+instead of offset arithmetic (openvax/varcode#271 stage 3d, #309).
+
+**WORK IN PROGRESS — not registered in the annotator registry,
+not functional.** This module currently ships a class skeleton,
+a classifier signature with a documented decision table, and
+TODOs. See the PR description and #309 for the rollout plan.
+
+Algorithm
+---------
+
+1. **Gate**: non-coding / incomplete transcripts and splice-adjacent
+   variants go straight to :class:`LegacyEffectAnnotator`. Sequence-
+   diff owns protein-level diff classification; splice classification
+   stays offset-based (#305 will rewrite that module on top of
+   :class:`MutantTranscript` without sequence-diff's involvement).
+
+2. **Fast path**: trivial single-codon SNVs dispatch to the shared
+   :func:`try_fast_path_snv` helper (stage 3c). Both annotators hit
+   the same code here so they can't diverge on the common case.
+
+3. **Slow path**: materialize a :class:`MutantTranscript` via
+   :func:`apply_variant_to_transcript`, translate its cDNA with the
+   transcript's codon table (mt-aware via #294), and compare the
+   resulting protein to the reference. The minimal edit comes from
+   :func:`trim_shared_flanking_strings`; classification is a
+   finite decision table (see :func:`classify_from_protein_diff`).
+
+Generalization to structural variants (forward-looking)
+-------------------------------------------------------
+
+The current :class:`MutantTranscript` carries a single
+``reference_transcript``, which expresses point variants and indels
+cleanly but doesn't fit SV-class events:
+
+* **Gene fusions** compose segments from two reference transcripts.
+  See #252.
+* **Translocations** can join a transcript to an intergenic region,
+  producing many candidate ORFs resolvable only with RNA evidence
+  (long-read transcript assembly in particular). See #257, #259.
+* **Large inversions / duplications / tandem repeats** can produce
+  multiple plausible mutant transcripts per DNA event.
+
+The cross-cutting pattern is **one DNA event → possibility set of
+plausible mutant proteins**, narrowed by RNA evidence (#259) — the
+same shape as splice outcomes (#262/#305). The planned extensions:
+
+1. ``MutantTranscript`` grows a ``reference_segments`` alternative
+   to ``reference_transcript``, each segment a ``(transcript,
+   cdna_range)``. Fusion = two segments from different transcripts;
+   translocation-to-intergenic = one transcript segment plus a
+   genomic-interval segment.
+2. An SV-annotator returns ``List[MutantTranscript]`` (or a
+   :class:`MultiOutcomeEffect` wrapper per the #299 generalization)
+   when outcomes are ambiguous. RNA evidence narrows the set at
+   a later stage.
+3. The :func:`classify_from_protein_diff` decision table below is
+   unchanged for SVs — once the mutant protein is materialized,
+   classification is the same. The difference is upstream: how
+   you get there.
+
+None of this SV work is in scope for 3d (#309). Calling it out
+here so the point-variant design doesn't close off the SV path.
+"""
+
+from ..version import __version__ as _varcode_version
+
+# Intentional: `apply_variant_to_transcript` will be imported here in
+# 3d's classifier. Keeping the import path documented in the module
+# docstring only for now to avoid a ruff F401 on the WIP scaffolding.
+
+
+class SequenceDiffEffectAnnotator:
+    """Classify effects by diffing translated mutant protein against
+    the reference protein. **WIP — skeleton only.** See module
+    docstring.
+    """
+
+    name = "sequence_diff"
+    version = _varcode_version
+    supports = frozenset({"snv", "indel", "mnv"})
+    """Variant kinds handled directly. Splice effects delegate to
+    legacy; SV-class variants (``sv``, ``fusion``, ``translocation``,
+    ``inversion``, ``duplication``) get added once the
+    ``reference_segments`` generalization lands — see module
+    docstring."""
+
+    def annotate_on_transcript(self, variant, transcript):
+        """Dispatch a single (variant, transcript) pair.
+
+        **Not implemented.** Stage 3d will fill this in against the
+        validation corpus described in #309. Raises
+        :class:`NotImplementedError` so accidental registration
+        catches you early.
+        """
+        raise NotImplementedError(
+            "SequenceDiffEffectAnnotator is scaffolding only in %s. "
+            "Use LegacyEffectAnnotator until #309 lands the "
+            "classifier." % _varcode_version)
+
+
+def classify_from_protein_diff(mutant_transcript, variant, transcript):
+    """Classify a :class:`MutationEffect` from a reference/mutant
+    protein pair.
+
+    **Not implemented.** Decision table the implementation will follow
+    (from #309), applied after
+    :func:`trim_shared_flanking_strings` has reduced
+    ``(reference_protein, mutant_protein)`` to the minimal edit
+    ``(ref_delta, alt_delta)`` with shared ``prefix`` and ``suffix``:
+
+    +----------------------------------------------+-----------------------+
+    | Condition                                    | Effect                |
+    +==============================================+=======================+
+    | ``ref == mut``                               | Silent                |
+    +----------------------------------------------+-----------------------+
+    | first codon is a non-ATG alternate start     | AlternateStartCodon   |
+    | and proteins otherwise match                 | (non-diff special     |
+    |                                              | case, see #304)       |
+    +----------------------------------------------+-----------------------+
+    | ``aa_offset == 0`` and                       | StartLoss             |
+    | ``not mut.startswith('M')``                  |                       |
+    +----------------------------------------------+-----------------------+
+    | ``ref_delta`` ends at ``len(ref)`` and       | StopLoss (requires    |
+    | ``len(mut) > len(ref)``                      | 3'UTR readthrough —   |
+    |                                              | extend                |
+    |                                              | apply_variant_to_     |
+    |                                              | transcript)           |
+    +----------------------------------------------+-----------------------+
+    | ``total_length_delta % 3 != 0`` and          | FrameShiftTruncation  |
+    | ``len(alt_delta) == 0``                      |                       |
+    +----------------------------------------------+-----------------------+
+    | ``total_length_delta % 3 != 0``              | FrameShift            |
+    +----------------------------------------------+-----------------------+
+    | ``len(mut) < len(ref)`` with in-frame edit   | PrematureStop         |
+    +----------------------------------------------+-----------------------+
+    | ``len(ref_delta) == len(alt_delta) == 1``    | Substitution          |
+    +----------------------------------------------+-----------------------+
+    | ``len(ref_delta) == 0``                      | Insertion             |
+    +----------------------------------------------+-----------------------+
+    | ``len(alt_delta) == 0``                      | Deletion              |
+    +----------------------------------------------+-----------------------+
+    | otherwise                                    | ComplexSubstitution   |
+    +----------------------------------------------+-----------------------+
+    """
+    raise NotImplementedError(
+        "classify_from_protein_diff is WIP scaffolding — see #309.")
+
+
+def _variant_is_splice_adjacent(variant, transcript):
+    """True when ``variant`` sits within the canonical splice window
+    (last 3 bases of an exon or first 3–6 bases of an intron) on
+    ``transcript``.
+
+    **Not implemented.** Sequence-diff delegates splice-adjacent
+    variants to the legacy classifier; this gate decides when. The
+    implementation can reuse the distance-to-exon helpers in
+    :mod:`varcode.effects.effect_prediction`.
+    """
+    raise NotImplementedError(
+        "_variant_is_splice_adjacent is WIP scaffolding — see #309.")

--- a/varcode/annotators/sequence_diff.py
+++ b/varcode/annotators/sequence_diff.py
@@ -73,6 +73,76 @@ same shape as splice outcomes (#262/#305). The planned extensions:
 
 None of this SV work is in scope for 3d (#309). Calling it out
 here so the point-variant design doesn't close off the SV path.
+
+Ownership boundary with topiary's ProteinFragment
+-------------------------------------------------
+
+Topiary's :class:`ProteinFragment` is the downstream universal
+substrate for "mutant protein with source-type tag + target
+intervals" (openvax/topiary#121). The split should be:
+
+* :class:`MutantTranscript` — transcript-level reasoning. Lives in
+  varcode. Owns splicing decisions, UTR readthrough, codon-table
+  selection, edit provenance.
+* :class:`ProteinFragment` — prediction-boundary substrate. Lives
+  in topiary. Owns MHC-binding input framing, peptide-window
+  slicing, source-type tagging.
+
+The conversion from MutantTranscript to ProteinFragment is 1:1:
+``fragment.sequence = mutant_transcript.mutant_protein_sequence``,
+``fragment.source_type = <variant_class>``, ``fragment.fragment_id
+= <transcript_id>:<variant_hash>``, and provenance fields
+(``annotator_name``, evidence dict) thread through as fragment
+metadata. Downstream tools should use MutantTranscript for
+transcript-level reasoning and convert to ProteinFragment at the
+prediction boundary — ad-hoc conversions drift across tools.
+
+Possibility-set prior for DNA-only callers
+------------------------------------------
+
+When a single DNA event produces a possibility set of mutant
+proteins (splice outcomes, fusion candidates, translocation
+ORFs), and RNA evidence isn't available to narrow it, callers
+still need to pick a top outcome for downstream pipelines that
+consume one protein per variant (neoantigen prediction, vaccine
+peptide selection). The :class:`MultiOutcomeEffect` wrapper
+should carry a **prior over outcomes** even when that prior is
+crude:
+
+* Splice outcomes: the plausibility tables in
+  ``varcode.splice_outcomes`` already serve this role.
+* Fusions: canonical-transcript-preferred; known recurrent
+  junctions (BCR-ABL, EML4-ALK, TMPRSS2-ERG) get
+  possibility-set size 1.
+* Translocations producing many ORFs: rank by
+  (in-frame, ORF length, canonical-transcript involvement).
+
+The API convention: ``.most_likely`` always returns the
+highest-prior candidate, ``.candidates`` returns all of them
+sorted prior-descending. Callers that want "best guess from DNA
+alone" read ``.most_likely``; callers with RNA evidence filter
+``.candidates`` by observation support. Same shape as the
+existing :class:`SpliceOutcomeSet` — extending it uniformly
+across variant classes is exactly what #299 tracks.
+
+Recurrent-junction registry (for fusions)
+-----------------------------------------
+
+Known recurrent fusion junctions should short-circuit to a
+single MutantTranscript rather than enumerate candidates. The
+registry contract needs resolution before fusion support lands:
+
+* Does varcode ship the registry, or does each fusion annotator
+  (Exacto's plugin, Isovar's plugin) consult its own?
+* If varcode ships it, what's the data source — COSMIC fusion
+  entries, a curated list, user-supplied?
+* If annotators consult their own, what's the common lookup
+  interface so registries can coexist?
+
+None of this needs resolution for 3d's point-variant classifier.
+Flagging so the design doesn't lock in a particular answer too
+early. Likely lives in its own tracking issue once #252 fusion
+support starts.
 """
 
 from ..version import __version__ as _varcode_version
@@ -96,6 +166,13 @@ class SequenceDiffEffectAnnotator:
     ``inversion``, ``duplication``) get added once the
     ``reference_segments`` generalization lands — see module
     docstring."""
+
+    def __repr__(self):
+        # Include the registered name in the repr so users who see
+        # "<SequenceDiffEffectAnnotator ...>" in an error message can
+        # immediately map it back to the annotator= kwarg string.
+        return "SequenceDiffEffectAnnotator(name=%r, version=%r)" % (
+            self.name, self.version)
 
     def annotate_on_transcript(self, variant, transcript):
         """Dispatch a single (variant, transcript) pair.
@@ -168,6 +245,45 @@ def _variant_is_splice_adjacent(variant, transcript):
     variants to the legacy classifier; this gate decides when. The
     implementation can reuse the distance-to-exon helpers in
     :mod:`varcode.effects.effect_prediction`.
+
+    Dual-dispatch decision (from vaxrank feedback on PR #310)
+    ---------------------------------------------------------
+
+    A splice-adjacent variant in the **exon body** (e.g. a missense
+    at the last exonic base) is biologically *both* a splice effect
+    AND a protein-level coding effect. Legacy's
+    :class:`ExonicSpliceSite` carries an ``alternate_effect`` field
+    for exactly this reason — it captures "what happens if splicing
+    proceeds normally." Options for sequence-diff:
+
+    **(a) Dual-dispatch**: when the variant is exon-body *and* in
+    the splice window, run legacy for the splice classification
+    AND return sequence-diff's protein-level classification as
+    the ``alternate_effect`` on the resulting
+    :class:`ExonicSpliceSite`. Output is an :class:`ExonicSpliceSite`
+    whose ``alternate_effect`` comes from sequence-diff's diff
+    logic instead of legacy's offset arithmetic — the two
+    classifications agree on the common case because they go
+    through the same shared fast path (stage 3c), and disagree
+    only on the cases sequence-diff provably handles better
+    (boundary codons, frameshift realignment, etc.).
+
+    **(b) Legacy-only**: exon-body splice-adjacent variants
+    delegate entirely to legacy. Protein-level consequences come
+    from legacy's offset-based logic, even for the cases where
+    sequence-diff's diff would be more accurate. Neoantigen
+    pipelines lose the sequence-diff-corrected protein consequence
+    on splice-adjacent missense.
+
+    **Recommended: (a)**, dual-dispatch for exon-body variants.
+    Pure-intronic splice variants (inside the intron, e.g. +1/+2)
+    stay legacy-only since there's no protein-level diff to
+    compute — the variant doesn't sit in translated sequence.
+
+    This is the contract the classifier will honor in 3d; calling
+    it out explicitly here (rather than in a commit message) so
+    the splice-adjacency behaviour is reviewable alongside the
+    rest of the design.
     """
     raise NotImplementedError(
         "_variant_is_splice_adjacent is WIP scaffolding — see #309.")

--- a/varcode/annotators/sequence_diff.py
+++ b/varcode/annotators/sequence_diff.py
@@ -18,6 +18,11 @@ not functional.** This module currently ships a class skeleton,
 a classifier signature with a documented decision table, and
 TODOs. See the PR description and #309 for the rollout plan.
 
+See :doc:`/effect_annotation` for the user-facing guide covering
+how legacy, sequence-diff, splice outcomes, and the SV roadmap
+fit together. This module docstring captures implementation
+detail relevant to reviewers of the classifier itself.
+
 Algorithm
 ---------
 

--- a/varcode/mutant_transcript.py
+++ b/varcode/mutant_transcript.py
@@ -93,6 +93,21 @@ class MutantTranscript:
     translation is lazy). Callers that require the protein must
     check or compute it themselves for now — the sequence-diff
     annotator in stage 2 will guarantee it's populated.
+
+    **Forward-looking — structural variants (SVs).** The single
+    ``reference_transcript`` field expresses point variants and
+    indels cleanly but doesn't fit fusions, translocations, or large
+    rearrangements. The planned generalization is a
+    ``reference_segments`` alternative — a sequence of
+    ``(transcript_or_interval, cdna_range)`` pairs, where a fusion is
+    two segments from two transcripts and a translocation-to-intergenic
+    is one transcript segment plus a genomic-interval segment. SV
+    annotators that don't have a unique mutant protein (e.g. a
+    translocation producing many candidate ORFs that only RNA can
+    resolve) should return ``List[MutantTranscript]`` or wrap it in a
+    :class:`MultiOutcomeEffect` per #299. See #252 / #257 / #259 /
+    #305 for the roadmap. The current dataclass shape is the
+    point-variant subset; the SV extension doesn't break it.
     """
 
     reference_transcript: object


### PR DESCRIPTION
**Draft / WIP — not for merge.** Skeleton for #309 so downstream reviewers (Vaxrank, Isovar) can comment on shape and extensibility before the algorithmic work starts.

> **User-facing documentation**: [docs/effect_annotation.md](docs/effect_annotation.md) is the canonical guide to how legacy, sequence-diff, splice outcomes, `MultiOutcomeEffect`, and the SV roadmap fit together. Start there for the big picture; this module docstring covers classifier-specific implementation detail.

## Shipping plan

| Order | Issue / PR | Scope |
|---|---|---|
| 1 | **#299 Part 1** (new PR, not filed yet) | Retrofit `ExonicSpliceSite` as `MultiOutcomeEffect`; `alternate_effect` becomes a derived property on both `ExonicSpliceSite` and `SpliceOutcomeSet`. Pure refactor, no behaviour change. |
| 2 | **This PR** (after #299 Part 1 lands) | Wire `apply_variant_to_transcript` + classifier + dual-dispatch against the unified shape. |
| 3 | **3e** (separate PR) | Flip default annotator to `sequence_diff` once the parity corpus passes. |
| parallel | **#305** | Rewrite `splice_outcomes.py` on `MutantTranscript`. Only needs stage 2's builder + 3d's classifier — can proceed independently of the default flip. |

## What's in THIS PR

- `varcode/annotators/sequence_diff.py` — class skeleton, classifier signature with the full decision table in the docstring, splice-adjacency gate stub with the dual-dispatch contract documented. All methods raise `NotImplementedError`. Not registered with the annotator registry.
- `tests/test_sequence_diff_parity.py` — parity harness skeleton with corpus composition spec, `pytest.mark.parity` marker, and INFO-logging rollout policy documented.
- `MutantTranscript` docstring extended with the SV extensibility roadmap (`reference_segments`, fusion / translocation / inversion handling).
- `docs/effect_annotation.md` — new user-facing guide linked from `docs/index.md`.
- Module docstring sections on: SV generalization, `MutantTranscript` ↔ `ProteinFragment` ownership boundary, possibility-set prior, recurrent-junction registry open question, dual-dispatch splice-adjacency contract.

## Feedback welcome on

1. **Classifier decision table** — anything missing? Edge cases worth calling out?
2. **Splice-adjacency gate** — resolved as dual-dispatch for exon-body, legacy-only for pure-intronic. See `_variant_is_splice_adjacent` docstring for the contract.
3. **SV extension shape** — does the `reference_segments` generalization match what Vaxrank / Isovar would consume? See module docstring + `docs/effect_annotation.md`.
4. **Corpus composition** — planned list in `test_sequence_diff_parity.py` docstring. What else belongs?
5. **Recurrent-junction registry** — most underspecified open question. Varcode-ships vs. plugin-consults? Not blocking 3d; likely spawns its own tracking issue when #252 starts.

Linked: #271 tracking, #304 staging, #309 implementation plan, #305 splice_outcomes rewrite, #299 MultiOutcomeEffect formalization, #252 / #257 / #259 / #297 — SV / fusion / RNA-evidence / ML-splice tracking.
