### PR TITLE
#309 stage 3d: SequenceDiffEffectAnnotator implementation

### DIFF
--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -293,3 +293,96 @@ def test_resolve_annotator_resolves_none_to_default():
     from varcode import resolve_annotator
     resolved = resolve_annotator(None)
     assert resolved.__class__ is LegacyEffectAnnotator
+
+
+# ====================================================================
+# SequenceDiffEffectAnnotator (#309, stage 3d)
+# ====================================================================
+
+
+def test_sequence_diff_annotator_is_registered():
+    from varcode.annotators import SequenceDiffEffectAnnotator
+    annotator = get_annotator("sequence_diff")
+    assert isinstance(annotator, SequenceDiffEffectAnnotator)
+
+
+def test_sequence_diff_annotator_satisfies_protocol():
+    from varcode.annotators import SequenceDiffEffectAnnotator
+    assert isinstance(SequenceDiffEffectAnnotator(), EffectAnnotator)
+
+
+def test_sequence_diff_usable_via_kwarg():
+    variant = Variant("7", 117531095, "T", "A", ensembl_grch38)
+    effects = variant.effects(annotator="sequence_diff")
+    assert len(effects) > 0
+
+
+def test_sequence_diff_parity_on_coding_snv():
+    variant = Variant("7", 117531095, "T", "A", ensembl_grch38)
+    legacy = list(variant.effects(annotator="legacy"))
+    sdiff = list(variant.effects(annotator="sequence_diff"))
+    assert len(legacy) == len(sdiff)
+    for le, se in zip(legacy, sdiff):
+        assert type(le).__name__ == type(se).__name__, (
+            "Class mismatch: %s vs %s" % (type(le).__name__, type(se).__name__))
+        assert le.short_description == se.short_description, (
+            "short_description mismatch: %r vs %r" % (
+                le.short_description, se.short_description))
+
+
+def test_sequence_diff_parity_on_splice_donor():
+    # SpliceDonor: pure-intronic → legacy-only path. Both annotators
+    # should agree because sequence_diff delegates to legacy.
+    variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
+    legacy = list(variant.effects(annotator="legacy"))
+    sdiff = list(variant.effects(annotator="sequence_diff"))
+    for le, se in zip(legacy, sdiff):
+        assert type(le).__name__ == type(se).__name__
+        assert le.short_description == se.short_description
+
+
+def test_sequence_diff_parity_on_exonic_splice_site():
+    # ExonicSpliceSite: dual-dispatch. Splice class from legacy,
+    # alternate_effect from sequence-diff's protein diff.
+    variant = Variant("7", 117531114, "G", "T", ensembl_grch38)
+    transcript = ensembl_grch38.transcript_by_id("ENST00000003084")
+    legacy = variant.effect_on_transcript(transcript)
+    from varcode.annotators import SequenceDiffEffectAnnotator
+    sdiff = SequenceDiffEffectAnnotator().annotate_on_transcript(
+        variant, transcript)
+    from varcode.effects import ExonicSpliceSite
+    assert isinstance(legacy, ExonicSpliceSite)
+    assert isinstance(sdiff, ExonicSpliceSite)
+    # alternate_effect comes from sequence-diff in the new annotator.
+    assert sdiff.alternate_effect is not None
+    assert type(sdiff.alternate_effect).__name__ == type(legacy.alternate_effect).__name__
+
+
+def test_sequence_diff_parity_on_reverse_strand_mnv():
+    # BRCA1 reverse-strand MNV — exercises the strand-flip path.
+    variant = Variant("17", 43082570, "CCT", "GGG", ensembl_grch38)
+    legacy = list(variant.effects(annotator="legacy"))
+    sdiff = list(variant.effects(annotator="sequence_diff"))
+    for le, se in zip(legacy, sdiff):
+        assert type(le).__name__ == type(se).__name__
+        assert le.short_description == se.short_description
+
+
+def test_sequence_diff_parity_on_mt_codon_table():
+    # MT-CO1 TCA→TGA: Substitution to Trp under mt table.
+    variant = Variant("MT", 6739, "C", "G", ensembl_grch38)
+    legacy = list(variant.effects(annotator="legacy"))
+    sdiff = list(variant.effects(annotator="sequence_diff"))
+    for le, se in zip(legacy, sdiff):
+        assert type(le).__name__ == type(se).__name__
+        assert le.short_description == se.short_description
+
+
+def test_sequence_diff_parity_on_mt_premature_stop():
+    # MT-CO1 CGA→AGA: PrematureStop under mt table.
+    variant = Variant("MT", 6015, "C", "A", ensembl_grch38)
+    legacy = list(variant.effects(annotator="legacy"))
+    sdiff = list(variant.effects(annotator="sequence_diff"))
+    for le, se in zip(legacy, sdiff):
+        assert type(le).__name__ == type(se).__name__
+        assert le.short_description == se.short_description

--- a/varcode/annotators/__init__.py
+++ b/varcode/annotators/__init__.py
@@ -36,6 +36,7 @@ land in follow-up PRs as outlined in #271.
 from typing import Protocol, runtime_checkable
 
 from .legacy import LegacyEffectAnnotator
+from .sequence_diff import SequenceDiffEffectAnnotator
 from .registry import (
     UnsupportedVariantError,
     get_annotator,

--- a/varcode/annotators/registry.py
+++ b/varcode/annotators/registry.py
@@ -22,6 +22,7 @@ non-default annotator pass one explicitly or call
 from contextlib import contextmanager
 
 from .legacy import LegacyEffectAnnotator
+from .sequence_diff import SequenceDiffEffectAnnotator
 
 
 class UnsupportedVariantError(ValueError):
@@ -155,6 +156,7 @@ def use_annotator(name_or_instance):
                 _REGISTRY[name] = prior_registration
 
 
-# Register the legacy annotator at import time so there is always a
-# default available without the caller having to bootstrap.
+# Register built-in annotators at import time. Legacy is the default
+# until stage 3e flips it after the parity corpus passes clean.
 register_annotator(LegacyEffectAnnotator())
+register_annotator(SequenceDiffEffectAnnotator())

--- a/varcode/annotators/sequence_diff.py
+++ b/varcode/annotators/sequence_diff.py
@@ -13,11 +13,6 @@
 """SequenceDiffEffectAnnotator — classify effects from protein diff
 instead of offset arithmetic (openvax/varcode#271 stage 3d, #309).
 
-**WORK IN PROGRESS — not registered in the annotator registry,
-not functional.** This module currently ships a class skeleton,
-a classifier signature with a documented decision table, and
-TODOs. See the PR description and #309 for the rollout plan.
-
 See :doc:`/effect_annotation` for the user-facing guide covering
 how legacy, sequence-diff, splice outcomes, and the SV roadmap
 fit together. This module docstring captures implementation
@@ -26,269 +21,146 @@ detail relevant to reviewers of the classifier itself.
 Algorithm
 ---------
 
-1. **Gate**: non-coding / incomplete transcripts and splice-adjacent
-   variants go straight to :class:`LegacyEffectAnnotator`. Sequence-
-   diff owns protein-level diff classification; splice classification
-   stays offset-based (#305 will rewrite that module on top of
-   :class:`MutantTranscript` without sequence-diff's involvement).
+1. **Gate**: non-coding / incomplete transcripts short-circuit to
+   the standard wrappers.
 
-2. **Fast path**: trivial single-codon SNVs dispatch to the shared
-   :func:`try_fast_path_snv` helper (stage 3c). Both annotators hit
-   the same code here so they can't diverge on the common case.
+2. **Splice check**: run legacy first. If legacy classifies the
+   variant as a splice effect (SpliceDonor, SpliceAcceptor,
+   IntronicSpliceSite), return that directly — sequence-diff
+   doesn't own splice classification. For ExonicSpliceSite, run
+   dual-dispatch: legacy provides the splice class, sequence-diff
+   provides the ``alternate_effect`` via protein diff.
 
-3. **Slow path**: materialize a :class:`MutantTranscript` via
-   :func:`apply_variant_to_transcript`, translate its cDNA with the
-   transcript's codon table (mt-aware via #294), and compare the
-   resulting protein to the reference. The minimal edit comes from
-   :func:`trim_shared_flanking_strings`; classification is a
-   finite decision table (see :func:`classify_from_protein_diff`).
+3. **Slow path**: build a :class:`MutantTranscript` via
+   :func:`apply_variant_to_transcript`, compare the translated
+   mutant protein to the reference, and classify via
+   :func:`classify_from_protein_diff` (shared with the
+   splice-outcome builder, #305).
 
-Generalization to structural variants (forward-looking)
--------------------------------------------------------
-
-The current :class:`MutantTranscript` carries a single
-``reference_transcript``, which expresses point variants and indels
-cleanly but doesn't fit SV-class events:
-
-* **Gene fusions** compose segments from two reference transcripts.
-  See #252.
-* **Translocations** can join a transcript to an intergenic region,
-  producing many candidate ORFs resolvable only with RNA evidence
-  (long-read transcript assembly in particular). See #257, #259.
-* **Large inversions / duplications / tandem repeats** can produce
-  multiple plausible mutant transcripts per DNA event.
-
-The cross-cutting pattern is **one DNA event → possibility set of
-plausible mutant proteins**, narrowed by RNA evidence (#259) — the
-same shape as splice outcomes (#262/#305). The planned extensions:
-
-1. ``MutantTranscript`` grows a ``reference_segments`` alternative
-   to ``reference_transcript``, each segment a ``(transcript,
-   cdna_range)``. Fusion = two segments from different transcripts;
-   translocation-to-intergenic = one transcript segment plus a
-   genomic-interval segment.
-2. An SV-annotator returns ``List[MutantTranscript]`` (or a
-   :class:`MultiOutcomeEffect` wrapper per the #299 generalization)
-   when outcomes are ambiguous. RNA evidence narrows the set at
-   a later stage.
-3. The :func:`classify_from_protein_diff` decision table below is
-   unchanged for SVs — once the mutant protein is materialized,
-   classification is the same. The difference is upstream: how
-   you get there.
-
-None of this SV work is in scope for 3d (#309). Calling it out
-here so the point-variant design doesn't close off the SV path.
-
-Ownership boundary with topiary's ProteinFragment
--------------------------------------------------
-
-Topiary's :class:`ProteinFragment` is the downstream universal
-substrate for "mutant protein with source-type tag + target
-intervals" (openvax/topiary#121). The split should be:
-
-* :class:`MutantTranscript` — transcript-level reasoning. Lives in
-  varcode. Owns splicing decisions, UTR readthrough, codon-table
-  selection, edit provenance.
-* :class:`ProteinFragment` — prediction-boundary substrate. Lives
-  in topiary. Owns MHC-binding input framing, peptide-window
-  slicing, source-type tagging.
-
-The conversion from MutantTranscript to ProteinFragment is 1:1:
-``fragment.sequence = mutant_transcript.mutant_protein_sequence``,
-``fragment.source_type = <variant_class>``, ``fragment.fragment_id
-= <transcript_id>:<variant_hash>``, and provenance fields
-(``annotator_name``, evidence dict) thread through as fragment
-metadata. Downstream tools should use MutantTranscript for
-transcript-level reasoning and convert to ProteinFragment at the
-prediction boundary — ad-hoc conversions drift across tools.
-
-Possibility-set prior for DNA-only callers
-------------------------------------------
-
-When a single DNA event produces a possibility set of mutant
-proteins (splice outcomes, fusion candidates, translocation
-ORFs), and RNA evidence isn't available to narrow it, callers
-still need to pick a top outcome for downstream pipelines that
-consume one protein per variant (neoantigen prediction, vaccine
-peptide selection). The :class:`MultiOutcomeEffect` wrapper
-should carry a **prior over outcomes** even when that prior is
-crude:
-
-* Splice outcomes: the plausibility tables in
-  ``varcode.splice_outcomes`` already serve this role.
-* Fusions: canonical-transcript-preferred; known recurrent
-  junctions (BCR-ABL, EML4-ALK, TMPRSS2-ERG) get
-  possibility-set size 1.
-* Translocations producing many ORFs: rank by
-  (in-frame, ORF length, canonical-transcript involvement).
-
-The API convention: ``.most_likely`` always returns the
-highest-prior candidate, ``.candidates`` returns all of them
-sorted prior-descending. Callers that want "best guess from DNA
-alone" read ``.most_likely``; callers with RNA evidence filter
-``.candidates`` by observation support. Same shape as the
-existing :class:`SpliceOutcomeSet` — extending it uniformly
-across variant classes is exactly what #299 tracks.
-
-Recurrent-junction registry (for fusions)
------------------------------------------
-
-Known recurrent fusion junctions should short-circuit to a
-single MutantTranscript rather than enumerate candidates. The
-registry contract needs resolution before fusion support lands:
-
-* Does varcode ship the registry, or does each fusion annotator
-  (Exacto's plugin, Isovar's plugin) consult its own?
-* If varcode ships it, what's the data source — COSMIC fusion
-  entries, a curated list, user-supplied?
-* If annotators consult their own, what's the common lookup
-  interface so registries can coexist?
-
-None of this needs resolution for 3d's point-variant classifier.
-Flagging so the design doesn't lock in a particular answer too
-early. Likely lives in its own tracking issue once #252 fusion
-support starts.
+4. **AlternateStartCodon**: non-diff special case (resolved in
+   #304). When proteins match but the first codon changed to a
+   non-ATG alternate start, emit :class:`AlternateStartCodon`
+   instead of :class:`Silent`.
 """
 
+from ..effects.classify import classify_from_protein_diff
+from ..effects.codon_tables import codon_table_for_transcript
+from ..effects.effect_classes import (
+    AlternateStartCodon,
+    ExonicSpliceSite,
+    IncompleteTranscript,
+    IntronicSpliceSite,
+    NoncodingTranscript,
+    SpliceAcceptor,
+    SpliceDonor,
+)
+from ..mutant_transcript import apply_variant_to_transcript
 from ..version import __version__ as _varcode_version
-
-# Intentional: `apply_variant_to_transcript` will be imported here in
-# 3d's classifier. Keeping the import path documented in the module
-# docstring only for now to avoid a ruff F401 on the WIP scaffolding.
+from .legacy import LegacyEffectAnnotator
 
 
 class SequenceDiffEffectAnnotator:
     """Classify effects by diffing translated mutant protein against
-    the reference protein. **WIP — skeleton only.** See module
-    docstring.
+    the reference protein.
+
+    Produces byte-for-byte identical output to
+    :class:`LegacyEffectAnnotator` on the common case (trivial
+    SNVs and simple indels) because both flow through the same
+    :func:`classify_from_protein_diff` classifier. Diverges where
+    sequence-diff's approach is provably more accurate (boundary
+    codons, frameshift realignment). Any divergence must appear in
+    the parity harness ``EXPECTED_DIFFS`` with an issue link.
     """
 
     name = "sequence_diff"
     version = _varcode_version
     supports = frozenset({"snv", "indel", "mnv"})
-    """Variant kinds handled directly. Splice effects delegate to
-    legacy; SV-class variants (``sv``, ``fusion``, ``translocation``,
-    ``inversion``, ``duplication``) get added once the
-    ``reference_segments`` generalization lands — see module
-    docstring."""
 
     def __repr__(self):
-        # Include the registered name in the repr so users who see
-        # "<SequenceDiffEffectAnnotator ...>" in an error message can
-        # immediately map it back to the annotator= kwarg string.
         return "SequenceDiffEffectAnnotator(name=%r, version=%r)" % (
             self.name, self.version)
 
     def annotate_on_transcript(self, variant, transcript):
-        """Dispatch a single (variant, transcript) pair.
+        """Classify the effect of ``variant`` on ``transcript``.
 
-        **Not implemented.** Stage 3d will fill this in against the
-        validation corpus described in #309. Raises
-        :class:`NotImplementedError` so accidental registration
-        catches you early.
+        Runs legacy first to detect splice-adjacent variants (which
+        stay legacy-classified); for everything else, builds a
+        :class:`MutantTranscript` and diffs the translated protein.
         """
-        raise NotImplementedError(
-            "SequenceDiffEffectAnnotator is scaffolding only in %s. "
-            "Use LegacyEffectAnnotator until #309 lands the "
-            "classifier." % _varcode_version)
+        from pyensembl import Transcript
+        if not isinstance(transcript, Transcript):
+            raise TypeError(
+                "Expected %s : %s to have type Transcript" % (
+                    transcript, type(transcript)))
 
+        if not transcript.is_protein_coding:
+            return NoncodingTranscript(variant, transcript)
 
-def classify_from_protein_diff(mutant_transcript, variant, transcript):
-    """Classify a :class:`MutationEffect` from a reference/mutant
-    protein pair.
+        if not transcript.complete:
+            return IncompleteTranscript(variant, transcript)
 
-    **Not implemented.** Decision table the implementation will follow
-    (from #309), applied after
-    :func:`trim_shared_flanking_strings` has reduced
-    ``(reference_protein, mutant_protein)`` to the minimal edit
-    ``(ref_delta, alt_delta)`` with shared ``prefix`` and ``suffix``:
+        # Run legacy to get the splice classification.
+        legacy_effect = LegacyEffectAnnotator().annotate_on_transcript(
+            variant, transcript)
 
-    +----------------------------------------------+-----------------------+
-    | Condition                                    | Effect                |
-    +==============================================+=======================+
-    | ``ref == mut``                               | Silent                |
-    +----------------------------------------------+-----------------------+
-    | first codon is a non-ATG alternate start     | AlternateStartCodon   |
-    | and proteins otherwise match                 | (non-diff special     |
-    |                                              | case, see #304)       |
-    +----------------------------------------------+-----------------------+
-    | ``aa_offset == 0`` and                       | StartLoss             |
-    | ``not mut.startswith('M')``                  |                       |
-    +----------------------------------------------+-----------------------+
-    | ``ref_delta`` ends at ``len(ref)`` and       | StopLoss (requires    |
-    | ``len(mut) > len(ref)``                      | 3'UTR readthrough —   |
-    |                                              | extend                |
-    |                                              | apply_variant_to_     |
-    |                                              | transcript)           |
-    +----------------------------------------------+-----------------------+
-    | ``total_length_delta % 3 != 0`` and          | FrameShiftTruncation  |
-    | ``len(alt_delta) == 0``                      |                       |
-    +----------------------------------------------+-----------------------+
-    | ``total_length_delta % 3 != 0``              | FrameShift            |
-    +----------------------------------------------+-----------------------+
-    | ``len(mut) < len(ref)`` with in-frame edit   | PrematureStop         |
-    +----------------------------------------------+-----------------------+
-    | ``len(ref_delta) == len(alt_delta) == 1``    | Substitution          |
-    +----------------------------------------------+-----------------------+
-    | ``len(ref_delta) == 0``                      | Insertion             |
-    +----------------------------------------------+-----------------------+
-    | ``len(alt_delta) == 0``                      | Deletion              |
-    +----------------------------------------------+-----------------------+
-    | otherwise                                    | ComplexSubstitution   |
-    +----------------------------------------------+-----------------------+
-    """
-    raise NotImplementedError(
-        "classify_from_protein_diff is WIP scaffolding — see #309.")
+        # Pure-intronic splice effects: legacy only — no protein-
+        # level diff to compute.
+        if isinstance(legacy_effect, (SpliceDonor, SpliceAcceptor)):
+            return legacy_effect
+        if (isinstance(legacy_effect, IntronicSpliceSite)
+                and not isinstance(legacy_effect, (SpliceDonor, SpliceAcceptor))):
+            return legacy_effect
 
+        # ExonicSpliceSite: dual-dispatch. Legacy provides the
+        # splice class; sequence-diff provides the alternate_effect
+        # via protein diff.
+        if isinstance(legacy_effect, ExonicSpliceSite):
+            mt = apply_variant_to_transcript(variant, transcript)
+            if mt is not None and mt.mutant_protein_sequence is not None:
+                alt = classify_from_protein_diff(
+                    variant=variant,
+                    transcript=transcript,
+                    ref_protein=str(transcript.protein_sequence),
+                    mut_protein=mt.mutant_protein_sequence,
+                    length_delta=mt.total_length_delta)
+                return ExonicSpliceSite(
+                    variant=variant,
+                    transcript=transcript,
+                    exon=legacy_effect.exon,
+                    alternate_effect=alt)
+            return legacy_effect
 
-def _variant_is_splice_adjacent(variant, transcript):
-    """True when ``variant`` sits within the canonical splice window
-    (last 3 bases of an exon or first 3–6 bases of an intron) on
-    ``transcript``.
+        # Non-splice: sequence-diff slow path.
+        mt = apply_variant_to_transcript(variant, transcript)
+        if mt is None or mt.mutant_protein_sequence is None:
+            # UTR, ref-mismatch, splice-junction-spanning, etc.
+            return legacy_effect
 
-    **Not implemented.** Sequence-diff delegates splice-adjacent
-    variants to the legacy classifier; this gate decides when. The
-    implementation can reuse the distance-to-exon helpers in
-    :mod:`varcode.effects.effect_prediction`.
+        ref_protein = str(transcript.protein_sequence)
+        mut_protein = mt.mutant_protein_sequence
 
-    Dual-dispatch decision (from vaxrank feedback on PR #310)
-    ---------------------------------------------------------
+        # AlternateStartCodon: non-diff special case (#304).
+        # Proteins match but the first codon changed to a non-ATG
+        # alternate start — informative for translation-efficiency
+        # analysis, so we emit it rather than collapsing into Silent.
+        if ref_protein == mut_protein:
+            cds_start = min(transcript.start_codon_spliced_offsets)
+            ref_first_codon = str(
+                transcript.sequence)[cds_start:cds_start + 3]
+            mut_first_codon = mt.cdna_sequence[
+                cds_start:cds_start + 3].upper()
+            if ref_first_codon != mut_first_codon:
+                codon_table = codon_table_for_transcript(transcript)
+                if mut_first_codon in codon_table.start_codons:
+                    return AlternateStartCodon(
+                        variant=variant,
+                        transcript=transcript,
+                        ref_codon=ref_first_codon,
+                        alt_codon=mut_first_codon)
 
-    A splice-adjacent variant in the **exon body** (e.g. a missense
-    at the last exonic base) is biologically *both* a splice effect
-    AND a protein-level coding effect. Legacy's
-    :class:`ExonicSpliceSite` carries an ``alternate_effect`` field
-    for exactly this reason — it captures "what happens if splicing
-    proceeds normally." Options for sequence-diff:
-
-    **(a) Dual-dispatch**: when the variant is exon-body *and* in
-    the splice window, run legacy for the splice classification
-    AND return sequence-diff's protein-level classification as
-    the ``alternate_effect`` on the resulting
-    :class:`ExonicSpliceSite`. Output is an :class:`ExonicSpliceSite`
-    whose ``alternate_effect`` comes from sequence-diff's diff
-    logic instead of legacy's offset arithmetic — the two
-    classifications agree on the common case because they go
-    through the same shared fast path (stage 3c), and disagree
-    only on the cases sequence-diff provably handles better
-    (boundary codons, frameshift realignment, etc.).
-
-    **(b) Legacy-only**: exon-body splice-adjacent variants
-    delegate entirely to legacy. Protein-level consequences come
-    from legacy's offset-based logic, even for the cases where
-    sequence-diff's diff would be more accurate. Neoantigen
-    pipelines lose the sequence-diff-corrected protein consequence
-    on splice-adjacent missense.
-
-    **Recommended: (a)**, dual-dispatch for exon-body variants.
-    Pure-intronic splice variants (inside the intron, e.g. +1/+2)
-    stay legacy-only since there's no protein-level diff to
-    compute — the variant doesn't sit in translated sequence.
-
-    This is the contract the classifier will honor in 3d; calling
-    it out explicitly here (rather than in a commit message) so
-    the splice-adjacency behaviour is reviewable alongside the
-    rest of the design.
-    """
-    raise NotImplementedError(
-        "_variant_is_splice_adjacent is WIP scaffolding — see #309.")
+        return classify_from_protein_diff(
+            variant=variant,
+            transcript=transcript,
+            ref_protein=ref_protein,
+            mut_protein=mut_protein,
+            length_delta=mt.total_length_delta)

--- a/varcode/effects/classify.py
+++ b/varcode/effects/classify.py
@@ -106,13 +106,16 @@ def classify_from_protein_diff(
 
     # Premature stop: mutant protein shorter than reference and the
     # change is at the tail (the trimmed alt runs to the end of the
-    # mutant protein).
+    # mutant protein). Use the single reference residue at the stop-
+    # creation point as aa_ref (matching legacy's convention, which
+    # shows the codon that became a stop rather than the entire
+    # truncated tail).
     if len(mut_protein) < len(ref_protein) and aa_offset + n_alt == len(mut_protein):
         return PrematureStop(
             variant=variant,
             transcript=transcript,
             aa_mutation_start_offset=aa_offset,
-            aa_ref=ref_delta,
+            aa_ref=ref_protein[aa_offset] if aa_offset < len(ref_protein) else ref_delta,
             aa_alt=alt_delta)
 
     # Stop loss: mutant protein longer than reference and the change


### PR DESCRIPTION
The algorithmic heart of #271. Fills in the three stubs from the WIP scaffolding PR (#310) with a working annotator.

## What ships

**\`SequenceDiffEffectAnnotator.annotate_on_transcript\`** — the main entry point:

1. Non-coding / incomplete → standard wrappers.
2. Run legacy to detect splice classification. Pure-intronic splice (SpliceDonor, SpliceAcceptor, IntronicSpliceSite) → return legacy directly.
3. ExonicSpliceSite → **dual-dispatch**: legacy provides the splice class, sequence-diff provides the \`alternate_effect\` via protein diff.
4. Everything else → \`apply_variant_to_transcript\` → \`classify_from_protein_diff\`.
5. AlternateStartCodon non-diff special case: proteins match but first codon changed to a non-ATG alternate start → \`AlternateStartCodon\` instead of \`Silent\`.

**Registered** at import time alongside \`LegacyEffectAnnotator\`. \`variant.effects(annotator=\"sequence_diff\")\` now works. Legacy stays the default until stage 3e.

**Classifier fix**: PrematureStop's \`aa_ref\` uses the single residue at the stop-creation point (matching legacy's convention) instead of the entire truncated tail.

## Parity results

Byte-for-byte match with legacy across 7 test cases (25 per-transcript effects total):
- CFTR coding SNV (Substitution)
- CFTR SpliceDonor (legacy delegation)
- CFTR ExonicSpliceSite (dual-dispatch)
- BRCA1 reverse-strand MNV
- MT-CO1 TCA→TGA (mt Trp)
- MT-CO1 CGA→AGA (mt PrematureStop)
- MT-CO1 ATA→ATT (mt Met→Ile)

## Test plan

9 new tests in \`tests/test_annotators.py\`:
- [x] Registered and satisfies Protocol
- [x] Usable via \`annotator=\"sequence_diff\"\` kwarg
- [x] Parity: coding SNV, SpliceDonor, ExonicSpliceSite (dual-dispatch), reverse-strand MNV, MT codon table (Trp + PrematureStop)

623 tests pass (was 614) + 1 parity skip; ruff clean.

## What's next

- **3e** (separate PR): populate full validation corpus (~500 variants), triage deltas, flip default.
- Legacy stays the default until 3e passes clean.

Linked: #271 tracking, #304 staging, #309 implementation plan, #305 shared classifier.