### PR TITLE
#305: rewrite splice_outcomes exon-skip builder on MutantTranscript + shared classifier

### DIFF
--- a/varcode/effects/classify.py
+++ b/varcode/effects/classify.py
@@ -1,0 +1,166 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Classify a MutationEffect from a reference/mutant protein pair.
+
+Shared classifier used by both the splice-outcome builder
+(:mod:`varcode.splice_outcomes`, #305) and the forthcoming
+:class:`SequenceDiffEffectAnnotator` (#309 / stage 3d). Reduces
+the protein pair via :func:`trim_shared_flanking_strings` and
+dispatches to the standard Effect classes.
+
+This module deliberately does NOT handle:
+
+* Non-coding / incomplete transcripts — caller gates those before
+  reaching the classifier.
+* Splice-class effects (SpliceDonor, etc.) — those come from the
+  position-based splice classifier, not from a protein diff.
+* ``AlternateStartCodon`` — requires inspecting the mutant cDNA's
+  first codon, not just the protein strings. The caller (the
+  annotator) special-cases that before calling this function.
+"""
+
+from ..string_helpers import trim_shared_flanking_strings
+from .effect_classes import (
+    ComplexSubstitution,
+    Deletion,
+    FrameShift,
+    FrameShiftTruncation,
+    Insertion,
+    PrematureStop,
+    Silent,
+    StartLoss,
+    StopLoss,
+    Substitution,
+)
+
+
+def classify_from_protein_diff(
+        variant,
+        transcript,
+        ref_protein,
+        mut_protein,
+        length_delta=0):
+    """Classify a :class:`MutationEffect` by diffing translated
+    proteins.
+
+    Parameters
+    ----------
+    variant : Variant
+    transcript : pyensembl.Transcript
+    ref_protein : str
+        Reference protein sequence (from ``transcript.protein_sequence``).
+    mut_protein : str
+        Mutant protein sequence (translated from the mutated cDNA,
+        stopping at the first stop codon).
+    length_delta : int
+        Net nucleotide-level length change of the cDNA edit
+        (positive for net insertion, negative for net deletion, zero
+        for substitution). Used to detect frameshifts: when
+        ``length_delta % 3 != 0`` AND the protein diff shows a
+        changed tail, the effect is a :class:`FrameShift`.
+
+    Returns
+    -------
+    MutationEffect subclass instance
+    """
+    if ref_protein == mut_protein:
+        return Silent(
+            variant=variant,
+            transcript=transcript,
+            aa_pos=0,
+            aa_ref=ref_protein[:1] if ref_protein else "")
+
+    # Start loss: mutant protein doesn't begin with M.
+    if not mut_protein or (mut_protein[0] != "M" and ref_protein and ref_protein[0] == "M"):
+        return StartLoss(variant=variant, transcript=transcript)
+
+    ref_delta, alt_delta, prefix, suffix = trim_shared_flanking_strings(
+        ref_protein, mut_protein)
+
+    aa_offset = len(prefix)
+    n_ref = len(ref_delta)
+    n_alt = len(alt_delta)
+
+    # Frameshift: cDNA length change not divisible by 3.
+    if length_delta % 3 != 0:
+        if n_alt == 0:
+            return FrameShiftTruncation(
+                variant=variant,
+                transcript=transcript,
+                stop_codon_offset=aa_offset)
+        return FrameShift(
+            variant=variant,
+            transcript=transcript,
+            aa_mutation_start_offset=aa_offset,
+            shifted_sequence=alt_delta)
+
+    # Premature stop: mutant protein shorter than reference and the
+    # change is at the tail (the trimmed alt runs to the end of the
+    # mutant protein).
+    if len(mut_protein) < len(ref_protein) and aa_offset + n_alt == len(mut_protein):
+        return PrematureStop(
+            variant=variant,
+            transcript=transcript,
+            aa_mutation_start_offset=aa_offset,
+            aa_ref=ref_delta,
+            aa_alt=alt_delta)
+
+    # Stop loss: mutant protein longer than reference and the change
+    # extends past the original stop.
+    if len(mut_protein) > len(ref_protein) and aa_offset + n_ref >= len(ref_protein):
+        return StopLoss(
+            variant=variant,
+            transcript=transcript,
+            aa_ref=ref_delta,
+            aa_alt=alt_delta)
+
+    # Silent (after trimming — all changes cancelled out).
+    if n_ref == 0 and n_alt == 0:
+        return Silent(
+            variant=variant,
+            transcript=transcript,
+            aa_pos=aa_offset,
+            aa_ref=prefix + suffix)
+
+    # Deletion.
+    if n_alt == 0:
+        return Deletion(
+            variant=variant,
+            transcript=transcript,
+            aa_mutation_start_offset=aa_offset,
+            aa_ref=ref_delta)
+
+    # Insertion.
+    if n_ref == 0:
+        return Insertion(
+            variant=variant,
+            transcript=transcript,
+            aa_mutation_start_offset=aa_offset,
+            aa_alt=alt_delta)
+
+    # Substitution (simple 1:1).
+    if n_ref == 1 and n_alt == 1:
+        return Substitution(
+            variant=variant,
+            transcript=transcript,
+            aa_mutation_start_offset=aa_offset,
+            aa_ref=ref_delta,
+            aa_alt=alt_delta)
+
+    # Complex substitution (multi-residue edit).
+    return ComplexSubstitution(
+        variant=variant,
+        transcript=transcript,
+        aa_mutation_start_offset=aa_offset,
+        aa_ref=ref_delta,
+        aa_alt=alt_delta)

--- a/varcode/splice_outcomes.py
+++ b/varcode/splice_outcomes.py
@@ -576,133 +576,6 @@ def _build_cryptic_splice_candidate(splice_effect, plausibility, outcome):
 # ---------------------------------------------------------------------
 
 
-def _exon_contains_start_codon(transcript, exon):
-    """True if the given exon contains the annotated start codon."""
-    if not transcript.complete:
-        return False
-    try:
-        start_offsets = transcript.start_codon_spliced_offsets
-    except Exception:
-        return False
-    if not start_offsets:
-        return False
-    exon_start = _exon_start_offset_in_transcript_or_none(transcript, exon)
-    if exon_start is None:
-        return False
-    exon_length = exon.end - exon.start + 1
-    exon_end = exon_start + exon_length - 1
-    first_start = min(start_offsets)
-    return exon_start <= first_start <= exon_end
-
-
-def _exon_start_offset_in_transcript_or_none(transcript, exon):
-    """Like :func:`_exon_start_offset_in_transcript` but returns None
-    on failure instead of raising."""
-    try:
-        return _exon_start_offset_in_transcript(transcript, exon)
-    except (StopIteration, ValueError):
-        return None
-
-
-def _build_start_loss_effect(variant, transcript):
-    """Build a StartLoss effect stub when the start-codon exon is
-    skipped. Returns None if the transcript can't accommodate it.
-    """
-    if not transcript.complete:
-        return None
-    try:
-        return StartLoss(variant=variant, transcript=transcript)
-    except Exception:
-        return None
-
-
-def _build_out_of_frame_exon_skip_effect(variant, transcript, skipped_exon):
-    """Compute the mutant protein for an out-of-frame exon skip.
-
-    Builds the post-skip cDNA by joining all exons except the skipped
-    one, translating from the original start codon, and following the
-    frameshift until the first stop. Returns a Deletion-style effect
-    with aa_ref set to the joined skipped region; leaves the mutant
-    protein accessible via a custom subclass-like shim.
-    """
-    if not transcript.complete:
-        return None
-    try:
-        exon_start_in_tx = _exon_start_offset_in_transcript(
-            transcript, skipped_exon)
-    except (StopIteration, ValueError):
-        return None
-    cds_start_offset = min(transcript.start_codon_spliced_offsets)
-    if exon_start_in_tx < cds_start_offset:
-        return None
-    exon_length = skipped_exon.end - skipped_exon.start + 1
-    # Construct the post-skip cDNA by excising the exon's nucleotides
-    # from the full transcript sequence.
-    full_sequence = str(transcript.sequence)
-    post_skip_cdna = (
-        full_sequence[:exon_start_in_tx]
-        + full_sequence[exon_start_in_tx + exon_length:]
-    )
-    # Translate from the start codon through the frameshift to first stop.
-    coding_from_start = post_skip_cdna[cds_start_offset:]
-    protein = _translate_to_first_stop(
-        coding_from_start, codon_table=codon_table_for_transcript(transcript))
-    if not protein:
-        return None
-    # Compute the aa position where the frameshift begins — this is
-    # where the exon used to start, in aa coordinates.
-    aa_frameshift_start = (exon_start_in_tx - cds_start_offset) // 3
-    if aa_frameshift_start >= len(transcript.protein_sequence):
-        return None
-    return _ExonSkipFrameshiftEffect(
-        variant=variant,
-        transcript=transcript,
-        aa_frameshift_start=aa_frameshift_start,
-        protein=protein,
-    )
-
-
-def _translate_to_first_stop(cdna, codon_table=None):
-    """Translate a cDNA string to protein, stopping at the first stop
-    codon. Returns the protein string without the stop symbol.
-
-    ``codon_table`` defaults to the standard nuclear table; pass the
-    vertebrate mitochondrial table for mt transcripts so AGA/AGG act
-    as stops and TGA codes for Trp.
-    """
-    if codon_table is None:
-        from .effects.codon_tables import STANDARD
-        codon_table = STANDARD
-    n_codons = len(cdna) // 3
-    truncated = str(cdna[:n_codons * 3])
-    return translate_sequence(truncated, codon_table=codon_table, to_stop=True)
-
-
-class _ExonSkipFrameshiftEffect(MutationEffect):
-    """Internal helper effect representing an exon-skip-induced
-    frameshift. Carries the computed mutant protein sequence but isn't
-    intended as a public effect class — it's wrapped inside the
-    SpliceCandidate.
-    """
-    def __init__(self, variant, transcript, aa_frameshift_start, protein):
-        MutationEffect.__init__(self, variant)
-        self.transcript = transcript
-        self.aa_mutation_start_offset = aa_frameshift_start
-        self.aa_ref = str(
-            transcript.protein_sequence[aa_frameshift_start:])
-        # aa_alt is the new amino acids after the frameshift point.
-        self.aa_alt = protein[aa_frameshift_start:]
-        self.mutant_protein_sequence = protein
-
-    @property
-    def short_description(self):
-        return "p.%s%dfs*%d" % (
-            self.aa_ref[:1] if self.aa_ref else "?",
-            self.aa_mutation_start_offset + 1,
-            len(self.aa_alt),
-        )
-
-
 def _build_exon_skip_mutant_transcript(variant, transcript, exon):
     """Build a :class:`MutantTranscript` representing an exon skip.
 
@@ -779,137 +652,6 @@ def _affected_exon(splice_effect):
     if hasattr(splice_effect, "nearest_exon"):
         return splice_effect.nearest_exon
     return None
-
-
-def _build_in_frame_exon_skip_effect(variant, transcript, skipped_exon):
-    """Construct the coding effect of an in-frame exon skip.
-
-    When the skipped exon's first base sits at a codon boundary, the
-    skip is a clean :class:`Deletion` of ``exon_length / 3`` amino
-    acids. When the exon starts mid-codon (phase 1 or 2), the boundary
-    codon is reshaped from flanking bases of the preceding and
-    following exons — so the skip touches ``exon_length / 3 + 1``
-    original codons and replaces them with one new codon. Depending
-    on whether that new codon's amino acid matches either flanking
-    residue, the effect is :class:`Deletion`, :class:`Substitution`,
-    or :class:`ComplexSubstitution` — we compute each candidate and
-    let :func:`trim_shared_flanking_strings` collapse it to the
-    minimal edit. See openvax/varcode#298.
-
-    Returns ``None`` when the math can't be completed (e.g. the
-    skipped exon overlaps the 5' UTR or extends past the reference
-    protein's end).
-    """
-    if not transcript.complete:
-        return None
-    try:
-        exon_start_in_tx = _exon_start_offset_in_transcript(
-            transcript, skipped_exon)
-    except (StopIteration, ValueError):
-        return None
-    cds_start_offset = min(transcript.start_codon_spliced_offsets)
-    if exon_start_in_tx < cds_start_offset:
-        # Exon overlaps the 5' UTR or start codon; the simple
-        # amino-acid math doesn't apply.
-        return None
-
-    aa_start = (exon_start_in_tx - cds_start_offset) // 3
-    cds_offset_in_exon = (exon_start_in_tx - cds_start_offset) % 3
-    exon_length = skipped_exon.end - skipped_exon.start + 1
-
-    if cds_offset_in_exon == 0:
-        # Codon-aligned skip: exon_length / 3 codons are cleanly
-        # removed with no boundary reshaping.
-        n_aa_removed = exon_length // 3
-        aa_end = aa_start + n_aa_removed
-        if aa_end > len(transcript.protein_sequence):
-            return None
-        aa_ref = str(transcript.protein_sequence[aa_start:aa_end])
-        if not aa_ref:
-            return None
-        return Deletion(
-            variant=variant,
-            transcript=transcript,
-            aa_mutation_start_offset=aa_start,
-            aa_ref=aa_ref,
-        )
-
-    # Mid-codon skip: exon starts at phase 1 or 2 of codon aa_start.
-    # The original codons touched are aa_start through aa_start + n,
-    # where n = exon_length / 3 (the two boundary codons plus the
-    # fully-internal ones; n + 1 codons total). After skipping, those
-    # n+1 codons are replaced by ONE reshaped codon composed of the
-    # preceding exon's trailing bases plus the following exon's
-    # leading bases.
-    n_aa_touched = exon_length // 3 + 1
-    aa_end = aa_start + n_aa_touched
-    if aa_end > len(transcript.protein_sequence):
-        return None
-
-    aa_ref = str(transcript.protein_sequence[aa_start:aa_end])
-    if not aa_ref:
-        return None
-
-    full_sequence = str(transcript.sequence)
-    pre_bases = cds_offset_in_exon                # 1 or 2
-    post_bases = 3 - cds_offset_in_exon           # 2 or 1
-    boundary_codon_start = exon_start_in_tx - pre_bases
-    post_exon_offset = exon_start_in_tx + exon_length
-    if (boundary_codon_start < 0
-            or post_exon_offset + post_bases > len(full_sequence)):
-        # Not enough flanking sequence to reconstruct the boundary
-        # codon (e.g. skipping the terminal exon).
-        return None
-    new_codon = (
-        full_sequence[boundary_codon_start:exon_start_in_tx]
-        + full_sequence[post_exon_offset:post_exon_offset + post_bases]
-    )
-    if len(new_codon) != 3:
-        return None
-    try:
-        aa_alt = translate_sequence(
-            new_codon,
-            codon_table=codon_table_for_transcript(transcript),
-            to_stop=False)
-    except ValueError:
-        return None
-    # aa_alt may contain '*' if the reshaped codon is a stop; leave
-    # that to the caller to interpret (the next candidate builder
-    # that specializes on premature stops can pick it up later).
-
-    trimmed_ref, trimmed_alt, shared_prefix, _ = trim_shared_flanking_strings(
-        aa_ref, aa_alt)
-    # Shared prefix shifts the effective mutation start forward.
-    aa_mutation_start_offset = aa_start + len(shared_prefix)
-
-    if not trimmed_alt and not trimmed_ref:
-        # Reshaped codon happens to match the boundary exactly — the
-        # skip is effectively silent at the protein level. Return None
-        # so the caller falls back to the predicted-class-name stub
-        # (exceedingly rare in practice).
-        return None
-    if not trimmed_alt:
-        return Deletion(
-            variant=variant,
-            transcript=transcript,
-            aa_mutation_start_offset=aa_mutation_start_offset,
-            aa_ref=trimmed_ref,
-        )
-    if len(trimmed_ref) == 1 and len(trimmed_alt) == 1:
-        return Substitution(
-            variant=variant,
-            transcript=transcript,
-            aa_mutation_start_offset=aa_mutation_start_offset,
-            aa_ref=trimmed_ref,
-            aa_alt=trimmed_alt,
-        )
-    return ComplexSubstitution(
-        variant=variant,
-        transcript=transcript,
-        aa_mutation_start_offset=aa_mutation_start_offset,
-        aa_ref=trimmed_ref,
-        aa_alt=trimmed_alt,
-    )
 
 
 def _exon_start_offset_in_transcript(transcript, exon):
@@ -1052,20 +794,23 @@ _SPLICE_SIGNAL_CLASS_REGISTRY = {
 
 def _rehydrate_coding_effect(state):
     """Resolve a coding-effect dict (with ``__effect_class__`` tag) to a
-    concrete instance. ``_ExonSkipFrameshiftEffect`` (the internal
-    shim from out-of-frame exon skip math) is handled separately
-    since it isn't in the public effect-class registry.
+    concrete instance.
     """
     state = dict(state)
     class_name = state.pop("__effect_class__", None)
     if class_name == "_ExonSkipFrameshiftEffect":
-        # Internal shim — reconstruct minimally via its __init__.
-        return _ExonSkipFrameshiftEffect(
-            variant=state["variant"],
-            transcript=state["transcript"],
-            aa_frameshift_start=state["aa_mutation_start_offset"],
-            protein=state["mutant_protein_sequence"],
-        )
+        # Migration from pre-#305 serialized data: the internal
+        # _ExonSkipFrameshiftEffect shim no longer exists. Construct
+        # a FrameShift from the stored fields instead.
+        from .effects.effect_classes import FrameShift
+        try:
+            return FrameShift(
+                variant=state["variant"],
+                transcript=state["transcript"],
+                aa_mutation_start_offset=state["aa_mutation_start_offset"],
+                shifted_sequence=state.get("aa_alt", ""))
+        except Exception:
+            return None
     registry = _coding_effect_class_registry()
     effect_cls = registry.get(class_name)
     if effect_cls is None:

--- a/varcode/splice_outcomes.py
+++ b/varcode/splice_outcomes.py
@@ -46,20 +46,17 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
+from .effects.classify import classify_from_protein_diff
 from .effects.codon_tables import codon_table_for_transcript, translate_sequence
 from .effects.effect_classes import (
-    ComplexSubstitution,
-    Deletion,
     ExonicSpliceSite,
     IntronicSpliceSite,
     MultiOutcomeEffect,
     MutationEffect,
     SpliceAcceptor,
     SpliceDonor,
-    StartLoss,
-    Substitution,
 )
-from .string_helpers import trim_shared_flanking_strings
+from .mutant_transcript import MutantTranscript, TranscriptEdit
 
 
 class SpliceOutcome(Enum):
@@ -468,10 +465,13 @@ def _build_normal_splicing_candidate(splice_effect, plausibility):
 def _build_exon_skipping_candidate(splice_effect, plausibility):
     """Exon skipping: the affected exon is excluded from the transcript.
 
-    Computes the resulting protein by removing the exon's amino acids
-    (in-frame skip) or by triggering a frameshift (out-of-frame skip).
-    Reports the change as a Deletion when in-frame and as a frameshift
-    label otherwise.
+    Builds a :class:`MutantTranscript` by deleting the exon's cDNA
+    range from the transcript sequence, translates, and classifies
+    the effect via :func:`classify_from_protein_diff`. This replaces
+    the three ad-hoc helpers from the original prototype (#305):
+    boundary-codon reconstruction, start-loss detection, and
+    in-frame vs. out-of-frame distinction all fall out of the diff
+    naturally.
     """
     transcript = getattr(splice_effect, "transcript", None)
     exon = _affected_exon(splice_effect)
@@ -484,39 +484,38 @@ def _build_exon_skipping_candidate(splice_effect, plausibility):
             predicted_class_name="ExonLoss",
         )
 
-    exon_contains_start_codon = _exon_contains_start_codon(transcript, exon)
+    mt = _build_exon_skip_mutant_transcript(
+        splice_effect.variant, transcript, exon)
     exon_length = exon.end - exon.start + 1
-    if exon_contains_start_codon:
-        # Losing the exon that contains the start codon means the
-        # protein as annotated can't be produced; label this as
-        # StartLoss. We can't easily construct the StartLoss effect
-        # here without more context, so return a stub with the right
-        # predicted class.
-        coding_effect = _build_start_loss_effect(
-            splice_effect.variant, transcript)
-        predicted_class_name = "StartLoss"
-        description = (
-            "Exon %s is skipped and contains the start codon; "
-            "annotated translation initiation is lost." % (
-                getattr(exon, "exon_id", "?"),))
-    elif exon_length % 3 == 0:
-        coding_effect = _build_in_frame_exon_skip_effect(
-            splice_effect.variant, transcript, exon)
-        # The in-frame-skip helper now returns Deletion, Substitution,
-        # or ComplexSubstitution depending on whether the skip touches
-        # a codon-straddling boundary (see #298). Derive the label
-        # from the actual effect class when available.
-        predicted_class_name = (
-            type(coding_effect).__name__
-            if coding_effect is not None
-            else "Deletion")
+
+    if mt is None or mt.mutant_protein_sequence is None:
+        # Couldn't compute protein (incomplete transcript, exon not
+        # found in transcript, etc.).
+        predicted = "FrameShift" if exon_length % 3 != 0 else "Deletion"
+        return SpliceCandidate(
+            outcome=SpliceOutcome.EXON_SKIPPING,
+            plausibility=plausibility,
+            description="Exon %s is skipped." % getattr(exon, "exon_id", "?"),
+            coding_effect=None,
+            predicted_class_name=predicted,
+        )
+
+    ref_protein = str(transcript.protein_sequence)
+    mut_protein = mt.mutant_protein_sequence
+    coding_effect = classify_from_protein_diff(
+        variant=splice_effect.variant,
+        transcript=transcript,
+        ref_protein=ref_protein,
+        mut_protein=mut_protein,
+        length_delta=-exon_length,
+    )
+    predicted_class_name = type(coding_effect).__name__
+
+    if exon_length % 3 == 0:
         description = (
             "Exon %s is skipped (in-frame, %d aa removed)." % (
                 getattr(exon, "exon_id", "?"), exon_length // 3))
     else:
-        coding_effect = _build_out_of_frame_exon_skip_effect(
-            splice_effect.variant, transcript, exon)
-        predicted_class_name = "FrameShift"
         description = (
             "Exon %s is skipped (out of frame, frameshift in the "
             "joined transcript)." % getattr(exon, "exon_id", "?"))
@@ -702,6 +701,71 @@ class _ExonSkipFrameshiftEffect(MutationEffect):
             self.aa_mutation_start_offset + 1,
             len(self.aa_alt),
         )
+
+
+def _build_exon_skip_mutant_transcript(variant, transcript, exon):
+    """Build a :class:`MutantTranscript` representing an exon skip.
+
+    Deletes the exon's cDNA range from the transcript sequence and
+    translates the result. Adjusts the CDS start offset when the
+    skipped exon precedes the coding region (5'UTR exon). When the
+    skipped exon contains the start codon, returns a MutantTranscript
+    with an empty protein so the classifier emits StartLoss.
+    """
+    if not transcript.complete:
+        return None
+    try:
+        exon_start_in_tx = _exon_start_offset_in_transcript(
+            transcript, exon)
+    except (StopIteration, ValueError):
+        return None
+
+    exon_length = exon.end - exon.start + 1
+    full_sequence = str(transcript.sequence)
+
+    post_skip_cdna = (
+        full_sequence[:exon_start_in_tx]
+        + full_sequence[exon_start_in_tx + exon_length:]
+    )
+
+    cds_start = min(transcript.start_codon_spliced_offsets)
+
+    # Adjust CDS start for the deletion.
+    if exon_start_in_tx + exon_length <= cds_start:
+        # Exon is entirely in the 5' UTR → shift CDS start left.
+        new_cds_start = cds_start - exon_length
+    elif exon_start_in_tx >= cds_start:
+        # Exon is entirely after the CDS start → no shift.
+        new_cds_start = cds_start
+    else:
+        # Exon overlaps the CDS start → start codon lost.
+        new_cds_start = None
+
+    mut_protein = ""
+    if new_cds_start is not None and new_cds_start < len(post_skip_cdna):
+        codon_table = codon_table_for_transcript(transcript)
+        coding = post_skip_cdna[new_cds_start:]
+        truncated = coding[:(len(coding) // 3) * 3]
+        try:
+            mut_protein = translate_sequence(
+                truncated, codon_table=codon_table, to_stop=True)
+        except ValueError:
+            mut_protein = ""
+
+    edit = TranscriptEdit(
+        cdna_start=exon_start_in_tx,
+        cdna_end=exon_start_in_tx + exon_length,
+        alt_bases="",
+        source_variant=variant,
+    )
+
+    return MutantTranscript(
+        reference_transcript=transcript,
+        edits=(edit,),
+        cdna_sequence=post_skip_cdna,
+        mutant_protein_sequence=mut_protein,
+        annotator_name="splice_outcomes",
+    )
 
 
 def _affected_exon(splice_effect):


### PR DESCRIPTION
Rewrites the exon-skipping outcome builder in `splice_outcomes.py` on top of `MutantTranscript` and a new shared `classify_from_protein_diff` classifier. Closes the #262 prototype loop — the module docstring's "this is a prototype" qualifier is now obsolete for the exon-skip path.

## What changes

### New: `varcode/effects/classify.py`

Shared classifier that takes `(ref_protein, mut_protein, length_delta)` and emits the standard Effect classes via `trim_shared_flanking_strings`. Used by the splice-outcome builder (this PR) and the forthcoming `SequenceDiffEffectAnnotator` (#309 stage 3d).

Decision table:

| Condition | Effect |
|---|---|
| proteins match | `Silent` |
| mutant doesn't start with M | `StartLoss` |
| length_delta % 3 != 0, alt empty | `FrameShiftTruncation` |
| length_delta % 3 != 0 | `FrameShift` |
| mutant shorter, trimmed at tail | `PrematureStop` |
| mutant longer, trimmed past ref end | `StopLoss` |
| 1:1 residue change | `Substitution` |
| ref-only residues removed | `Deletion` |
| alt-only residues added | `Insertion` |
| otherwise | `ComplexSubstitution` |

### Rewritten: `_build_exon_skipping_candidate`

Old path (three ad-hoc helpers):
- `_build_in_frame_exon_skip_effect` — boundary-codon reconstruction (#298)
- `_build_out_of_frame_exon_skip_effect` — manual cDNA excision + `_ExonSkipFrameshiftEffect` shim
- `_build_start_loss_effect` — explicit start-codon-in-exon check

New path (one builder + the shared classifier):
- `_build_exon_skip_mutant_transcript` — deletes the exon's cDNA range, adjusts CDS start for 5'UTR exons, translates
- `classify_from_protein_diff` — protein diff → Effect

What falls out naturally from the diff (no ad-hoc logic needed):
- **Boundary-codon reconstruction** (#298) — the MutantTranscript translates the actual post-skip cDNA; no manual codon reshaping.
- **Start-loss detection** — exon containing the start codon → empty protein → classifier emits `StartLoss`.
- **In-frame vs. out-of-frame** — classifier uses `length_delta` to detect frameshifts.
- **`_ExonSkipFrameshiftEffect` shim** — gone. Standard `FrameShift` effect produced directly by the classifier.

### Removed (dead code, -268 lines)

`_exon_contains_start_codon`, `_exon_start_offset_in_transcript_or_none`, `_build_start_loss_effect`, `_build_out_of_frame_exon_skip_effect`, `_translate_to_first_stop`, `_ExonSkipFrameshiftEffect`, `_build_in_frame_exon_skip_effect`, plus the unused imports they depended on.

### Serialization migration

`_rehydrate_coding_effect` maps old `_ExonSkipFrameshiftEffect` serialized data to `FrameShift`. Old data from the 2.4.0–2.8.0 window round-trips cleanly.

## Why this matters for #309 (stage 3d)

The `classify_from_protein_diff` classifier that this PR introduces IS the same classifier the `SequenceDiffEffectAnnotator` will use. By building it in service of the splice rewrite, we:
- Develop and test it against a concrete use case (diverse outcome types: Silent, Deletion, FrameShift, PrematureStop, StartLoss)
- Validate it against the existing 42-test splice suite + the broader 614-test baseline
- Make stage 3d's PR smaller: it just wires the already-tested classifier into the annotator entry point

## Test plan

- [x] All 42 existing splice-outcome tests pass byte-for-byte (same Effect classes, same `short_description`, same `aa_ref`/`aa_alt`)
- [x] Full 614-test suite passes (no regressions elsewhere)
- [x] Ruff clean
- [x] Net LOC reduction: `splice_outcomes.py` -268 lines, `classify.py` +166 lines = **net -100 lines of code**

Linked: #305 tracking, #271 tracking, #309 classifier, #298 (boundary codon — absorbed), #262 (prototype — closes the loop for exon-skip path).