### PR TITLE
#271 stage 3e: fix 18 parity divergences + flip default to protein_diff

### DIFF
--- a/tests/test_annotators.py
+++ b/tests/test_annotators.py
@@ -61,9 +61,8 @@ def test_duck_typed_annotator_satisfies_protocol():
 # ====================================================================
 
 
-def test_legacy_annotator_is_registered_by_default():
+def test_legacy_annotator_is_registered():
     assert get_annotator("legacy").__class__ is LegacyEffectAnnotator
-    assert get_default_annotator().__class__ is LegacyEffectAnnotator
 
 
 def test_register_and_retrieve_custom_annotator():
@@ -219,11 +218,11 @@ def test_use_annotator_swaps_default_within_scope():
         def annotate_on_transcript(self, variant, transcript):
             return None
     scoped_instance = Scoped()
-    assert get_default_annotator().__class__ is LegacyEffectAnnotator
+    prior_default = get_default_annotator()
     with use_annotator(scoped_instance):
         assert get_default_annotator() is scoped_instance
-    # On exit, default is restored.
-    assert get_default_annotator().__class__ is LegacyEffectAnnotator
+    # On exit, default is restored to whatever it was before.
+    assert get_default_annotator() is prior_default
     # And the scoped-instance registration is cleaned up.
     from varcode.annotators.registry import _REGISTRY
     assert "test_scoped" not in _REGISTRY
@@ -238,10 +237,11 @@ def test_use_annotator_with_registered_name_preserves_registration():
             return None
     persisted = Persisted()
     register_annotator(persisted)
+    prior_default = get_default_annotator()
     try:
         with use_annotator("test_persisted"):
             assert get_default_annotator() is persisted
-        assert get_default_annotator().__class__ is LegacyEffectAnnotator
+        assert get_default_annotator() is prior_default
         # Registration persists after the context exit since it
         # wasn't created by the context manager.
         from varcode.annotators.registry import _REGISTRY
@@ -292,7 +292,7 @@ def test_resolve_annotator_passes_through_instance():
 def test_resolve_annotator_resolves_none_to_default():
     from varcode import resolve_annotator
     resolved = resolve_annotator(None)
-    assert resolved.__class__ is LegacyEffectAnnotator
+    assert resolved is get_default_annotator()
 
 
 # ====================================================================

--- a/tests/test_csv_roundtrip.py
+++ b/tests/test_csv_roundtrip.py
@@ -307,9 +307,9 @@ def test_effect_collection_from_csv_raises_without_genome_or_header():
 def test_effect_collection_carries_annotator_provenance():
     variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
     ec = variant.effects()
-    # predict_variant_effects should have populated the fields from
-    # the resolved annotator (legacy by default).
-    assert ec.annotator == "legacy"
+    # predict_variant_effects should have populated the annotator name
+    # from whichever annotator is currently the default.
+    assert ec.annotator is not None
     assert ec.annotator_version is not None
     assert ec.annotated_at is not None
 
@@ -324,7 +324,7 @@ def test_effect_collection_to_csv_emits_annotator_header():
             head = "".join(f.readline() for _ in range(8))
     finally:
         os.unlink(path)
-    assert "# annotator=legacy" in head
+    assert "# annotator=" in head
     assert "# annotator_version=" in head
     assert "# annotated_at=" in head
 
@@ -360,18 +360,22 @@ def test_effect_collection_clone_preserves_annotator_metadata():
 
 def test_effect_collection_from_csv_warns_on_annotator_mismatch():
     import warnings
+    from varcode import get_default_annotator
     variant = Variant("17", 43082575 - 5, "CCT", "GGG", "GRCh38")
     ec = variant.effects()
     path = _tmp_csv()
+    # Use a fake annotator name that's guaranteed to differ from
+    # whatever the current default is.
+    fake_name = "fake_annotator_for_test"
+    current_default = get_default_annotator().name
     try:
         ec.to_csv(path)
-        # Rewrite the header to claim a different annotator.
         with open(path) as f:
             lines = f.readlines()
         with open(path, "w") as f:
             for line in lines:
                 if line.startswith("# annotator="):
-                    f.write("# annotator=protein_diff\n")
+                    f.write("# annotator=%s\n" % fake_name)
                 else:
                     f.write(line)
         with warnings.catch_warnings(record=True) as caught:
@@ -382,7 +386,7 @@ def test_effect_collection_from_csv_warns_on_annotator_mismatch():
 
     messages = [str(w.message) for w in caught]
     assert any(
-        "protein_diff" in m and "legacy" in m for m in messages), (
+        fake_name in m and current_default in m for m in messages), (
         "Expected a warning about annotator mismatch, got: %r" % messages)
 
 

--- a/varcode/annotators/protein_diff.py
+++ b/varcode/annotators/protein_diff.py
@@ -139,10 +139,9 @@ class ProteinDiffEffectAnnotator:
         ref_protein = str(transcript.protein_sequence)
         mut_protein = mt.mutant_protein_sequence
 
-        # AlternateStartCodon: non-diff special case (#304).
-        # Proteins match but the first codon changed to a non-ATG
-        # alternate start — informative for translation-efficiency
-        # analysis, so we emit it rather than collapsing into Silent.
+        # Proteins match → Silent or AlternateStartCodon. Handle
+        # both here because the shared classifier doesn't have
+        # access to the cDNA edit offset for the correct aa_pos.
         if ref_protein == mut_protein:
             cds_start = min(transcript.start_codon_spliced_offsets)
             ref_first_codon = str(
@@ -157,10 +156,43 @@ class ProteinDiffEffectAnnotator:
                         transcript=transcript,
                         ref_codon=ref_first_codon,
                         alt_codon=mut_first_codon)
+            from ..effects.effect_classes import Silent
+            edit = mt.edits[0] if mt.edits else None
+            aa_pos = (edit.cdna_start - cds_start) // 3 if edit else 0
+            aa_ref = (
+                ref_protein[aa_pos]
+                if 0 <= aa_pos < len(ref_protein)
+                else "")
+            return Silent(
+                variant=variant,
+                transcript=transcript,
+                aa_pos=aa_pos,
+                aa_ref=aa_ref)
 
-        return classify_from_protein_diff(
+        effect = classify_from_protein_diff(
             variant=variant,
             transcript=transcript,
             ref_protein=ref_protein,
             mut_protein=mut_protein,
             length_delta=mt.total_length_delta)
+
+        # For pure insertions that create a premature stop, legacy
+        # uses aa_ref="" (nothing was at the insertion point in the
+        # reference). The protein-diff classifier sees it as a
+        # substitution + truncation and uses the reference residue.
+        # Match legacy's convention for parity.
+        is_pure_insertion = (
+            len(variant.trimmed_ref) == 0
+            or (len(variant.trimmed_ref) == 1
+                and variant.trimmed_alt.startswith(variant.trimmed_ref)))
+        from ..effects.effect_classes import PrematureStop
+        if is_pure_insertion and isinstance(effect, PrematureStop):
+            if effect.aa_ref != "":
+                return PrematureStop(
+                    variant=variant,
+                    transcript=transcript,
+                    aa_mutation_start_offset=effect.aa_mutation_start_offset,
+                    aa_ref="",
+                    aa_alt=effect.aa_alt)
+
+        return effect

--- a/varcode/annotators/registry.py
+++ b/varcode/annotators/registry.py
@@ -37,7 +37,7 @@ class UnsupportedVariantError(ValueError):
 
 
 _REGISTRY = {}
-_DEFAULT_NAME = "legacy"
+_DEFAULT_NAME = "protein_diff"
 
 
 def register_annotator(annotator):

--- a/varcode/effects/classify.py
+++ b/varcode/effects/classify.py
@@ -93,6 +93,15 @@ def classify_from_protein_diff(
 
     # Frameshift: cDNA length change not divisible by 3.
     if length_delta % 3 != 0:
+        # Guard: if the mutation offset is past the end of the
+        # reference protein, the edit is in the stop-codon / 3'UTR
+        # region. That's a StopLoss, not a FrameShift.
+        if aa_offset >= len(ref_protein):
+            return StopLoss(
+                variant=variant,
+                transcript=transcript,
+                aa_ref="",
+                aa_alt=alt_delta)
         if n_alt == 0:
             return FrameShiftTruncation(
                 variant=variant,
@@ -118,9 +127,15 @@ def classify_from_protein_diff(
             aa_ref=ref_protein[aa_offset] if aa_offset < len(ref_protein) else ref_delta,
             aa_alt=alt_delta)
 
-    # Stop loss: mutant protein longer than reference and the change
-    # extends past the original stop.
-    if len(mut_protein) > len(ref_protein) and aa_offset + n_ref >= len(ref_protein):
+    # Stop loss: mutant protein longer than reference, the change
+    # extends past the original stop, AND reference residues were
+    # replaced (n_ref > 0). The n_ref > 0 guard distinguishes true
+    # stop-loss (stop codon disrupted) from an in-frame insertion
+    # near the protein's tail (which adds residues but preserves the
+    # stop — that's an Insertion, not StopLoss).
+    if (len(mut_protein) > len(ref_protein)
+            and aa_offset + n_ref >= len(ref_protein)
+            and n_ref > 0):
         return StopLoss(
             variant=variant,
             transcript=transcript,

--- a/varcode/mutant_transcript.py
+++ b/varcode/mutant_transcript.py
@@ -248,18 +248,39 @@ def apply_variant_to_transcript(variant, transcript):
     if cdna_ref != expected_ref:
         return None
 
-    edit = TranscriptEdit(
-        cdna_start=cdna_offset,
-        cdna_end=cdna_offset + n_ref,
-        alt_bases=cdna_alt,
-        source_variant=variant,
-    )
-
-    mutant_cdna = (
-        full_sequence[:cdna_offset]
-        + cdna_alt
-        + full_sequence[cdna_offset + n_ref:]
-    )
+    # For pure insertions (n_ref == 0), VCF convention places the alt
+    # AFTER the anchor base in genomic coordinates. On the forward
+    # strand that's cdna_offset + 1; on the reverse strand, "after"
+    # in genomic coords is "before" in cDNA coords (the cDNA runs
+    # 3'→5' in genomic space), so the insertion goes AT cdna_offset.
+    if n_ref == 0:
+        if transcript.on_backward_strand:
+            insert_at = cdna_offset
+        else:
+            insert_at = cdna_offset + 1
+        edit = TranscriptEdit(
+            cdna_start=insert_at,
+            cdna_end=insert_at,
+            alt_bases=cdna_alt,
+            source_variant=variant,
+        )
+        mutant_cdna = (
+            full_sequence[:insert_at]
+            + cdna_alt
+            + full_sequence[insert_at:]
+        )
+    else:
+        edit = TranscriptEdit(
+            cdna_start=cdna_offset,
+            cdna_end=cdna_offset + n_ref,
+            alt_bases=cdna_alt,
+            source_variant=variant,
+        )
+        mutant_cdna = (
+            full_sequence[:cdna_offset]
+            + cdna_alt
+            + full_sequence[cdna_offset + n_ref:]
+        )
 
     mutant_protein = None
     cds_start = min(transcript.start_codon_spliced_offsets)


### PR DESCRIPTION
All 623 tests pass under both annotators. Flips the default from \`\"legacy\"\` to \`\"protein_diff\"\`. Legacy stays available as \`annotator=\"legacy\"\`.

## Parity fixes resolved (18 → 0)

| Category | Count | Fix |
|---|---|---|
| Test-infrastructure | 7 | Assertions now annotator-agnostic |
| Insertion offset (VCF convention) | 10 | Insert AFTER anchor base, strand-aware |
| FrameShift past protein end | 1 | Guard → StopLoss when offset ≥ protein length |
| StopLoss vs Insertion at tail | 1 | \`n_ref > 0\` guard on StopLoss condition |
| Silent aa_pos | 3 | Compute from cDNA edit offset, not default 0 |
| PrematureStop insertion convention | 2 | Adjust aa_ref to \"\" for pure-insertion variants |

## Key bug fixes

**Insertion offset**: \`apply_variant_to_transcript\` placed insertions at the wrong cDNA position. VCF convention: insertion goes AFTER the anchor base. On reverse-strand transcripts, \"after\" in genomic coords = \"before\" in cDNA coords. Both cases now handled correctly.

**StopLoss guard**: an in-frame insertion before the stop codon (adding residues but preserving the stop) was classified as StopLoss because the mutant protein is longer. Added \`n_ref > 0\` — a pure insertion with no reference residues changed preserves the stop and is an Insertion, not StopLoss.

## Default flip

\`_DEFAULT_NAME\` in \`registry.py\`: \`\"legacy\"\` → \`\"protein_diff\"\`. From this version forward, \`variant.effects()\` dispatches through \`ProteinDiffEffectAnnotator\` by default.

## Verification

\`\`\`
pytest tests/                                  # 623 passed (protein_diff default)
pytest tests/ --annotator=legacy               # 623 passed
pytest tests/ --annotator=protein_diff         # 623 passed
\`\`\`

Ruff clean.

Linked: #271 tracking, #304 staging (this PR is 3e), #309 annotator.