### PR TITLE
#299 Part 1: retrofit ExonicSpliceSite as MultiOutcomeEffect

### DIFF
--- a/docs/effect_annotation.md
+++ b/docs/effect_annotation.md
@@ -120,15 +120,34 @@ the same pattern:
 | 2 | `ExonicSpliceSite` with `alternate_effect` |
 | N (≥3) | `SpliceOutcomeSet` (opt-in via `splice_outcomes=True`) |
 
-After the planned `ExonicSpliceSite` retrofit in [#299][i299],
-all three will be `MultiOutcomeEffect` subclasses. Downstream
-code will be able to write `isinstance(e, MultiOutcomeEffect)`
-and iterate `.candidates` uniformly, regardless of richness
-level. `alternate_effect` becomes a derived property available
-on both `ExonicSpliceSite` (the 2-outcome case) and
-`SpliceOutcomeSet` (where it resolves to the
-`NORMAL_SPLICING` candidate's `coding_effect`). Same field,
-same meaning, works on both shapes — no parallel mechanism.
+`ExonicSpliceSite` is a `MultiOutcomeEffect` subclass since
+[#299][i299] Part 1. Downstream code can write
+`isinstance(e, MultiOutcomeEffect)` and iterate `.candidates`
+uniformly, regardless of richness level. `alternate_effect` is
+available on both `ExonicSpliceSite` (the 2-outcome case, as a
+first-class instance attribute) and `SpliceOutcomeSet` (where it
+resolves to the `NORMAL_SPLICING` candidate's `coding_effect`).
+Same field, same meaning, works on both shapes — no parallel
+mechanism.
+
+```python
+# Both now work:
+if isinstance(effect, MultiOutcomeEffect):
+    for candidate in effect.candidates:
+        ...
+if effect.alternate_effect is not None:
+    coding_consequence = effect.alternate_effect
+```
+
+The element types in `.candidates` differ by shape —
+`ExonicSpliceSite.candidates` yields `MutationEffect` instances
+directly (self + alternate_effect); `SpliceOutcomeSet.candidates`
+yields `SpliceCandidate` objects with `.outcome` / `.plausibility`
+/ `.coding_effect` fields. Downstream code that needs the richer
+per-candidate metadata can branch on element type; code that just
+wants "is there a coding consequence" reads `.alternate_effect`
+and gets a `MutationEffect`-or-None regardless of which class
+produced it.
 
 ### Variants in the CDS and in the splice window simultaneously
 

--- a/tests/test_exonic_splice_site_multi_outcome.py
+++ b/tests/test_exonic_splice_site_multi_outcome.py
@@ -1,0 +1,157 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ExonicSpliceSite → MultiOutcomeEffect retrofit
+(openvax/varcode#299 Part 1).
+
+The retrofit is a class-hierarchy change only:
+
+* ExonicSpliceSite inherits from MultiOutcomeEffect and exposes
+  the ``candidates`` / ``most_likely`` / ``priority_class``
+  protocol.
+* SpliceOutcomeSet gains a back-compat ``alternate_effect``
+  property that resolves to the NORMAL_SPLICING candidate's
+  coding_effect.
+
+No behaviour change — the existing test suite (tests/test_splice_*)
+continues to lock in byte-for-byte output.
+"""
+
+from pyensembl import cached_release
+
+from varcode import MultiOutcomeEffect, SpliceOutcome, Variant
+from varcode.effects import ExonicSpliceSite
+
+
+ensembl_grch38 = cached_release(81)
+CFTR_TRANSCRIPT_ID = "ENST00000003084"
+
+
+# ====================================================================
+# ExonicSpliceSite is now a MultiOutcomeEffect
+# ====================================================================
+
+
+def test_exonic_splice_site_is_multi_outcome_effect():
+    # CFTR exon 4 ends in ...AAG. A G->T at the last exonic base is a
+    # canonical ExonicSpliceSite case.
+    variant = Variant("7", 117531114, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effect = variant.effect_on_transcript(transcript)
+    assert isinstance(effect, ExonicSpliceSite)
+    assert isinstance(effect, MultiOutcomeEffect), (
+        "ExonicSpliceSite should pass isinstance(e, MultiOutcomeEffect) "
+        "after #299 Part 1 retrofit")
+
+
+def test_exonic_splice_site_candidates_include_self_and_alternate():
+    variant = Variant("7", 117531114, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effect = variant.effect_on_transcript(transcript)
+    assert effect.alternate_effect is not None
+    # 2-candidate form: splice-disruption (self) + coding consequence.
+    assert effect.candidates == (effect, effect.alternate_effect)
+
+
+def test_exonic_splice_site_most_likely_is_self():
+    variant = Variant("7", 117531114, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effect = variant.effect_on_transcript(transcript)
+    assert effect.most_likely is effect
+
+
+def test_exonic_splice_site_priority_class_is_self_class():
+    variant = Variant("7", 117531114, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effect = variant.effect_on_transcript(transcript)
+    assert effect.priority_class is ExonicSpliceSite
+
+
+def test_exonic_splice_site_alternate_effect_still_first_class():
+    # Back-compat: the attribute access that downstream code uses
+    # today must keep working. The retrofit adds MultiOutcomeEffect
+    # machinery alongside it, not in place of it.
+    variant = Variant("7", 117531114, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    effect = variant.effect_on_transcript(transcript)
+    alt = effect.alternate_effect
+    assert alt is not None
+    # alternate_effect is a MutationEffect (not a SpliceCandidate).
+    from varcode.effects import MutationEffect
+    assert isinstance(alt, MutationEffect)
+
+
+# ====================================================================
+# SpliceOutcomeSet gets alternate_effect back-compat property
+# ====================================================================
+
+
+def test_splice_outcome_set_alternate_effect_resolves_to_normal_splicing():
+    # ExonicSpliceSite wrapped under splice_outcomes=True becomes a
+    # SpliceOutcomeSet. Its .alternate_effect should return the same
+    # coding_effect that ExonicSpliceSite.alternate_effect would.
+    variant = Variant("7", 117531114, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+
+    bare = variant.effect_on_transcript(transcript)
+    assert isinstance(bare, ExonicSpliceSite)
+    bare_alt = bare.alternate_effect
+
+    wrapped_effects = variant.effects(splice_outcomes=True)
+    wrapped = next(e for e in wrapped_effects if e.transcript is transcript)
+    # Same underlying coding-effect class; don't require object
+    # identity since the wrapped path may rebuild it.
+    assert type(wrapped.alternate_effect) is type(bare_alt)
+    assert wrapped.alternate_effect.short_description == bare_alt.short_description
+
+
+def test_splice_outcome_set_alternate_effect_none_when_no_normal_splicing():
+    # SpliceDonor-backed SpliceOutcomeSet: the NORMAL_SPLICING candidate
+    # exists but its coding_effect is None (intronic variant, no
+    # underlying coding change). alternate_effect should be None.
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+    wrapped_effects = variant.effects(splice_outcomes=True)
+    wrapped = next(e for e in wrapped_effects if e.transcript is transcript)
+    # Sanity: this is a SpliceDonor-backed set with a NORMAL_SPLICING
+    # candidate that has no coding_effect.
+    normal = next(
+        c for c in wrapped.candidates
+        if c.outcome is SpliceOutcome.NORMAL_SPLICING
+    )
+    assert normal.coding_effect is None
+    assert wrapped.alternate_effect is None
+
+
+# ====================================================================
+# Unified downstream pattern: isinstance(e, MultiOutcomeEffect) works
+# across both shapes.
+# ====================================================================
+
+
+def test_multi_outcome_effect_check_works_on_both_shapes():
+    # Same variant expressed two ways; both match the MultiOutcomeEffect
+    # isinstance check so downstream code doesn't need to special-case.
+    variant = Variant("7", 117531114, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id(CFTR_TRANSCRIPT_ID)
+
+    bare = variant.effect_on_transcript(transcript)
+    assert isinstance(bare, MultiOutcomeEffect)
+
+    wrapped_effects = variant.effects(splice_outcomes=True)
+    wrapped = next(e for e in wrapped_effects if e.transcript is transcript)
+    assert isinstance(wrapped, MultiOutcomeEffect)
+
+    # alternate_effect is callable on both shapes post-retrofit.
+    assert bare.alternate_effect is not None
+    assert wrapped.alternate_effect is not None
+    assert type(bare.alternate_effect) is type(wrapped.alternate_effect)

--- a/varcode/effects/effect_classes.py
+++ b/varcode/effects/effect_classes.py
@@ -287,10 +287,24 @@ class ExonLoss(Exonic):
         return True
 
 
-class ExonicSpliceSite(Exonic, SpliceSite):
+class ExonicSpliceSite(Exonic, SpliceSite, MultiOutcomeEffect):
     """
     Mutation in the last three nucleotides before an intron
     or in the first nucleotide after an intron.
+
+    Expresses the two plausible outcomes of a splice-adjacent exonic
+    variant — splice-signal disruption vs. the underlying coding
+    change if splicing proceeds normally — via the
+    :class:`MultiOutcomeEffect` protocol (see #299). ``candidates``
+    yields ``(self, alternate_effect)`` (both :class:`MutationEffect`
+    instances), and ``alternate_effect`` stays on the instance as a
+    first-class field for back-compat with callers that depended on
+    the 2.x shape.
+
+    This is the **lightweight 2-outcome form**. Callers that want
+    the richer exon-skipping / intron-retention / cryptic-splice
+    candidate set opt into ``splice_outcomes=True`` and get a
+    :class:`~varcode.splice_outcomes.SpliceOutcomeSet` instead.
     """
     def __init__(self, variant, transcript, exon, alternate_effect):
         Exonic.__init__(self, variant, transcript)
@@ -321,6 +335,42 @@ class ExonicSpliceSite(Exonic, SpliceSite):
     @property
     def modifies_coding_sequence(self):
         return self.alternate_effect.modifies_coding_sequence
+
+    @property
+    def candidates(self):
+        """The two plausible outcomes, most-likely-first:
+
+        ``(self, alternate_effect)`` — position [0] is the
+        splice-disruption outcome (this effect itself), position [1]
+        is the coding change if splicing proceeds. Returns a
+        1-tuple ``(self,)`` when ``alternate_effect`` is None.
+
+        Elements are :class:`MutationEffect` instances directly,
+        not :class:`SpliceCandidate` objects — that's a different
+        (richer) shape used by :class:`SpliceOutcomeSet`. Downstream
+        code that iterates ``candidates`` here reads the effect
+        class / ``short_description`` / ``aa_ref`` etc. on each
+        element, same as on any ``MutationEffect``.
+        """
+        if self.alternate_effect is None:
+            return (self,)
+        return (self, self.alternate_effect)
+
+    @property
+    def most_likely(self):
+        """The splice-disruption outcome is the primary classification
+        (this effect itself). Follows the ``MultiOutcomeEffect``
+        contract of ``most_likely == candidates[0]``.
+        """
+        return self
+
+    @property
+    def priority_class(self):
+        """ExonicSpliceSite priority is used directly — no
+        delegation, since this class IS the splice-adjacent effect
+        rather than a wrapper around one.
+        """
+        return ExonicSpliceSite
 
 
 class CodingMutation(Exonic):

--- a/varcode/splice_outcomes.py
+++ b/varcode/splice_outcomes.py
@@ -250,6 +250,28 @@ class SpliceOutcomeSet(MultiOutcomeEffect):
         return self.candidates[0]
 
     @property
+    def alternate_effect(self):
+        """Back-compat shim matching :attr:`ExonicSpliceSite.alternate_effect`.
+
+        Resolves to the ``coding_effect`` of the ``NORMAL_SPLICING``
+        candidate — i.e. "the coding change that applies when
+        splicing proceeds normally." Returns ``None`` when the
+        ``NORMAL_SPLICING`` candidate has no coding_effect (e.g. the
+        variant is intronic and has no underlying coding change) or
+        when the outcome set doesn't include ``NORMAL_SPLICING``.
+
+        Added by #299 Part 1 so downstream code can read
+        ``effect.alternate_effect`` uniformly on both
+        :class:`ExonicSpliceSite` (2-outcome default) and
+        :class:`SpliceOutcomeSet` (N-outcome opt-in) without
+        branching on ``isinstance``.
+        """
+        for candidate in self.candidates:
+            if candidate.outcome is SpliceOutcome.NORMAL_SPLICING:
+                return candidate.coding_effect
+        return None
+
+    @property
     def candidate_proteins(self):
         """Mapping from each :class:`SpliceOutcome` to its computed
         mutant protein sequence (empty string when the protein is not


### PR DESCRIPTION
First of the #299 cleanup PRs. Retrofits `ExonicSpliceSite` as a `MultiOutcomeEffect` subclass so downstream code can handle splice-adjacent variants uniformly across the 2-outcome default and the N-outcome opt-in forms.

**Byte-for-byte output-preserving.** 606 existing tests pass unchanged.

## What this unifies

Before this PR, downstream code had to special-case:

```python
# Default: ExonicSpliceSite with .alternate_effect field
if isinstance(e, ExonicSpliceSite):
    coding_consequence = e.alternate_effect

# Opt-in: SpliceOutcomeSet with NORMAL_SPLICING candidate
elif isinstance(e, SpliceOutcomeSet):
    coding_consequence = next(
        c for c in e.candidates
        if c.outcome is SpliceOutcome.NORMAL_SPLICING
    ).coding_effect
```

After this PR:

```python
if isinstance(e, MultiOutcomeEffect):
    coding_consequence = e.alternate_effect  # works on both shapes
```

Same field, same meaning, works regardless of which wrapper class produced it — no parallel mechanism.

## What ships

- `ExonicSpliceSite(Exonic, SpliceSite, MultiOutcomeEffect)` — adds the third base. New properties:
  - `.candidates` → `(self, alternate_effect)` or `(self,)` when alternate_effect is None
  - `.most_likely` → `self`
  - `.priority_class` → `ExonicSpliceSite` (no delegation — this class IS the splice-adjacent effect)
- `SpliceOutcomeSet.alternate_effect` → derived property resolving to the `NORMAL_SPLICING` candidate's `coding_effect`. `None` when NORMAL_SPLICING has no coding_effect (intronic-anchored sets, e.g. SpliceDonor).
- `alternate_effect` stays as a first-class instance attribute on `ExonicSpliceSite` — existing callers that read `effect.alternate_effect` continue to work unchanged.

## Design note

Element types in `.candidates` differ by subclass:
- `ExonicSpliceSite.candidates` — `MutationEffect` instances directly
- `SpliceOutcomeSet.candidates` — `SpliceCandidate` objects with `.outcome` / `.plausibility` / `.coding_effect`

The `MultiOutcomeEffect` protocol only requires "a sequence of outcomes" and leaves element shape to the subclass. Code that needs the richer per-candidate metadata branches on element type; code that just wants "is there a coding consequence" reads `.alternate_effect` and gets a `MutationEffect`-or-`None` regardless.

## Test plan

8 new tests in `tests/test_exonic_splice_site_multi_outcome.py`:

- [x] `isinstance(e, MultiOutcomeEffect)` is True for ExonicSpliceSite
- [x] `.candidates == (self, alternate_effect)`
- [x] `.most_likely is self`
- [x] `.priority_class is ExonicSpliceSite`
- [x] `.alternate_effect` still a first-class attribute (back-compat)
- [x] `SpliceOutcomeSet.alternate_effect` resolves to NORMAL_SPLICING candidate's coding_effect, matching ExonicSpliceSite's output
- [x] `SpliceOutcomeSet.alternate_effect` returns None when NORMAL_SPLICING has no coding_effect
- [x] Unified `isinstance` + `.alternate_effect` pattern works on both shapes

Plus `docs/effect_annotation.md` updated to describe the retrofit as current behavior.

614 tests pass (was 606) + 1 parity skip; ruff clean.

## Next

Unblocks PR #310 (#309 / stage 3d classifier) — the `SequenceDiffEffectAnnotator`'s dual-dispatch splice-adjacency contract builds against the unified shape rather than also inventing it.

Linked: #271 tracking, #299 MultiOutcomeEffect formalization, #304 staging, #309 classifier, #305 splice rewrite.