### PR TITLE
Wire load_vcf's SV path end-to-end (#264)

### DIFF
--- a/tests/test_structural_variants.py
+++ b/tests/test_structural_variants.py
@@ -237,6 +237,16 @@ def test_parse_symbolic_non_ins_ignores_insseq():
     assert sv.alt_assembly is None
 
 
+def test_parse_symbolic_insseq_takes_precedence_over_svinsseq():
+    """When both fields are present, INSSEQ wins (Manta canonical
+    name takes precedence over the Sniffles/PBSV alias). Pins the
+    short-circuit ordering in ``parse_symbolic_alt``."""
+    sv = parse_symbolic_alt(
+        contig="1", start=100, ref="A", alt="<INS>",
+        info={"INSSEQ": "AAAA", "SVINSSEQ": "GGGG"}, genome="GRCh38")
+    assert sv.alt_assembly == "AAAA"
+
+
 def test_parse_symbolic_svtype_info_overrides_alt():
     """When INFO/SVTYPE is present, it takes precedence over the
     ALT token. Useful for VCFs that use a non-canonical ALT but
@@ -374,7 +384,10 @@ def test_vcf_loader_parses_svs_when_opted_in():
 
 def test_vcf_loader_spanning_star_always_skipped():
     """``*`` is skipped regardless of the ``parse_structural_variants``
-    flag — it's not an SV to parse."""
+    flag — it's not an SV to parse, and the drop is silent (not
+    counted as a symbolic skip) because every consumer drops these
+    and warning would be noise."""
+    import warnings
     body = (
         "##fileformat=VCFv4.2\n"
         "##reference=GRCh38\n"
@@ -384,11 +397,53 @@ def test_vcf_loader_spanning_star_always_skipped():
     )
     path = _write_vcf(body)
     try:
-        vc = load_vcf(path, genome="GRCh38", parse_structural_variants=True)
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            vc = load_vcf(
+                path, genome="GRCh38", parse_structural_variants=True)
     finally:
         os.unlink(path)
     assert len(vc) == 1
     assert vc[0].ref == "C" and vc[0].alt == "T"
+    # No symbolic-skip warning — ``*`` doesn't go through the same
+    # counter as <DEL> etc., to keep the load path quiet on the
+    # common case where every consumer drops ``*``.
+    assert not any(
+        "symbolic/breakend" in str(w.message)
+        or "Could not parse" in str(w.message)
+        for w in captured), (
+            "Spanning ``*`` shouldn't trigger an SV-skip warning; "
+            "got %r" % [str(w.message) for w in captured])
+
+
+def test_vcf_loader_unparseable_breakend_warns_distinctly():
+    """A malformed breakend (``G[hello`` — open bracket, no mate) hits
+    ``_is_symbolic_allele`` but fails ``_BREAKEND_RE``. With the flag
+    on, this is the ``unparseable`` path: distinct warning text from
+    the ``flag_off`` case, since the user can't fix this by toggling
+    the flag — the ALT shape itself is unrecognized."""
+    import warnings
+    body = (
+        "##fileformat=VCFv4.2\n"
+        "##reference=GRCh38\n"
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        "22\t51179178\t.\tG\tG[hello\t100\tPASS\t.\n"
+    )
+    path = _write_vcf(body)
+    try:
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            vc = load_vcf(
+                path, genome="GRCh38", parse_structural_variants=True)
+    finally:
+        os.unlink(path)
+    assert len(vc) == 0
+    unparseable = [w for w in captured if "Could not parse" in str(w.message)]
+    assert len(unparseable) == 1
+    assert "breakend shape" in str(unparseable[0].message)
+    # Crucially, this is *not* the flag-off message — toggling the
+    # flag wouldn't help since the parser already ran.
+    assert "parse_structural_variants=True" not in str(unparseable[0].message)
 
 
 def test_vcf_loader_default_warning_mentions_flag():
@@ -484,3 +539,69 @@ def test_vcf_loader_sv_yields_structural_variant_effect():
     assert len(sv_effects) >= 1, (
         "Expected at least one StructuralVariantEffect from the loaded "
         "<DEL> row; got effect types %s" % [type(e).__name__ for e in effects])
+
+
+def test_sv_effect_on_transcript_routes_via_sv_annotator():
+    """Companion to the kind-dispatch fix in
+    :func:`predict_variant_effects`: the legacy
+    :meth:`Variant.effect_on_transcript` path also has to route SVs
+    through ``StructuralVariantAnnotator``. Otherwise ``predict_*_effects``
+    is correct but ``sv.effect_on_transcript(t)`` quietly does offset
+    arithmetic on the placeholder ``ref="N"/alt="A"`` and emits
+    nonsense — a footgun for anyone who learned the legacy API."""
+    from pyensembl import cached_release
+    from varcode.effects.effect_classes import StructuralVariantEffect
+    ensembl_grch38 = cached_release(81)
+    cftr = ensembl_grch38.transcript_by_id("ENST00000003084")
+    sv = StructuralVariant(
+        contig="7",
+        start=cftr.start + 100,
+        end=cftr.start + 50_000,
+        sv_type="DEL",
+        alt="<DEL>",
+        genome=ensembl_grch38,
+    )
+    effect = sv.effect_on_transcript(cftr)
+    assert isinstance(effect, StructuralVariantEffect), (
+        "SV.effect_on_transcript must dispatch to the SV annotator "
+        "and produce a StructuralVariantEffect — got %s" % type(effect).__name__)
+
+
+def test_vcf_loader_sv_explicit_protein_diff_passes_through():
+    """The dispatch only kicks in when ``annotator is None``. An
+    explicit override (``annotator="protein_diff"``, e.g. for parity
+    testing the SV against the point-variant path) must bypass the
+    SV-routing shim. We don't assert what comes back — just that
+    the routing didn't quietly substitute the SV annotator."""
+    from pyensembl import cached_release
+    from varcode.effects.effect_classes import StructuralVariantEffect
+    ensembl_grch38 = cached_release(81)
+    cftr = ensembl_grch38.transcript_by_id("ENST00000003084")
+    body = (
+        "##fileformat=VCFv4.2\n"
+        "##reference=GRCh38\n"
+        "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"type\">\n"
+        "##INFO=<ID=END,Number=1,Type=Integer,Description=\"end\">\n"
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        "7\t%d\t.\tA\t<DEL>\t100\tPASS\tSVTYPE=DEL;END=%d\n"
+    ) % (cftr.start + 100, cftr.start + 50_000)
+    path = _write_vcf(body)
+    try:
+        vc = load_vcf(
+            path, genome=ensembl_grch38, parse_structural_variants=True)
+        effects = vc.effects(
+            annotator="protein_diff", raise_on_error=False)
+    finally:
+        os.unlink(path)
+    # protein_diff doesn't understand SVs; on the placeholder REF/ALT
+    # it should produce something, but specifically *not* a typed
+    # StructuralVariantEffect — that would mean the dispatch fired
+    # despite the explicit override.
+    sv_effects = [e for e in effects if isinstance(e, StructuralVariantEffect)]
+    assert len(sv_effects) == 0, (
+        "Explicit annotator='protein_diff' on an SV must bypass the "
+        "SV-routing shim; got %d StructuralVariantEffect instance(s)."
+        % len(sv_effects))
+    assert effects.annotator == "protein_diff", (
+        "Collection-level annotator metadata should reflect the "
+        "explicit override, not the SV annotator.")

--- a/tests/test_structural_variants.py
+++ b/tests/test_structural_variants.py
@@ -167,6 +167,74 @@ def test_parse_symbolic_cn0_maps_to_cnv():
         info={"END": 500}, genome="GRCh38")
     assert sv is not None
     assert sv.sv_type == "CNV"
+    # The integer is preserved so consumers can distinguish a
+    # zero-copy deletion from a higher-copy duplication.
+    assert sv.info["copy_number"] == 0
+
+
+def test_parse_symbolic_cn3_distinct_from_cn0():
+    """``<CN3>`` and ``<CN0>`` both map to ``sv_type="CNV"`` but
+    must remain distinguishable — one's a deletion, one's a
+    duplication. The integer rides along in ``info["copy_number"]``."""
+    cn0 = parse_symbolic_alt(
+        contig="1", start=100, ref="N", alt="<CN0>",
+        info={"END": 500}, genome="GRCh38")
+    cn3 = parse_symbolic_alt(
+        contig="1", start=100, ref="N", alt="<CN3>",
+        info={"END": 500}, genome="GRCh38")
+    assert cn0.info["copy_number"] == 0
+    assert cn3.info["copy_number"] == 3
+
+
+def test_parse_symbolic_cnv_no_number_omits_copy_number():
+    """``<CNV>`` (no integer) means "copy number altered, count
+    unspecified" — the parser shouldn't fabricate a number."""
+    sv = parse_symbolic_alt(
+        contig="1", start=100, ref="N", alt="<CNV>",
+        info={"END": 500}, genome="GRCh38")
+    assert sv.sv_type == "CNV"
+    assert "copy_number" not in sv.info
+
+
+def test_parse_symbolic_ins_extracts_insseq_into_alt_assembly():
+    """Long-read callers (Manta) ship the inserted sequence in
+    INFO/INSSEQ; the parser routes it into ``alt_assembly`` so the
+    SV annotator's assembly path picks it up."""
+    sv = parse_symbolic_alt(
+        contig="1", start=100, ref="A", alt="<INS>",
+        info={"INSSEQ": "ACGTACGT"}, genome="GRCh38")
+    assert sv is not None
+    assert sv.sv_type == "INS"
+    assert sv.alt_assembly == "ACGTACGT"
+
+
+def test_parse_symbolic_ins_extracts_svinsseq_alias():
+    """Some Sniffles/PBSV variants use SVINSSEQ instead of INSSEQ.
+    Both are accepted."""
+    sv = parse_symbolic_alt(
+        contig="1", start=100, ref="A", alt="<INS>",
+        info={"SVINSSEQ": "TTTTGGGG"}, genome="GRCh38")
+    assert sv.alt_assembly == "TTTTGGGG"
+
+
+def test_parse_symbolic_insseq_unwraps_single_element_list():
+    """Undeclared INFO Strings come back from the header parser as
+    1-element lists (no ``Number=1`` to unwrap on). The SV parser
+    unwraps those rather than passing the list through to
+    ``alt_assembly``."""
+    sv = parse_symbolic_alt(
+        contig="1", start=100, ref="A", alt="<INS>",
+        info={"INSSEQ": ["ACGT"]}, genome="GRCh38")
+    assert sv.alt_assembly == "ACGT"
+
+
+def test_parse_symbolic_non_ins_ignores_insseq():
+    """``INSSEQ`` only applies to INS — a DEL row that happens to
+    carry the field shouldn't have it land in ``alt_assembly``."""
+    sv = parse_symbolic_alt(
+        contig="1", start=100, ref="N", alt="<DEL>",
+        info={"INSSEQ": "ACGT", "END": 500}, genome="GRCh38")
+    assert sv.alt_assembly is None
 
 
 def test_parse_symbolic_svtype_info_overrides_alt():
@@ -321,3 +389,98 @@ def test_vcf_loader_spanning_star_always_skipped():
         os.unlink(path)
     assert len(vc) == 1
     assert vc[0].ref == "C" and vc[0].alt == "T"
+
+
+def test_vcf_loader_default_warning_mentions_flag():
+    """When SVs are dropped because ``parse_structural_variants=False``,
+    the warning should tell the user about the flag — not just point
+    at an issue tracker."""
+    import warnings
+    body = (
+        "##fileformat=VCFv4.2\n"
+        "##reference=GRCh38\n"
+        "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"type\">\n"
+        "##INFO=<ID=END,Number=1,Type=Integer,Description=\"end\">\n"
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        "22\t51179178\t.\tA\t<DEL>\t100\tPASS\tSVTYPE=DEL;END=51179500\n"
+        "22\t51179700\t.\tC\tT\t100\tPASS\t.\n"
+    )
+    path = _write_vcf(body)
+    try:
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            load_vcf(path, genome="GRCh38")
+    finally:
+        os.unlink(path)
+    skip_warnings = [
+        w for w in captured if "symbolic/breakend" in str(w.message)]
+    assert len(skip_warnings) == 1
+    assert "parse_structural_variants=True" in str(skip_warnings[0].message)
+
+
+def test_vcf_loader_sv_carries_sample_info():
+    """SV rows from somatic callers (Manta, DELLY, GRIDSS) ship
+    FORMAT/sample data — the loader must parse it just like the
+    simple-ALT path, not stash ``None``."""
+    body = (
+        "##fileformat=VCFv4.2\n"
+        "##reference=GRCh38\n"
+        "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"type\">\n"
+        "##INFO=<ID=END,Number=1,Type=Integer,Description=\"end\">\n"
+        "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"genotype\">\n"
+        "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"depth\">\n"
+        "##FORMAT=<ID=PR,Number=2,Type=Integer,Description=\"paired-read support\">\n"
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNORMAL\tTUMOR\n"
+        "22\t51179178\tsv1\tA\t<DEL>\t100\tPASS\tSVTYPE=DEL;END=51179500"
+        "\tGT:DP:PR\t0/0:50:48,2\t0/1:55:30,25\n"
+    )
+    path = _write_vcf(body)
+    try:
+        vc = load_vcf(path, genome="GRCh38", parse_structural_variants=True)
+    finally:
+        os.unlink(path)
+    assert len(vc) == 1
+    sv = vc[0]
+    assert isinstance(sv, StructuralVariant)
+    sample_info = vc.metadata[sv]["sample_info"]
+    assert sample_info is not None, (
+        "SV rows must carry per-sample FORMAT data through to metadata; "
+        "previously sample_info was always None on the SV branch.")
+    assert list(sample_info) == ["NORMAL", "TUMOR"]
+    assert sample_info["TUMOR"]["GT"] == "0/1"
+    assert sample_info["TUMOR"]["DP"] == 55
+    assert sample_info["TUMOR"]["PR"] == [30, 25]
+
+
+def test_vcf_loader_sv_yields_structural_variant_effect():
+    """End-to-end: a VCF with an SV row, loaded with the flag on,
+    produces a typed :class:`StructuralVariantEffect` when annotated.
+
+    This is the gate that protects #257 / #252 / #261: if this test
+    works, downstream issues can build SV-typed pipelines on top of
+    ``load_vcf`` instead of constructing :class:`StructuralVariant`
+    objects by hand.
+    """
+    from pyensembl import cached_release
+    from varcode.effects.effect_classes import StructuralVariantEffect
+    ensembl_grch38 = cached_release(81)
+    cftr = ensembl_grch38.transcript_by_id("ENST00000003084")
+    body = (
+        "##fileformat=VCFv4.2\n"
+        "##reference=GRCh38\n"
+        "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"type\">\n"
+        "##INFO=<ID=END,Number=1,Type=Integer,Description=\"end\">\n"
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        "7\t%d\t.\tA\t<DEL>\t100\tPASS\tSVTYPE=DEL;END=%d\n"
+    ) % (cftr.start + 100, cftr.start + 50_000)
+    path = _write_vcf(body)
+    try:
+        vc = load_vcf(
+            path, genome=ensembl_grch38, parse_structural_variants=True)
+        effects = vc.effects()
+    finally:
+        os.unlink(path)
+    sv_effects = [e for e in effects if isinstance(e, StructuralVariantEffect)]
+    assert len(sv_effects) >= 1, (
+        "Expected at least one StructuralVariantEffect from the loaded "
+        "<DEL> row; got effect types %s" % [type(e).__name__ for e in effects])

--- a/varcode/effects/effect_prediction.py
+++ b/varcode/effects/effect_prediction.py
@@ -77,8 +77,19 @@ def predict_variant_effects(
     """
     # Lazy import — varcode.annotators depends on varcode.effects at
     # load time, so we defer to break the cycle.
-    from ..annotators.registry import resolve_annotator
+    from ..annotators.registry import get_annotator, resolve_annotator
     annotator_instance = resolve_annotator(annotator)
+    # Kind dispatch for structural variants: ``fast``/``protein_diff``
+    # declare ``supports = {"snv","indel","mnv"}``, but that flag is
+    # metadata — nobody dispatches on it. Without this override an SV
+    # silently flows to the point-variant annotator, which annotates
+    # the placeholder ``ref="N"/alt="A"`` and emits nonsense. When
+    # the caller didn't explicitly pick an annotator, route SVs to
+    # the SV annotator regardless of the default. Explicit overrides
+    # (annotator="protein_diff" on an SV, e.g. for parity testing)
+    # still pass through. See #264.
+    if annotator is None and getattr(variant, "is_structural", False):
+        annotator_instance = get_annotator("structural_variant")
     annotator_name = getattr(annotator_instance, "name", None)
     annotator_version = getattr(annotator_instance, "version", None)
     # if this variant isn't overlapping any genes, return a

--- a/varcode/sv_allele_parser.py
+++ b/varcode/sv_allele_parser.py
@@ -68,7 +68,13 @@ def _extract_info_scalar(info, key):
     String fields as 1-element lists (no ``Number=1`` to unwrap on);
     most SV callers don't declare ``INSSEQ``/``SVINSSEQ`` even though
     each row carries exactly one inserted sequence — so the natural
-    consumer wants the bare string."""
+    consumer wants the bare string.
+
+    Multi-element lists pass through unchanged. INSSEQ/SVINSSEQ are
+    conventionally Number=1; a multi-value list is malformed input
+    and we'd rather surface the unexpected shape than silently coerce
+    (e.g. by joining) and confuse a downstream type-checker.
+    """
     val = _extract_info(info, key)
     if isinstance(val, list) and len(val) == 1:
         return val[0]

--- a/varcode/sv_allele_parser.py
+++ b/varcode/sv_allele_parser.py
@@ -62,6 +62,25 @@ def _extract_info(info, key):
     return None
 
 
+def _extract_info_scalar(info, key):
+    """Like :func:`_extract_info` but unwraps a single-element list
+    to its sole value. The header-driven INFO parser keeps undeclared
+    String fields as 1-element lists (no ``Number=1`` to unwrap on);
+    most SV callers don't declare ``INSSEQ``/``SVINSSEQ`` even though
+    each row carries exactly one inserted sequence — so the natural
+    consumer wants the bare string."""
+    val = _extract_info(info, key)
+    if isinstance(val, list) and len(val) == 1:
+        return val[0]
+    return val
+
+
+# Copy-number ALT, captured separately from the generic symbolic regex
+# so we can pull the integer out of ``CN0`` / ``CN3`` etc. into a typed
+# field. ``<CNV>`` (no number) is matched here too with copy_number=None.
+_CN_TOKEN_RE = re.compile(r"^CN(?P<n>\d*)$")
+
+
 def parse_symbolic_alt(
         contig: str,
         start: int,
@@ -91,8 +110,16 @@ def parse_symbolic_alt(
         # the custom ``symbolic_subtype`` key.
         top, _, subtype = token.partition(":")
 
-        # CNV / copy-number: sometimes written <CN0>, <CN2>, <CNV>.
-        if top.startswith("CN"):
+        # Copy-number alleles: <CN0>, <CN1>, <CN2>, ..., <CNV>. We collapse
+        # to sv_type="CNV" but preserve the integer count separately so
+        # downstream code can distinguish a deletion (CN0 / CN1 in a
+        # diploid) from a duplication (CN3+) without re-parsing the ALT.
+        copy_number = None
+        cn_match = _CN_TOKEN_RE.match(top)
+        if cn_match:
+            cn_digits = cn_match.group("n")
+            if cn_digits:
+                copy_number = int(cn_digits)
             top = "CNV"
 
         if top not in SV_TYPES:
@@ -110,9 +137,23 @@ def parse_symbolic_alt(
         if svtype_from_info and svtype_from_info.upper() in SV_TYPES:
             top = svtype_from_info.upper()
 
+        # Inserted-sequence hint for INS rows. Long-read callers ship
+        # the assembled inserted sequence as INSSEQ (Manta) or
+        # SVINSSEQ (some Sniffles/PBSV variants). Both are accepted;
+        # the resolved sequence flows through StructuralVariant's
+        # ``alt_assembly`` slot, where the SV annotator already prefers
+        # it over inferring from breakpoint coordinates alone.
+        alt_assembly = None
+        if top == "INS":
+            alt_assembly = (
+                _extract_info_scalar(info, "INSSEQ")
+                or _extract_info_scalar(info, "SVINSSEQ"))
+
         sv_info = {}
         if subtype:
             sv_info["symbolic_subtype"] = subtype
+        if copy_number is not None:
+            sv_info["copy_number"] = copy_number
 
         return StructuralVariant(
             contig=contig,
@@ -121,6 +162,7 @@ def parse_symbolic_alt(
             sv_type=top,
             alt=alt,
             ref=ref or "N",
+            alt_assembly=alt_assembly,
             ci_start=tuple(ci_start) if ci_start else None,
             ci_end=tuple(ci_end) if ci_end else None,
             info=sv_info,

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -492,6 +492,16 @@ class Variant(Serializable):
         return effects
 
     def effect_on_transcript(self, transcript):
+        # SV dispatch — point-variant offset arithmetic doesn't apply
+        # to an SV's placeholder ``ref="N"/alt="A"``. Routed here at
+        # the user-facing API rather than inside
+        # ``predict_variant_effect_on_transcript`` so that internal
+        # callers (FastEffectAnnotator, protein_diff via fast) keep
+        # the unrouted behaviour they already chose. See #264.
+        if getattr(self, "is_structural", False):
+            from .annotators.registry import get_annotator
+            return get_annotator("structural_variant").annotate_on_transcript(
+                self, transcript)
         return predict_variant_effect_on_transcript(self, transcript)
 
     @property

--- a/varcode/vcf.py
+++ b/varcode/vcf.py
@@ -308,7 +308,16 @@ def dataframes_to_variant_collection(
 
     variants = []
     metadata = {}
-    n_skipped_symbolic = 0
+    # Split the skip counters so the user-facing warning can name a fix.
+    # ``flag_off``: symbolic ALT seen with ``parse_structural_variants=False``
+    #   — the user can opt into SV loading by flipping the flag.
+    # ``unparseable``: flag is on but ``parse_symbolic_alt`` couldn't
+    #   recognize the ALT shape — typically a malformed or
+    #   caller-specific extension; the flag won't help.
+    # The spanning-deletion ``*`` placeholder is silent — every consumer
+    # drops it and warning every time would just be noise.
+    n_skipped_flag_off = 0
+    n_skipped_unparseable = 0
     try:
         for chunk in dataframes:
             assert chunk.columns.tolist() == expected_columns,\
@@ -333,44 +342,52 @@ def dataframes_to_variant_collection(
                 for alt in alts.split(","):
                     if alt != ".":
                         if _is_symbolic_allele(alt):
-                            # Spanning-deletion placeholder (``*``) is
-                            # always skipped — it's a cross-row
-                            # reference, not an allele to annotate.
+                            # Spanning-deletion placeholder is a cross-row
+                            # reference, not an allele to annotate. Drop
+                            # silently regardless of the flag.
                             if alt == "*":
-                                n_skipped_symbolic += 1
                                 alt_num += 1
                                 continue
-                            if parse_structural_variants:
-                                # Parse symbolic / breakend ALT into a
-                                # StructuralVariant (PR 8). Falls back
-                                # to skipping if the parser can't
-                                # recognize the ALT shape.
-                                from .sv_allele_parser import (
-                                    parse_symbolic_alt)
-                                if info_parser is not None and info is None:
-                                    info = info_parser(tpl[8])
-                                sv = parse_symbolic_alt(
-                                    contig=chrom,
-                                    start=int(pos),
-                                    ref=ref,
-                                    alt=alt,
-                                    info=info,
-                                    genome=variant_kwargs.get("ensembl"),
-                                )
-                                if sv is not None:
-                                    variants.append(sv)
-                                    metadata[sv] = {
-                                        "id": id_,
-                                        "qual": qual,
-                                        "filter": flter,
-                                        "info": info,
-                                        "sample_info": sample_info,
-                                    }
-                                    alt_num += 1
-                                    continue
-                            # Flag off or parser rejected the ALT:
-                            # preserve the legacy filter-and-warn path.
-                            n_skipped_symbolic += 1
+                            if not parse_structural_variants:
+                                n_skipped_flag_off += 1
+                                alt_num += 1
+                                continue
+                            # Parse symbolic / breakend ALT into a
+                            # StructuralVariant. Falls back to skipping if
+                            # the parser can't recognize the ALT shape.
+                            from .sv_allele_parser import (
+                                parse_symbolic_alt)
+                            if info_parser is not None and info is None:
+                                info = info_parser(tpl[8])
+                                if sample_names and sample_info is None:
+                                    # SV rows from somatic callers (Manta,
+                                    # DELLY, GRIDSS) ship FORMAT/sample
+                                    # data — parse it like the simple-ALT
+                                    # branch does so it isn't silently
+                                    # dropped from metadata.
+                                    sample_info = sample_info_parser(
+                                        list(tpl[10:]),
+                                        tpl[9])
+                            sv = parse_symbolic_alt(
+                                contig=chrom,
+                                start=int(pos),
+                                ref=ref,
+                                alt=alt,
+                                info=info,
+                                genome=variant_kwargs.get("ensembl"),
+                            )
+                            if sv is None:
+                                n_skipped_unparseable += 1
+                                alt_num += 1
+                                continue
+                            variants.append(sv)
+                            metadata[sv] = {
+                                "id": id_,
+                                "qual": qual,
+                                "filter": flter,
+                                "info": info,
+                                "sample_info": sample_info,
+                            }
                             alt_num += 1
                             continue
                         if info_parser is not None and info is None:
@@ -403,13 +420,20 @@ def dataframes_to_variant_collection(
     except StopIteration:
         pass
 
-    if n_skipped_symbolic > 0:
+    if n_skipped_flag_off > 0:
         warn(
-            "Skipped %d symbolic/breakend allele(s) in %s that varcode "
-            "cannot currently represent as simple ref/alt Variants "
+            "Skipped %d symbolic/breakend allele(s) in %s "
             "(e.g. <DEL>, <CN0>, <INS:ME:ALU>, breakends). "
-            "Tracked in openvax/varcode#264." % (
-                n_skipped_symbolic, source_path)
+            "Pass parse_structural_variants=True to load_vcf to "
+            "load these as StructuralVariant objects." % (
+                n_skipped_flag_off, source_path)
+        )
+    if n_skipped_unparseable > 0:
+        warn(
+            "Could not parse %d symbolic/breakend allele(s) in %s — "
+            "ALT did not match a recognized symbolic or VCF 4.1 "
+            "breakend shape. Tracked in openvax/varcode#264." % (
+                n_skipped_unparseable, source_path)
         )
 
     return VariantCollection(


### PR DESCRIPTION
## Summary

Most of #264 was already shipped (`StructuralVariant`, `parse_symbolic_alt`, `parse_structural_variants=True` flag, `StructuralVariantAnnotator` at 918 lines). This PR closes the gaps that prevented the load path from being end-to-end usable — so #257 (SV types), #252 (gene fusions), and #261 (Exacto SV sequences) can build on `load_vcf` instead of hand-constructed `StructuralVariant` objects.

## Five fixes

1. **Sample info parsing for SV rows** (`vcf.py`). The symbolic branch was stashing `sample_info: None` in metadata; somatic SV callers (Manta, DELLY, GRIDSS) ship FORMAT data per sample, and dropping it loses real signal.
2. **INSSEQ / SVINSSEQ extraction** (`sv_allele_parser.py`). Long-read callers ship the inserted sequence in INFO; we now route it into `StructuralVariant.alt_assembly`, which the SV annotator already prefers over inferring from breakpoints.
3. **Copy-number preservation** (`sv_allele_parser.py`). `<CN0>` and `<CN3>` both collapse to `sv_type="CNV"` (same VCF semantics) but the integer is now preserved in `info["copy_number"]` so downstream code can distinguish zero-copy deletions from higher-copy duplications.
4. **Warning text** (`vcf.py`). When SVs are dropped because `parse_structural_variants=False`, the warning now names the flag instead of just pointing at the issue tracker. Split into two counters so the parser-rejected case (flag is on, ALT didn't match) gets a different message.
5. **Kind-based dispatch for SVs** (`effects/effect_prediction.py`). `predict_variant_effects` had no kind dispatch — SVs went to the default `protein_diff` annotator (whose `supports={"snv","indel","mnv"}` was metadata only) and got annotated against the placeholder `ref="N"/alt="A"`, producing `ExonLoss`/`NoncodingTranscript` instead of `LargeDeletion`. Added the missing dispatch: when no explicit annotator is requested and the variant is structural, route to `StructuralVariantAnnotator`. Explicit overrides (e.g. parity testing) still pass through.

## Out of scope (deferred)

- **MATEID-based breakend pairing** — architectural call for #257 (one variant or two?).
- **Flip `parse_structural_variants=True` as default** — behaviour change, needs a deprecation cycle.
- **Spanning `*` metadata attachment** — unclear what consumers want.

## Test plan

- [x] `./test.sh` — 1023 passed, 2 skipped (gained 9 SV tests, no regressions)
- [x] `./lint.sh` — clean
- [x] New end-to-end test: VCF → `load_vcf(parse_structural_variants=True)` → `vc.effects()` → typed `StructuralVariantEffect`. This is the gate for downstream #257 / #252 / #261 work.