### PR TITLE
Rename sequence_diff → protein_diff; add --annotator test fixture

### DIFF
--- a/docs/effect_annotation.md
+++ b/docs/effect_annotation.md
@@ -196,11 +196,11 @@ Two annotators coexist behind the `EffectAnnotator` protocol:
 | Annotator | Algorithm | Status |
 |---|---|---|
 | `LegacyEffectAnnotator` | Offset arithmetic against the reference CDS | Default |
-| `SequenceDiffEffectAnnotator` | Materializes `MutantTranscript`, translates, diffs against reference protein | [#309][i309] — WIP |
+| `ProteinDiffEffectAnnotator` | Materializes `MutantTranscript`, translates, diffs against reference protein | [#309][i309] — WIP |
 
 Both emit the same `MutationEffect` classes, share a fast path
 for trivial SNVs, and are interchangeable at the output level.
-The difference is internal: sequence-diff catches
+The difference is internal: protein-diff catches
 boundary-codon cases and frameshift realignments that offset
 arithmetic can miss.
 
@@ -208,11 +208,11 @@ arithmetic can miss.
 # Default (legacy):
 effects = variant.effects()
 
-# Opt into sequence-diff (once available):
-effects = variant.effects(annotator="sequence_diff")
+# Opt into protein-diff (once available):
+effects = variant.effects(annotator="protein_diff")
 
 # Scoped default swap:
-with varcode.use_annotator("sequence_diff"):
+with varcode.use_annotator("protein_diff"):
     effects = variant_collection.effects()
 ```
 
@@ -233,7 +233,7 @@ Every `EffectCollection` produced by `predict_variant_effects`
 records:
 
 - `annotator` — name of the annotator that ran (`"legacy"`,
-  `"sequence_diff"`, etc.)
+  `"protein_diff"`, etc.)
 - `annotator_version` — version string
 - `annotated_at` — ISO-8601 UTC timestamp
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,71 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared pytest fixtures for the varcode test suite.
+
+The ``dual_annotator`` fixture parametrizes every test that uses it
+over both ``"legacy"`` and ``"protein_diff"`` annotators. Tests that
+call ``variant.effects()`` inside a ``use_annotator(annotator_name)``
+scope exercise both code paths automatically.
+
+The ``annotator_scope`` autouse fixture sets the default annotator
+for the entire test function based on the ``--annotator`` CLI option
+(default: ``"legacy"``). This lets CI run the full suite under
+``protein_diff`` with ``pytest --annotator=protein_diff`` to catch
+parity regressions across ALL tests, not just the explicit parity
+harness.
+"""
+
+import pytest
+
+import varcode
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--annotator",
+        action="store",
+        default=None,
+        help=(
+            "Run the full test suite under a specific annotator "
+            "(e.g. --annotator=protein_diff). Default: no override "
+            "(uses whatever each test sets, which is legacy unless "
+            "the test explicitly picks something else)."
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def annotator_scope(request):
+    """When ``--annotator=<name>`` is passed on the CLI, temporarily
+    set it as the default for every test. Otherwise no-op.
+    """
+    name = request.config.getoption("--annotator")
+    if name is not None:
+        with varcode.use_annotator(name):
+            yield
+    else:
+        yield
+
+
+@pytest.fixture(params=["legacy", "protein_diff"])
+def dual_annotator(request):
+    """Parametrize a test over both annotators. Use this on tests
+    that exercise ``variant.effects()`` to get automatic dual-
+    annotator coverage::
+
+        def test_something(dual_annotator):
+            with varcode.use_annotator(dual_annotator):
+                effects = variant.effects()
+                ...
+    """
+    return request.param

--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -129,7 +129,7 @@ def test_legacy_annotator_matches_effect_on_transcript():
 
 # ====================================================================
 # UnsupportedVariantError is available as an exception class for the
-# sequence-diff annotator to raise. No code throws it yet (no
+# protein-diff annotator to raise. No code throws it yet (no
 # annotator currently checks `.supports` at runtime), but downstream
 # code can already catch it.
 # ====================================================================
@@ -296,31 +296,31 @@ def test_resolve_annotator_resolves_none_to_default():
 
 
 # ====================================================================
-# SequenceDiffEffectAnnotator (#309, stage 3d)
+# ProteinDiffEffectAnnotator (#309, stage 3d)
 # ====================================================================
 
 
-def test_sequence_diff_annotator_is_registered():
-    from varcode.annotators import SequenceDiffEffectAnnotator
-    annotator = get_annotator("sequence_diff")
-    assert isinstance(annotator, SequenceDiffEffectAnnotator)
+def test_protein_diff_annotator_is_registered():
+    from varcode.annotators import ProteinDiffEffectAnnotator
+    annotator = get_annotator("protein_diff")
+    assert isinstance(annotator, ProteinDiffEffectAnnotator)
 
 
-def test_sequence_diff_annotator_satisfies_protocol():
-    from varcode.annotators import SequenceDiffEffectAnnotator
-    assert isinstance(SequenceDiffEffectAnnotator(), EffectAnnotator)
+def test_protein_diff_annotator_satisfies_protocol():
+    from varcode.annotators import ProteinDiffEffectAnnotator
+    assert isinstance(ProteinDiffEffectAnnotator(), EffectAnnotator)
 
 
-def test_sequence_diff_usable_via_kwarg():
+def test_protein_diff_usable_via_kwarg():
     variant = Variant("7", 117531095, "T", "A", ensembl_grch38)
-    effects = variant.effects(annotator="sequence_diff")
+    effects = variant.effects(annotator="protein_diff")
     assert len(effects) > 0
 
 
-def test_sequence_diff_parity_on_coding_snv():
+def test_protein_diff_parity_on_coding_snv():
     variant = Variant("7", 117531095, "T", "A", ensembl_grch38)
     legacy = list(variant.effects(annotator="legacy"))
-    sdiff = list(variant.effects(annotator="sequence_diff"))
+    sdiff = list(variant.effects(annotator="protein_diff"))
     assert len(legacy) == len(sdiff)
     for le, se in zip(legacy, sdiff):
         assert type(le).__name__ == type(se).__name__, (
@@ -330,59 +330,59 @@ def test_sequence_diff_parity_on_coding_snv():
                 le.short_description, se.short_description))
 
 
-def test_sequence_diff_parity_on_splice_donor():
+def test_protein_diff_parity_on_splice_donor():
     # SpliceDonor: pure-intronic → legacy-only path. Both annotators
-    # should agree because sequence_diff delegates to legacy.
+    # should agree because protein_diff delegates to legacy.
     variant = Variant("7", 117531115, "G", "A", ensembl_grch38)
     legacy = list(variant.effects(annotator="legacy"))
-    sdiff = list(variant.effects(annotator="sequence_diff"))
+    sdiff = list(variant.effects(annotator="protein_diff"))
     for le, se in zip(legacy, sdiff):
         assert type(le).__name__ == type(se).__name__
         assert le.short_description == se.short_description
 
 
-def test_sequence_diff_parity_on_exonic_splice_site():
+def test_protein_diff_parity_on_exonic_splice_site():
     # ExonicSpliceSite: dual-dispatch. Splice class from legacy,
-    # alternate_effect from sequence-diff's protein diff.
+    # alternate_effect from protein-diff's protein diff.
     variant = Variant("7", 117531114, "G", "T", ensembl_grch38)
     transcript = ensembl_grch38.transcript_by_id("ENST00000003084")
     legacy = variant.effect_on_transcript(transcript)
-    from varcode.annotators import SequenceDiffEffectAnnotator
-    sdiff = SequenceDiffEffectAnnotator().annotate_on_transcript(
+    from varcode.annotators import ProteinDiffEffectAnnotator
+    sdiff = ProteinDiffEffectAnnotator().annotate_on_transcript(
         variant, transcript)
     from varcode.effects import ExonicSpliceSite
     assert isinstance(legacy, ExonicSpliceSite)
     assert isinstance(sdiff, ExonicSpliceSite)
-    # alternate_effect comes from sequence-diff in the new annotator.
+    # alternate_effect comes from protein-diff in the new annotator.
     assert sdiff.alternate_effect is not None
     assert type(sdiff.alternate_effect).__name__ == type(legacy.alternate_effect).__name__
 
 
-def test_sequence_diff_parity_on_reverse_strand_mnv():
+def test_protein_diff_parity_on_reverse_strand_mnv():
     # BRCA1 reverse-strand MNV — exercises the strand-flip path.
     variant = Variant("17", 43082570, "CCT", "GGG", ensembl_grch38)
     legacy = list(variant.effects(annotator="legacy"))
-    sdiff = list(variant.effects(annotator="sequence_diff"))
+    sdiff = list(variant.effects(annotator="protein_diff"))
     for le, se in zip(legacy, sdiff):
         assert type(le).__name__ == type(se).__name__
         assert le.short_description == se.short_description
 
 
-def test_sequence_diff_parity_on_mt_codon_table():
+def test_protein_diff_parity_on_mt_codon_table():
     # MT-CO1 TCA→TGA: Substitution to Trp under mt table.
     variant = Variant("MT", 6739, "C", "G", ensembl_grch38)
     legacy = list(variant.effects(annotator="legacy"))
-    sdiff = list(variant.effects(annotator="sequence_diff"))
+    sdiff = list(variant.effects(annotator="protein_diff"))
     for le, se in zip(legacy, sdiff):
         assert type(le).__name__ == type(se).__name__
         assert le.short_description == se.short_description
 
 
-def test_sequence_diff_parity_on_mt_premature_stop():
+def test_protein_diff_parity_on_mt_premature_stop():
     # MT-CO1 CGA→AGA: PrematureStop under mt table.
     variant = Variant("MT", 6015, "C", "A", ensembl_grch38)
     legacy = list(variant.effects(annotator="legacy"))
-    sdiff = list(variant.effects(annotator="sequence_diff"))
+    sdiff = list(variant.effects(annotator="protein_diff"))
     for le, se in zip(legacy, sdiff):
         assert type(le).__name__ == type(se).__name__
         assert le.short_description == se.short_description

--- a/tests/test_csv_roundtrip.py
+++ b/tests/test_csv_roundtrip.py
@@ -371,7 +371,7 @@ def test_effect_collection_from_csv_warns_on_annotator_mismatch():
         with open(path, "w") as f:
             for line in lines:
                 if line.startswith("# annotator="):
-                    f.write("# annotator=sequence_diff\n")
+                    f.write("# annotator=protein_diff\n")
                 else:
                     f.write(line)
         with warnings.catch_warnings(record=True) as caught:
@@ -382,7 +382,7 @@ def test_effect_collection_from_csv_warns_on_annotator_mismatch():
 
     messages = [str(w.message) for w in caught]
     assert any(
-        "sequence_diff" in m and "legacy" in m for m in messages), (
+        "protein_diff" in m and "legacy" in m for m in messages), (
         "Expected a warning about annotator mismatch, got: %r" % messages)
 
 

--- a/tests/test_mutant_transcript.py
+++ b/tests/test_mutant_transcript.py
@@ -113,11 +113,11 @@ def test_mutant_transcript_carries_sequences_when_producer_supplies_them():
         edits=(TranscriptEdit(10, 13, "TTT"),),
         cdna_sequence="AAA...TTT...GGG",
         mutant_protein_sequence="MKL*",
-        annotator_name="sequence_diff",
+        annotator_name="protein_diff",
     )
     assert mt.cdna_sequence == "AAA...TTT...GGG"
     assert mt.mutant_protein_sequence == "MKL*"
-    assert mt.annotator_name == "sequence_diff"
+    assert mt.annotator_name == "protein_diff"
 
 
 def test_mutant_transcript_is_exported_at_package_root():
@@ -140,7 +140,7 @@ def test_apply_snv_to_forward_strand_coding_variant():
     mt = apply_variant_to_transcript(variant, transcript)
     assert mt is not None
     assert mt.reference_transcript is transcript
-    assert mt.annotator_name == "sequence_diff"
+    assert mt.annotator_name == "protein_diff"
     assert len(mt.edits) == 1
     edit = mt.edits[0]
     assert edit.cdna_end - edit.cdna_start == 1

--- a/tests/test_protein_diff_parity.py
+++ b/tests/test_protein_diff_parity.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Parity harness for SequenceDiffEffectAnnotator vs LegacyEffectAnnotator
+"""Parity harness for ProteinDiffEffectAnnotator vs LegacyEffectAnnotator
 (openvax/varcode#271 stage 3d, #309).
 
 **WIP — skipped in CI.** The harness skeleton is in place so the
@@ -21,7 +21,7 @@ classifier lands. The target gate for 3d merge is:
         for transcript in variant.transcripts:
             legacy = LegacyEffectAnnotator().annotate_on_transcript(
                 variant, transcript)
-            sdiff = SequenceDiffEffectAnnotator().annotate_on_transcript(
+            sdiff = ProteinDiffEffectAnnotator().annotate_on_transcript(
                 variant, transcript)
             assert type(legacy) is type(sdiff)
             assert legacy.short_description == sdiff.short_description
@@ -34,8 +34,8 @@ deltas are logged as INFO via ``logging.info`` rather than asserted.
 The goal at that stage is to **review the parity contract** — each
 delta is either:
 
-  (a) a sequence-diff bug that needs fixing before merge, or
-  (b) a legacy bug that sequence-diff corrects (pinned in
+  (a) a protein-diff bug that needs fixing before merge, or
+  (b) a legacy bug that protein-diff corrects (pinned in
       ``EXPECTED_DIFFS`` with an issue link).
 
 Only after every delta has been triaged does the harness flip to
@@ -77,7 +77,7 @@ edge cases from the PR #310 review:
       1 but represent a compound substitution.
     * Variant at last exonic base that also changes an amino
       acid — verifies the splice-adjacency gate's dual-dispatch
-      behaviour (see sequence_diff._variant_is_splice_adjacent
+      behaviour (see protein_diff._variant_is_splice_adjacent
       docstring for the contract).
     * A variant whose effect_type changed across varcode major
       versions (legacy ComplexSubstitution ↔ Substitution) —
@@ -93,7 +93,7 @@ import pytest
 pytestmark = pytest.mark.parity
 
 pytest.skip(
-    "SequenceDiffEffectAnnotator is scaffolding only; parity harness "
+    "ProteinDiffEffectAnnotator is scaffolding only; parity harness "
     "activates with #309's classifier PR.",
     allow_module_level=True,
 )
@@ -103,13 +103,13 @@ pytest.skip(
 # in the module docstring.
 CORPUS = []
 
-# Variants where sequence_diff and legacy intentionally differ. Each
+# Variants where protein_diff and legacy intentionally differ. Each
 # entry: (variant_key, reason_issue_url, reason_description).
 # Empty at merge time — any real disagreements must be triaged, not
 # silently accepted.
 EXPECTED_DIFFS = {}
 
 
-def test_sequence_diff_matches_legacy_on_corpus():
+def test_protein_diff_matches_legacy_on_corpus():
     """Byte-for-byte parity on the validation corpus. Gate for 3d merge."""
     pass  # filled in by #309

--- a/varcode/annotators/__init__.py
+++ b/varcode/annotators/__init__.py
@@ -20,7 +20,7 @@ users can choose between:
 
 * ``legacy`` — the offset-based annotator that has shipped since
   2.0.0. Wraps :func:`varcode.effects.predict_variant_effect_on_transcript`.
-* ``sequence_diff`` — the coming annotator that materializes a
+* ``protein_diff`` — the coming annotator that materializes a
   :class:`MutantTranscript` and diffs its translated protein
   against the reference. Not in this stage; see #271.
 
@@ -28,7 +28,7 @@ Third parties (Isovar, Exacto) can register their own annotators by
 implementing the Protocol and calling :func:`register_annotator`.
 
 This stage 1 PR ships only the Protocol + registry + legacy wrapper;
-the sequence-diff annotator, fast-path routing, per-call selection on
+the protein-diff annotator, fast-path routing, per-call selection on
 ``Variant.effects()``, and ``EffectCollection`` provenance fields
 land in follow-up PRs as outlined in #271.
 """
@@ -36,7 +36,7 @@ land in follow-up PRs as outlined in #271.
 from typing import Protocol, runtime_checkable
 
 from .legacy import LegacyEffectAnnotator
-from .sequence_diff import SequenceDiffEffectAnnotator
+from .protein_diff import ProteinDiffEffectAnnotator
 from .registry import (
     UnsupportedVariantError,
     get_annotator,

--- a/varcode/annotators/legacy.py
+++ b/varcode/annotators/legacy.py
@@ -14,7 +14,7 @@
 offset-based effect prediction that varcode has shipped since 2.0.0.
 
 Exists as an :class:`EffectAnnotator` Protocol implementation so
-that the coming sequence-diff annotator can be introduced behind
+that the coming protein-diff annotator can be introduced behind
 the same interface without churning callers (#271, stage 2). Until
 then, this annotator is the default and produces byte-for-byte
 identical output to ``Variant.effect_on_transcript(transcript)``.
@@ -38,13 +38,13 @@ class LegacyEffectAnnotator:
     """Variant kinds this annotator handles. Splice-possibility
     sets, structural variants, and phased haplotypes fall outside
     the legacy offset-based path and will be handled by the
-    sequence-diff annotator."""
+    protein-diff annotator."""
 
     def annotate_on_transcript(self, variant, transcript):
         """Delegate to the existing per-transcript prediction.
 
         No fast-path / slow-path dispatch at this stage; that lives
-        on the sequence-diff annotator once it exists.
+        on the protein-diff annotator once it exists.
         """
         # Lazy import avoids a circular dep at package import time.
         from ..effects import predict_variant_effect_on_transcript

--- a/varcode/annotators/protein_diff.py
+++ b/varcode/annotators/protein_diff.py
@@ -10,11 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""SequenceDiffEffectAnnotator — classify effects from protein diff
+"""ProteinDiffEffectAnnotator — classify effects from protein diff
 instead of offset arithmetic (openvax/varcode#271 stage 3d, #309).
 
 See :doc:`/effect_annotation` for the user-facing guide covering
-how legacy, sequence-diff, splice outcomes, and the SV roadmap
+how legacy, protein-diff, splice outcomes, and the SV roadmap
 fit together. This module docstring captures implementation
 detail relevant to reviewers of the classifier itself.
 
@@ -26,9 +26,9 @@ Algorithm
 
 2. **Splice check**: run legacy first. If legacy classifies the
    variant as a splice effect (SpliceDonor, SpliceAcceptor,
-   IntronicSpliceSite), return that directly — sequence-diff
+   IntronicSpliceSite), return that directly — protein-diff
    doesn't own splice classification. For ExonicSpliceSite, run
-   dual-dispatch: legacy provides the splice class, sequence-diff
+   dual-dispatch: legacy provides the splice class, protein-diff
    provides the ``alternate_effect`` via protein diff.
 
 3. **Slow path**: build a :class:`MutantTranscript` via
@@ -59,7 +59,7 @@ from ..version import __version__ as _varcode_version
 from .legacy import LegacyEffectAnnotator
 
 
-class SequenceDiffEffectAnnotator:
+class ProteinDiffEffectAnnotator:
     """Classify effects by diffing translated mutant protein against
     the reference protein.
 
@@ -67,17 +67,17 @@ class SequenceDiffEffectAnnotator:
     :class:`LegacyEffectAnnotator` on the common case (trivial
     SNVs and simple indels) because both flow through the same
     :func:`classify_from_protein_diff` classifier. Diverges where
-    sequence-diff's approach is provably more accurate (boundary
+    protein-diff's approach is provably more accurate (boundary
     codons, frameshift realignment). Any divergence must appear in
     the parity harness ``EXPECTED_DIFFS`` with an issue link.
     """
 
-    name = "sequence_diff"
+    name = "protein_diff"
     version = _varcode_version
     supports = frozenset({"snv", "indel", "mnv"})
 
     def __repr__(self):
-        return "SequenceDiffEffectAnnotator(name=%r, version=%r)" % (
+        return "ProteinDiffEffectAnnotator(name=%r, version=%r)" % (
             self.name, self.version)
 
     def annotate_on_transcript(self, variant, transcript):
@@ -112,7 +112,7 @@ class SequenceDiffEffectAnnotator:
             return legacy_effect
 
         # ExonicSpliceSite: dual-dispatch. Legacy provides the
-        # splice class; sequence-diff provides the alternate_effect
+        # splice class; protein-diff provides the alternate_effect
         # via protein diff.
         if isinstance(legacy_effect, ExonicSpliceSite):
             mt = apply_variant_to_transcript(variant, transcript)
@@ -130,7 +130,7 @@ class SequenceDiffEffectAnnotator:
                     alternate_effect=alt)
             return legacy_effect
 
-        # Non-splice: sequence-diff slow path.
+        # Non-splice: protein-diff slow path.
         mt = apply_variant_to_transcript(variant, transcript)
         if mt is None or mt.mutant_protein_sequence is None:
             # UTR, ref-mismatch, splice-junction-spanning, etc.

--- a/varcode/annotators/registry.py
+++ b/varcode/annotators/registry.py
@@ -14,7 +14,7 @@
 
 Kept as a module-level dict (not a class) to match the flat registry
 pattern in the rest of varcode. Default selection is ``"legacy"``
-until the sequence-diff annotator ships; callers that want a
+until the protein-diff annotator ships; callers that want a
 non-default annotator pass one explicitly or call
 :func:`set_default_annotator`. See #271.
 """
@@ -22,7 +22,7 @@ non-default annotator pass one explicitly or call
 from contextlib import contextmanager
 
 from .legacy import LegacyEffectAnnotator
-from .sequence_diff import SequenceDiffEffectAnnotator
+from .protein_diff import ProteinDiffEffectAnnotator
 
 
 class UnsupportedVariantError(ValueError):
@@ -65,7 +65,7 @@ def get_default_annotator():
     """Return the annotator currently configured as the default.
 
     Stage-1 default is ``"legacy"``. After #271 stage 2 lands (the
-    sequence-diff annotator), that becomes the new default and
+    protein-diff annotator), that becomes the new default and
     ``"legacy"`` stays available as an opt-in for users who need
     byte-for-byte compatibility with 2.x output.
     """
@@ -116,7 +116,7 @@ def use_annotator(name_or_instance):
     Useful for A/B comparisons and scoped overrides without mutating
     global state across the codebase::
 
-        with varcode.use_annotator("sequence_diff"):
+        with varcode.use_annotator("protein_diff"):
             effects = variant_collection.effects()
 
     Accepts the same argument shape as the ``annotator=`` kwarg:
@@ -159,4 +159,4 @@ def use_annotator(name_or_instance):
 # Register built-in annotators at import time. Legacy is the default
 # until stage 3e flips it after the parity corpus passes clean.
 register_annotator(LegacyEffectAnnotator())
-register_annotator(SequenceDiffEffectAnnotator())
+register_annotator(ProteinDiffEffectAnnotator())

--- a/varcode/effects/classify.py
+++ b/varcode/effects/classify.py
@@ -14,7 +14,7 @@
 
 Shared classifier used by both the splice-outcome builder
 (:mod:`varcode.splice_outcomes`, #305) and the forthcoming
-:class:`SequenceDiffEffectAnnotator` (#309 / stage 3d). Reduces
+:class:`ProteinDiffEffectAnnotator` (#309 / stage 3d). Reduces
 the protein pair via :func:`trim_shared_flanking_strings` and
 dispatches to the standard Effect classes.
 

--- a/varcode/effects/fast_path.py
+++ b/varcode/effects/fast_path.py
@@ -13,7 +13,7 @@
 """Shared fast path for trivial single-codon SNVs (openvax/varcode#271,
 stage 3c).
 
-Both the legacy and forthcoming sequence-diff annotators dispatch
+Both the legacy and forthcoming protein-diff annotators dispatch
 coding-SNV variants through the same short-circuit so they agree on
 the common case. The full :func:`predict_in_frame_coding_effect` logic
 only runs for variants that actually need it — indels, MNVs,
@@ -23,7 +23,7 @@ classification.
 
 Extracting this helper doesn't change behaviour on its own: legacy
 still produces the same Effect classes and same ``short_description``
-byte-for-byte. The value comes in stage 3d when the sequence-diff
+byte-for-byte. The value comes in stage 3d when the protein-diff
 annotator shares this code path, removing it as a source of A/B
 divergence between the two annotators.
 """

--- a/varcode/mutant_transcript.py
+++ b/varcode/mutant_transcript.py
@@ -14,7 +14,7 @@
 variants to a reference transcript (openvax/varcode#271, stage 1).
 
 :class:`TranscriptEdit` and :class:`MutantTranscript` are the types
-used by the forthcoming sequence-diff :class:`EffectAnnotator`
+used by the forthcoming protein-diff :class:`EffectAnnotator`
 (``varcode.annotators``) to reshape effect annotation from
 "reason about offsets against the reference" to "materialize the
 mutant sequence, translate it, compare to the reference protein."
@@ -81,7 +81,7 @@ class MutantTranscript:
     applied, optionally carrying the mutated cDNA and protein
     sequences.
 
-    Producers (the sequence-diff annotator, RNA-evidence importers,
+    Producers (the protein-diff annotator, RNA-evidence importers,
     the splice-outcomes rewrite, germline-aware annotation) construct
     this once per (transcript, variant-set, context) and hand it to
     downstream consumers. Each consumer reads the fields it cares
@@ -91,7 +91,7 @@ class MutantTranscript:
     Sequence fields are ``Optional[str]`` because not every producer
     computes them eagerly (some stages just need the edit list; full
     translation is lazy). Callers that require the protein must
-    check or compute it themselves for now — the sequence-diff
+    check or compute it themselves for now — the protein-diff
     annotator in stage 2 will guarantee it's populated.
 
     **Forward-looking — structural variants (SVs).** The single
@@ -129,7 +129,7 @@ class MutantTranscript:
     codon. ``None`` if not yet translated, or if the edit set
     doesn't produce a coherent ORF (e.g. start-codon loss). Callers
     that need a guaranteed-present protein should use the
-    sequence-diff annotator once it lands."""
+    protein-diff annotator once it lands."""
 
     annotator_name: str = "unknown"
     """Name of the :class:`EffectAnnotator` (or other producer) that
@@ -197,7 +197,7 @@ def apply_variant_to_transcript(variant, transcript):
       computed offset.
 
     Callers that get ``None`` should fall back to the legacy
-    :class:`EffectAnnotator`. The forthcoming sequence-diff annotator
+    :class:`EffectAnnotator`. The forthcoming protein-diff annotator
     layers effect classification on top of this builder.
     """
     # Lazy imports to keep module-level deps light.
@@ -286,5 +286,5 @@ def apply_variant_to_transcript(variant, transcript):
         edits=(edit,),
         cdna_sequence=mutant_cdna,
         mutant_protein_sequence=mutant_protein,
-        annotator_name="sequence_diff",
+        annotator_name="protein_diff",
     )


### PR DESCRIPTION
Renames the second annotator from \`sequence_diff\` to \`protein_diff\` — clearer since varcode works with both nucleotide and protein sequences. \"protein_diff\" says exactly what the annotator does: diffs at the protein level.

Also adds test infrastructure for running the full suite under \`protein_diff\` to automatically surface parity divergences.

## Renames

- \`SequenceDiffEffectAnnotator\` → \`ProteinDiffEffectAnnotator\`
- \`varcode/annotators/sequence_diff.py\` → \`protein_diff.py\`
- \`tests/test_sequence_diff_parity.py\` → \`test_protein_diff_parity.py\`
- Registered name: \`\"sequence_diff\"\` → \`\"protein_diff\"\`
- All docstrings, comments, docs updated

## Test infrastructure

New \`tests/conftest.py\`:

- \`--annotator=<name>\` CLI option: run the full suite under a specific annotator
- \`autouse\` \`annotator_scope\` fixture that sets the default
- \`dual_annotator\` parametrize fixture for explicit both-annotator tests

Running \`pytest --annotator=protein_diff\` surfaces **18 failures** from 623 tests:

| Bucket | Count | Pattern |
|---|---|---|
| Test-infrastructure | 7 | Assertions on \`annotator == "legacy"\` in provenance fields |
| Real parity divergences | 11 | Stop-codon insertion edge cases (6), Silent short_description (3), mouse frameshift (1), crashing variant (1) |

These 11 divergences are the triage corpus for stage 3e (default flip). The infrastructure to discover them is now built in.

## Test plan

- [x] 623 tests pass under default (legacy)
- [x] Ruff clean
- [x] \`variant.effects(annotator=\"protein_diff\")\` works
- [x] \`--annotator=protein_diff\` surfaces known divergences

Linked: #271 tracking, #309 annotator implementation.