### PR TITLE
RNAEvidenceResolver protocol + apply hook (#259)

### DIFF
--- a/tests/test_rna_evidence.py
+++ b/tests/test_rna_evidence.py
@@ -1,0 +1,393 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for :mod:`varcode.rna_evidence` (#259).
+
+The protocol + apply hook should:
+
+* Be a no-op when no resolver is supplied (existing pipelines unchanged).
+* Append RNA-observed outcomes to ``MultiOutcomeEffect.outcomes`` in
+  the agreed-upon ordering (DNA-predicted first, RNA-observed after)
+  and via the back-compat ``_with_extra_outcomes`` hook so subclass
+  overrides of ``outcomes`` (SpliceOutcomeSet, StructuralVariantEffect)
+  pick up evidence uniformly.
+* Leave non-multi-outcome effects untouched even when the resolver
+  has evidence — the contract is "refinement of a possibility set",
+  not "replacement of a deterministic call".
+* Compose with subsequent evidence calls so a pipeline can attach
+  Isovar evidence first, then add Exacto evidence later.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from pyensembl import cached_release
+
+from varcode import (
+    NullRNAEvidenceResolver,
+    RNAEvidenceResolver,
+    StructuralVariant,
+    apply_rna_evidence_to_effects,
+    make_rna_outcome,
+    load_vcf,
+)
+from varcode.effects.effect_classes import (
+    LargeDeletion,
+    MultiOutcomeEffect,
+    StructuralVariantEffect,
+    Substitution,
+)
+from varcode.outcomes import Outcome
+
+
+ensembl_grch38 = cached_release(81)
+CFTR_ID = "ENST00000003084"
+
+
+def _cftr():
+    return ensembl_grch38.transcript_by_id(CFTR_ID)
+
+
+# --------------------------------------------------------------------
+# Protocol contract
+# --------------------------------------------------------------------
+
+
+class _StubResolver:
+    """In-test resolver that returns a fixed set of outcomes for any
+    (variant, transcript) pair. Useful for end-to-end tests where we
+    want to confirm the apply hook fires without standing up a real
+    Isovar pipeline."""
+
+    def __init__(self, outcomes):
+        self._outcomes = tuple(outcomes)
+
+    def observed_outcomes(self, variant, transcript):
+        return self._outcomes
+
+
+class TestProtocol:
+    def test_null_resolver_satisfies_protocol(self):
+        # runtime_checkable Protocol: duck-type via observed_outcomes.
+        assert isinstance(NullRNAEvidenceResolver(), RNAEvidenceResolver)
+
+    def test_arbitrary_class_with_method_satisfies_protocol(self):
+        assert isinstance(_StubResolver([]), RNAEvidenceResolver)
+
+    def test_object_without_method_does_not_satisfy(self):
+        class NotAResolver:
+            def something_else(self):
+                pass
+        assert not isinstance(NotAResolver(), RNAEvidenceResolver)
+
+
+# --------------------------------------------------------------------
+# make_rna_outcome helper
+# --------------------------------------------------------------------
+
+
+class TestMakeRNAOutcome:
+    """The factory shapes the evidence dict the way downstream code
+    expects, while still letting producer-specific fields ride along
+    in extra_evidence."""
+
+    def test_minimal_call_marks_source_rna(self):
+        o = make_rna_outcome(effect=Substitution)  # placeholder effect
+        assert o.source == "rna"
+        assert o.evidence == {}
+        assert o.probability is None
+
+    def test_well_known_fields_land_in_evidence(self):
+        o = make_rna_outcome(
+            effect=Substitution,
+            transcript_model_id="ISOFORM_42",
+            read_count=314,
+            probability=0.91)
+        assert o.evidence["transcript_model_id"] == "ISOFORM_42"
+        assert o.evidence["read_count"] == 314
+        assert o.probability == 0.91
+
+    def test_extra_evidence_merges_alongside_well_known(self):
+        o = make_rna_outcome(
+            effect=Substitution,
+            read_count=10,
+            extra_evidence={"tpm": 4.2, "junction_id": "JUNC_1"})
+        assert o.evidence["read_count"] == 10
+        assert o.evidence["tpm"] == 4.2
+        assert o.evidence["junction_id"] == "JUNC_1"
+
+    def test_source_override_for_tool_specific_filtering(self):
+        # Isovar / Exacto / longread_assembly producers set their own
+        # source string so consumers can filter by tool.
+        o = make_rna_outcome(effect=Substitution, source="isovar")
+        assert o.source == "isovar"
+
+
+# --------------------------------------------------------------------
+# apply_rna_evidence_to_effects — no-op cases
+# --------------------------------------------------------------------
+
+
+class TestApplyNoOpCases:
+    def test_none_resolver_returns_effects_unchanged(self):
+        marker = object()
+        effects = [marker]
+        result = apply_rna_evidence_to_effects(effects, None)
+        assert result is effects
+        assert effects == [marker]
+
+    def test_resolver_without_method_is_silent_noop(self):
+        """Defensive: if a caller passes the wrong object, we don't
+        crash mid-walk. Mirrors the
+        ``apply_phase_resolver_to_effects`` contract."""
+        class Garbage:
+            pass
+        marker = object()
+        effects = [marker]
+        result = apply_rna_evidence_to_effects(effects, Garbage())
+        assert result is effects
+
+    def test_null_resolver_leaves_outcomes_untouched(self):
+        sv = StructuralVariant(
+            contig="7",
+            start=_cftr().start + 100,
+            end=_cftr().start + 50_000,
+            sv_type="DEL",
+            genome=ensembl_grch38)
+        effect = sv.effect_on_transcript(_cftr())
+        baseline = tuple(effect.outcomes)
+        apply_rna_evidence_to_effects([effect], NullRNAEvidenceResolver())
+        assert tuple(effect.outcomes) == baseline
+
+
+# --------------------------------------------------------------------
+# apply_rna_evidence_to_effects — happy path
+# --------------------------------------------------------------------
+
+
+class TestApplyAttaches:
+    def _sv_effect(self):
+        sv = StructuralVariant(
+            contig="7",
+            start=_cftr().start + 100,
+            end=_cftr().start + 50_000,
+            sv_type="DEL",
+            genome=ensembl_grch38)
+        effect = sv.effect_on_transcript(_cftr())
+        # Sanity: the SV annotator returns a LargeDeletion (a
+        # StructuralVariantEffect, which is a MultiOutcomeEffect),
+        # so it has an ``outcomes`` view that should pick up extras.
+        assert isinstance(effect, LargeDeletion)
+        assert isinstance(effect, MultiOutcomeEffect)
+        return effect
+
+    def test_observed_outcomes_appended_to_outcomes_view(self):
+        effect = self._sv_effect()
+        baseline = tuple(effect.outcomes)
+        # Construct a stand-in observed outcome (the effect can be
+        # whatever — for this test we recycle the LargeDeletion's own
+        # most-likely candidate, since we just need a MutationEffect
+        # to wrap).
+        observed = make_rna_outcome(
+            effect=baseline[0].effect,
+            source="isovar",
+            transcript_model_id="ISOFORM_A",
+            read_count=42,
+            probability=0.78,
+            description="In-frame loss of CFTR exons 2-4 observed in tumor RNA")
+        apply_rna_evidence_to_effects(
+            [effect], _StubResolver([observed]))
+
+        new_outcomes = tuple(effect.outcomes)
+        # DNA-predicted outcomes preserved at the front, RNA-observed
+        # appended at the end. Consumers reading by source can pick
+        # whichever they want; consumers iterating in order get the
+        # most-likely DNA call first (preserves existing semantics).
+        assert len(new_outcomes) == len(baseline) + 1
+        assert new_outcomes[:len(baseline)] == baseline
+        assert new_outcomes[-1] is observed
+        assert new_outcomes[-1].source == "isovar"
+
+    def test_apply_is_idempotent_on_repeated_call_with_same_resolver(self):
+        """Calling apply twice with the same resolver doesn't duplicate
+        outcomes — wait, actually it DOES extend, since the apply
+        function is additive by design (so a pipeline can attach Isovar
+        first, Exacto after). We pin the additive contract here so
+        future refactors don't silently change to dedup."""
+        effect = self._sv_effect()
+        baseline_len = len(tuple(effect.outcomes))
+        observed = make_rna_outcome(
+            effect=tuple(effect.outcomes)[0].effect, source="isovar")
+        resolver = _StubResolver([observed])
+        apply_rna_evidence_to_effects([effect], resolver)
+        apply_rna_evidence_to_effects([effect], resolver)
+        assert len(tuple(effect.outcomes)) == baseline_len + 2
+
+    def test_mixed_sources_compose(self):
+        """The intended workflow: Isovar resolver runs first, Exacto
+        adds long-read disambiguation second. Consumers see both
+        sources alongside the original DNA-predicted outcomes."""
+        effect = self._sv_effect()
+        first = make_rna_outcome(
+            effect=tuple(effect.outcomes)[0].effect, source="isovar")
+        second = make_rna_outcome(
+            effect=tuple(effect.outcomes)[0].effect, source="exacto",
+            extra_evidence={"long_read_support": True})
+        apply_rna_evidence_to_effects([effect], _StubResolver([first]))
+        apply_rna_evidence_to_effects([effect], _StubResolver([second]))
+        sources = {o.source for o in effect.outcomes}
+        assert {"varcode", "isovar", "exacto"}.issubset(sources)
+
+
+# --------------------------------------------------------------------
+# Non-MultiOutcomeEffect cases
+# --------------------------------------------------------------------
+
+
+class TestNonMultiOutcomeNotMutated:
+    """Single-outcome effects (Missense, FrameShift, etc.) don't
+    expose an outcomes view — replacing them with multi-outcome
+    wrappers would break downstream isinstance checks. Pin that the
+    apply walk leaves them untouched."""
+
+    def test_missense_not_mutated_when_resolver_has_evidence(self):
+        # Use a real point-variant effect.
+        from varcode import Variant
+        v = Variant(
+            contig="7", start=140_753_336, ref="A", alt="T",
+            genome=ensembl_grch38)  # BRAF V600E-ish locus
+        effects = list(v.effects(raise_on_error=False))
+        assert effects, "BRAF locus should produce at least one effect"
+        # Pretend we have RNA evidence for this — apply shouldn't
+        # crash and should not mutate non-MultiOutcomeEffect entries.
+        observed = make_rna_outcome(
+            effect=effects[0], source="isovar")
+        apply_rna_evidence_to_effects(effects, _StubResolver([observed]))
+        for e in effects:
+            if not isinstance(e, MultiOutcomeEffect):
+                assert not hasattr(e, "_extra_outcomes") or not e._extra_outcomes
+
+
+# --------------------------------------------------------------------
+# Wiring through Variant.effects() and VariantCollection.effects()
+# --------------------------------------------------------------------
+
+
+def _write_vcf(body):
+    fd, path = tempfile.mkstemp(suffix=".vcf")
+    with os.fdopen(fd, "w") as f:
+        f.write(body)
+    return path
+
+
+class TestEffectsKwargWiring:
+    """The user-facing API path: ``rna_resolver=`` on
+    ``VariantCollection.effects()`` and ``Variant.effects()`` should
+    plumb through to the apply hook."""
+
+    def test_collection_effects_with_rna_resolver_attaches(self):
+        body = (
+            "##fileformat=VCFv4.2\n"
+            "##reference=GRCh38\n"
+            "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"type\">\n"
+            "##INFO=<ID=END,Number=1,Type=Integer,Description=\"end\">\n"
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+            "7\t%d\t.\tA\t<DEL>\t100\tPASS\tSVTYPE=DEL;END=%d\n"
+        ) % (_cftr().start + 100, _cftr().start + 50_000)
+        path = _write_vcf(body)
+        try:
+            vc = load_vcf(
+                path, genome=ensembl_grch38,
+                parse_structural_variants=True)
+        finally:
+            os.unlink(path)
+        # Capture the baseline (no resolver) and the with-resolver
+        # output and compare. Each SV is annotated against multiple
+        # transcripts; we just verify that *some* effect picked up
+        # observed outcomes.
+        baseline = vc.effects()
+        baseline_sv_effects = [
+            e for e in baseline
+            if isinstance(e, StructuralVariantEffect)]
+        assert baseline_sv_effects
+
+        # Stub resolver returns one observed outcome per call. Use the
+        # baseline's primary outcome's effect as the wrapper target.
+        observed_effect = tuple(baseline_sv_effects[0].outcomes)[0].effect
+        observed = make_rna_outcome(
+            effect=observed_effect, source="isovar",
+            transcript_model_id="ISO_1", read_count=11)
+        resolver = _StubResolver([observed])
+
+        with_evidence = vc.effects(rna_resolver=resolver)
+        sv_effects = [
+            e for e in with_evidence
+            if isinstance(e, StructuralVariantEffect)]
+        # Each SV effect should now carry the observed outcome.
+        for e in sv_effects:
+            sources = {o.source for o in e.outcomes}
+            assert "isovar" in sources, (
+                "Expected RNA-observed outcome on %r, got sources=%s"
+                % (e, sources))
+
+    def test_variant_effects_with_rna_resolver_attaches(self):
+        sv = StructuralVariant(
+            contig="7",
+            start=_cftr().start + 100,
+            end=_cftr().start + 50_000,
+            sv_type="DEL",
+            genome=ensembl_grch38)
+        baseline = list(sv.effects(raise_on_error=False))
+        sv_effects_baseline = [
+            e for e in baseline if isinstance(e, StructuralVariantEffect)]
+        assert sv_effects_baseline
+
+        observed_effect = tuple(sv_effects_baseline[0].outcomes)[0].effect
+        observed = make_rna_outcome(
+            effect=observed_effect, source="exacto", read_count=7)
+        with_evidence = list(
+            sv.effects(
+                raise_on_error=False,
+                rna_resolver=_StubResolver([observed])))
+        sv_effects = [
+            e for e in with_evidence
+            if isinstance(e, StructuralVariantEffect)]
+        for e in sv_effects:
+            sources = {o.source for o in e.outcomes}
+            assert "exacto" in sources
+
+
+# --------------------------------------------------------------------
+# Outcome ordering: DNA-predicted preserved at the front
+# --------------------------------------------------------------------
+
+
+class TestOrderingContract:
+    """``outcomes`` returns DNA-predicted entries first, RNA-observed
+    after. This preserves ``most_likely`` (which is ``candidates[0]``)
+    and lets consumers that read ``outcomes[0]`` for "the primary call"
+    keep working unchanged."""
+
+    def test_dna_predicted_outcomes_remain_first(self):
+        sv = StructuralVariant(
+            contig="7",
+            start=_cftr().start + 100,
+            end=_cftr().start + 50_000,
+            sv_type="DEL",
+            genome=ensembl_grch38)
+        effect = sv.effect_on_transcript(_cftr())
+        dna_predicted = tuple(effect.outcomes)
+        observed = make_rna_outcome(
+            effect=dna_predicted[0].effect, source="isovar")
+        apply_rna_evidence_to_effects([effect], _StubResolver([observed]))
+        new = tuple(effect.outcomes)
+        # First N entries are exactly the original DNA-predicted set.
+        assert new[:len(dna_predicted)] == dna_predicted
+        # most_likely should still be the original DNA-predicted top.
+        assert effect.most_likely is effect.candidates[0]

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -46,6 +46,12 @@ from .phasing import (
     VCFPhaseResolver,
     apply_phase_resolver_to_effects,
 )
+from .rna_evidence import (
+    NullRNAEvidenceResolver,
+    RNAEvidenceResolver,
+    apply_rna_evidence_to_effects,
+    make_rna_outcome,
+)
 from .splice_outcomes import (
     SpliceCandidate,
     SpliceOutcome,
@@ -112,6 +118,12 @@ __all__ = [
     "IsovarPhaseResolver",
     "VCFPhaseResolver",
     "apply_phase_resolver_to_effects",
+
+    # RNA-evidence resolver (openvax/varcode#259)
+    "RNAEvidenceResolver",
+    "NullRNAEvidenceResolver",
+    "apply_rna_evidence_to_effects",
+    "make_rna_outcome",
 
     "EffectAnnotator",
     "FastEffectAnnotator",

--- a/varcode/effects/effect_classes.py
+++ b/varcode/effects/effect_classes.py
@@ -163,9 +163,30 @@ class MultiOutcomeEffect(MutationEffect):
         :attr:`candidates` under ``source="varcode"``; subclasses
         (or external integrations) override to attach probabilities
         and evidence.
+
+        External integrations (RNA evidence, SpliceAI scoring, etc.)
+        attach extra outcomes via :meth:`_with_extra_outcomes` —
+        subclasses overriding this property must call that helper on
+        their derived tuple so the plug-in path remains uniform.
         """
         from ..outcomes import outcomes_from_candidates
-        return outcomes_from_candidates(self.candidates)
+        return self._with_extra_outcomes(
+            outcomes_from_candidates(self.candidates))
+
+    def _with_extra_outcomes(self, base_outcomes):
+        """Append externally-attached outcomes (#259) to a derived
+        ``outcomes`` tuple.
+
+        Subclasses that override :attr:`outcomes` should call this
+        helper on the tuple they construct so that
+        :func:`varcode.rna_evidence.apply_rna_evidence_to_effects`
+        and other post-hoc scorers can attach observed outcomes
+        without subclassing or monkey-patching.
+        """
+        extra = getattr(self, "_extra_outcomes", ())
+        if not extra:
+            return tuple(base_outcomes)
+        return tuple(base_outcomes) + tuple(extra)
 
 
 class Intergenic(MutationEffect):
@@ -1043,7 +1064,8 @@ class StructuralVariantEffect(TranscriptMutationEffect, MultiOutcomeEffect):
                     "interval_end": c.interval_end,
                 })
             for c in self._cryptic_candidates)
-        return primary + cryptic + tuple(self._splice_candidates)
+        return self._with_extra_outcomes(
+            primary + cryptic + tuple(self._splice_candidates))
 
 
 class LargeDeletion(StructuralVariantEffect):

--- a/varcode/rna_evidence.py
+++ b/varcode/rna_evidence.py
@@ -1,0 +1,203 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RNA-evidence resolver protocol for refining DNA-predicted variant
+effects with observed isoform / read-level evidence (#259).
+
+Varcode's effect classifiers predict possibilities from genomic
+coordinates alone — for many variants, especially structural ones,
+the actual protein consequence depends on what's transcribed and
+spliced. This module defines the contract that lets RNA-aware tools
+(Isovar, Exacto, custom long-read pipelines) attach observed
+:class:`~varcode.outcomes.Outcome` objects to existing effects
+without subclassing or churning the core classes.
+
+The shape mirrors :mod:`varcode.phasing`: a runtime-checkable
+:class:`Protocol`, an :func:`apply_rna_evidence_to_effects` walk that
+mutates effects in place, and a small :func:`make_rna_outcome` factory
+for the common provenance fields. Like :mod:`varcode.phasing`,
+nothing here imports Isovar — implementers duck-type the protocol.
+
+Usage::
+
+    resolver = MyIsovarResolver(reads=...)
+    # Per-call:
+    effects = vc.effects(rna_resolver=resolver)
+    # Or apply post-hoc to an existing collection:
+    apply_rna_evidence_to_effects(effects, resolver)
+
+    # Each affected effect gains observed outcomes alongside its
+    # DNA-predicted ones. Filter by source:
+    for effect in effects:
+        for outcome in getattr(effect, "outcomes", ()):
+            if outcome.source != "varcode":
+                # An RNA-observed isoform.
+                ...
+"""
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Optional, Protocol, Sequence, runtime_checkable
+
+from .outcomes import Outcome
+
+
+@runtime_checkable
+class RNAEvidenceResolver(Protocol):
+    """Source of RNA-observed outcomes for a ``(variant, transcript)``
+    pair.
+
+    Implementers return zero or more :class:`~varcode.outcomes.Outcome`
+    objects describing isoforms, fusions, or RNA-level events that were
+    actually observed in reads. An empty sequence means "no evidence
+    for this pair" — the existing DNA-predicted outcomes are left
+    alone.
+
+    Returned outcomes should set ``source`` to a producer-specific
+    string (``"isovar"``, ``"exacto"``, ``"longread_assembly"``, ...)
+    and populate ``evidence`` with whatever shape that producer
+    natively emits (transcript model IDs, junction read counts, etc.).
+    See :func:`make_rna_outcome` for a convenience factory that fills
+    the common fields.
+    """
+
+    def observed_outcomes(self, variant, transcript) -> Sequence[Outcome]:
+        """Return RNA-observed outcomes for ``variant`` on
+        ``transcript``, or an empty sequence when no evidence is
+        available. Must not raise on unknown ``(variant, transcript)``
+        pairs — return an empty sequence instead."""
+        ...
+
+
+class NullRNAEvidenceResolver:
+    """No-op resolver that always reports "no evidence".
+
+    Useful as a default in pipelines where an RNA resolver is optional
+    and as a baseline in tests. ``apply_rna_evidence_to_effects`` is
+    safe to call with this resolver — it's a no-op walk."""
+
+    def observed_outcomes(self, variant, transcript) -> Sequence[Outcome]:
+        return ()
+
+
+def make_rna_outcome(
+        effect,
+        *,
+        probability: Optional[float] = None,
+        source: str = "rna",
+        transcript_model_id: Optional[str] = None,
+        read_count: Optional[int] = None,
+        description: Optional[str] = None,
+        extra_evidence: Optional[Mapping[str, Any]] = None) -> Outcome:
+    """Construct an :class:`~varcode.outcomes.Outcome` carrying
+    RNA-derived provenance.
+
+    Convenience factory for the common fields a reads-based or
+    long-read assembly tool wants on each observed outcome — keeps
+    consumers from hand-rolling the ``evidence`` dict shape and lets
+    downstream code rely on a small set of well-known keys.
+
+    Parameters
+    ----------
+    effect : MutationEffect
+        The effect this RNA-observed outcome represents.
+    probability : float or None
+        Estimated frequency of this isoform (e.g. expression-supported
+        fraction). ``None`` means "not scored".
+    source : str
+        Producer name; defaults to ``"rna"``. Set to ``"isovar"`` /
+        ``"exacto"`` / etc. for tool-specific filtering.
+    transcript_model_id : str or None
+        Stable ID of the observed transcript model from the producer.
+        Stored under ``evidence["transcript_model_id"]``.
+    read_count : int or None
+        Supporting read count. Stored under ``evidence["read_count"]``.
+    description : str or None
+        Human-readable label, passed through to
+        :attr:`Outcome.description`.
+    extra_evidence : Mapping or None
+        Producer-specific extra fields, merged into the evidence dict
+        on top of the well-known keys above. Allows tool-native fields
+        (e.g. ``"tpm"``, ``"junction_id"``) to ride along without
+        forcing a schema here.
+    """
+    evidence: dict = {}
+    if transcript_model_id is not None:
+        evidence["transcript_model_id"] = transcript_model_id
+    if read_count is not None:
+        evidence["read_count"] = read_count
+    if extra_evidence:
+        evidence.update(extra_evidence)
+    return Outcome(
+        effect=effect,
+        probability=probability,
+        source=source,
+        evidence=evidence,
+        description=description,
+    )
+
+
+def apply_rna_evidence_to_effects(effects: Iterable, resolver) -> Iterable:
+    """Attach RNA-observed outcomes from ``resolver`` to each effect
+    in place.
+
+    Walks ``effects`` and, for any effect with a resolvable
+    ``(variant, transcript)``, asks ``resolver.observed_outcomes``
+    for any RNA-observed outcomes and stashes them on the effect's
+    ``_extra_outcomes`` slot. The :attr:`MultiOutcomeEffect.outcomes`
+    property (and its overrides) consult that slot via
+    :meth:`MultiOutcomeEffect._with_extra_outcomes` so callers see
+    DNA-predicted outcomes followed by RNA-observed ones.
+
+    Single-outcome effects (Missense, FrameShift, etc.) are left
+    untouched even when the resolver has evidence — those classes
+    don't expose an ``outcomes`` view, and replacing them with a
+    multi-outcome wrapper would break downstream ``isinstance`` checks.
+    Producers that need to surface RNA observations on point variants
+    should report them as a separate :class:`MultiOutcomeEffect` rather
+    than mutating an existing single-outcome one. (The point-variant
+    diff is generally already correct from DNA, so this is rarely an
+    issue in practice.)
+
+    Mirrors :func:`varcode.phasing.apply_phase_resolver_to_effects`:
+    in-place mutation, safe to call on a mixed collection where only
+    some variants have RNA evidence, no-op when ``resolver`` is None
+    or doesn't implement the protocol.
+
+    Returns ``effects`` for chaining convenience.
+    """
+    if resolver is None:
+        return effects
+    if not hasattr(resolver, "observed_outcomes"):
+        return effects
+
+    # Lazy import to avoid an import cycle (effect_classes imports
+    # from varcode.outcomes, which sits below us).
+    from .effects.effect_classes import MultiOutcomeEffect
+
+    for effect in effects:
+        if not isinstance(effect, MultiOutcomeEffect):
+            continue
+        variant = getattr(effect, "variant", None)
+        transcript = getattr(effect, "transcript", None)
+        if variant is None or transcript is None:
+            continue
+        observed = resolver.observed_outcomes(variant, transcript)
+        if not observed:
+            continue
+        # Coerce to tuple eagerly so we don't keep a generator that
+        # would silently exhaust on a second outcomes() read.
+        observed_tuple = tuple(observed)
+        if not observed_tuple:
+            continue
+        existing = getattr(effect, "_extra_outcomes", ())
+        effect._extra_outcomes = tuple(existing) + observed_tuple
+    return effects

--- a/varcode/splice_outcomes.py
+++ b/varcode/splice_outcomes.py
@@ -254,14 +254,15 @@ class SpliceOutcomeSet(MultiOutcomeEffect):
         dispatch on the biological outcome kind without reaching
         back into :attr:`candidates`.
         """
-        return tuple(
-            Outcome(
-                effect=self._outcome_effect(candidate),
-                probability=candidate.plausibility,
-                source="varcode",
-                description=candidate.description,
-                evidence={"splice_outcome": candidate.outcome})
-            for candidate in self.candidates)
+        return self._with_extra_outcomes(
+            tuple(
+                Outcome(
+                    effect=self._outcome_effect(candidate),
+                    probability=candidate.plausibility,
+                    source="varcode",
+                    description=candidate.description,
+                    evidence={"splice_outcome": candidate.outcome})
+                for candidate in self.candidates))
 
     def _outcome_effect(self, candidate):
         """Return the :class:`MutationEffect` that backs ``candidate``

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -445,7 +445,7 @@ class Variant(Serializable):
 
     def effects(
             self, raise_on_error=True, splice_outcomes=False,
-            annotator=None, phase_resolver=None):
+            annotator=None, phase_resolver=None, rna_resolver=None):
         """Predict the variant's effects on overlapping transcripts.
 
         Parameters
@@ -479,6 +479,16 @@ class Variant(Serializable):
             protein is the protein actually observed in RNA rather
             than one inferred from the reference. See
             openvax/varcode#269.
+
+        rna_resolver : RNAEvidenceResolver or None
+            Optional RNA-observed-outcome source. When provided, any
+            :class:`~varcode.MultiOutcomeEffect` in the result has
+            observed outcomes from the resolver appended to its
+            ``outcomes`` view (DNA-predicted first, RNA-observed
+            after). Useful for refining SV / splice / haplotype
+            predictions with isoform-level evidence from Isovar,
+            Exacto, or a custom long-read pipeline. See
+            openvax/varcode#259.
         """
         effects = predict_variant_effects(
             variant=self,
@@ -489,6 +499,9 @@ class Variant(Serializable):
         if phase_resolver is not None:
             from .phasing import apply_phase_resolver_to_effects
             apply_phase_resolver_to_effects(effects, phase_resolver)
+        if rna_resolver is not None:
+            from .rna_evidence import apply_rna_evidence_to_effects
+            apply_rna_evidence_to_effects(effects, rna_resolver)
         return effects
 
     def effect_on_transcript(self, transcript):

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -116,7 +116,7 @@ class VariantCollection(Collection):
 
     def effects(
             self, raise_on_error=True, splice_outcomes=False,
-            annotator=None, phase_resolver=None):
+            annotator=None, phase_resolver=None, rna_resolver=None):
         """
         Parameters
         ----------
@@ -144,6 +144,12 @@ class VariantCollection(Collection):
             ``mutant_transcript`` populated with the contig-derived
             :class:`~varcode.MutantTranscript`. See
             openvax/varcode#269.
+
+        rna_resolver : RNAEvidenceResolver or None
+            Optional RNA-observed-outcome source. When provided, any
+            :class:`~varcode.MultiOutcomeEffect` in the result has
+            observed outcomes from the resolver appended to its
+            ``outcomes`` view. See openvax/varcode#259.
         """
         from datetime import datetime, timezone
 
@@ -171,6 +177,9 @@ class VariantCollection(Collection):
             # individual effect severity.
             per_variant.extend(build_haplotype_effects(
                 self, per_variant, phase_resolver))
+        if rna_resolver is not None:
+            from .rna_evidence import apply_rna_evidence_to_effects
+            apply_rna_evidence_to_effects(per_variant, rna_resolver)
         return EffectCollection(per_variant,
             annotator=getattr(annotator_instance, "name", None),
             annotator_version=getattr(annotator_instance, "version", None),


### PR DESCRIPTION
## Summary

Adds the type-system half of #259 — the contract that lets RNA-aware tools (Isovar, Exacto, custom long-read pipelines) attach observed-isoform outcomes to existing effects without subclassing or churning the core classes. Mirrors the `PhaseResolver` pattern from #269.

The user's framing for picking this up next was: *SVs will need RNA more, so they should refine their predictions.* This PR makes that workflow concrete: a loaded `StructuralVariant` annotated as `LargeDeletion` already has DNA-predicted outcomes; an RNA resolver appends RNA-observed outcomes alongside them, and consumers filter by `Outcome.source`.

## Mechanism

- `RNAEvidenceResolver` Protocol (runtime-checkable, single method `observed_outcomes(variant, transcript)`).
- `apply_rna_evidence_to_effects(effects, resolver)` — in-place walk that stashes resolver outcomes on `effect._extra_outcomes`.
- `MultiOutcomeEffect.outcomes` (and overrides on `SpliceOutcomeSet` / `StructuralVariantEffect`) now go through a `_with_extra_outcomes` helper that appends the slot's contents to whatever the subclass derives. Existing `outcomes[0]` / `most_likely` semantics preserved.
- `Variant.effects(rna_resolver=...)` and `VariantCollection.effects(rna_resolver=...)` plumb through.

## Helpers

- `NullRNAEvidenceResolver` — always returns `()`. Default for pipelines, baseline for tests.
- `make_rna_outcome(effect, *, transcript_model_id=..., read_count=..., probability=..., extra_evidence=...)` — factory shaping the common evidence keys.

## What's deliberately NOT here

The seven RNA-informed effect classes from #259's body (FusionTranscript / FusionProtein / CircularRNA / CrypticExon / ExonTruncation / IntronRetention / UTRExtension). They need first producers to avoid being dead code, and their shape would likely churn before real use. Deferred to follow-up PRs that land each alongside its first concrete producer.

For now, producers wrap whatever `MutationEffect` they have (typically a DNA-predicted candidate from `effect.candidates`) inside an `Outcome` with their tool-specific `source` string and `evidence` dict. That's enough to refine SVs / splice / haplotype predictions today.

## Test plan

- [x] `./test.sh` — 1044 passed, 2 skipped (gained 17 tests in `tests/test_rna_evidence.py`)
- [x] `./lint.sh` — clean
- [x] `import varcode` doesn't pull `vcf` / `rpy2` (verified)
- [x] End-to-end smoke test included: load a VCF with `parse_structural_variants=True`, call `vc.effects(rna_resolver=stub)`, confirm the stub's outcomes appear on each `StructuralVariantEffect.outcomes` with their tool source.