### PR TITLE
GermlineContext + validation (slice 1 of #268)

### DIFF
--- a/tests/test_germline_context.py
+++ b/tests/test_germline_context.py
@@ -7,7 +7,7 @@
 """Tests for :class:`varcode.germline.GermlineContext` (#268, slice 1).
 
 Slice 1 ships the input contract — constructors, validation,
-sparseness flag, window-based lookup. No effect-side logic yet
+completeness flag, window-based lookup. No effect-side logic yet
 (annotator dispatch, transcript construction with germline applied,
 phase enumeration, LOH detection are subsequent slices).
 """
@@ -23,7 +23,7 @@ from varcode import (
     GenomeBuildMismatchError,
     GermlineContext,
     SampleNotFoundError,
-    Sparseness,
+    Completeness,
     Variant,
     load_vcf,
 )
@@ -31,11 +31,11 @@ from varcode.variant_collection import VariantCollection
 
 
 # --------------------------------------------------------------------
-# Sparseness enum
+# Completeness enum
 # --------------------------------------------------------------------
 
 
-class TestSparseness:
+class TestCompleteness:
     """The completeness flag is the load-bearing piece for correctness:
     a downstream caller deciding whether absence-of-a-call means
     ref/ref needs to read it, so its values must be stable and
@@ -43,14 +43,14 @@ class TestSparseness:
 
     def test_distinct_values(self):
         # All four states distinguishable.
-        assert len({Sparseness.COMPLETE, Sparseness.SPARSE,
-                    Sparseness.HOTSPOTS_ONLY, Sparseness.EMPTY}) == 4
+        assert len({Completeness.COMPLETE, Completeness.SPARSE,
+                    Completeness.HOTSPOTS_ONLY, Completeness.EMPTY}) == 4
 
     def test_round_trip_via_value(self):
         # Stable string identifiers — important for serialization
         # to CSVs / JSON evidence dicts in later slices.
-        for s in Sparseness:
-            assert Sparseness(s.value) is s
+        for s in Completeness:
+            assert Completeness(s.value) is s
 
 
 # --------------------------------------------------------------------
@@ -63,7 +63,7 @@ class TestEmptyContext:
         ctx = GermlineContext.empty()
         assert not ctx
         assert len(ctx) == 0
-        assert ctx.completeness is Sparseness.EMPTY
+        assert ctx.completeness is Completeness.EMPTY
 
     def test_empty_has_no_reference(self):
         # No claim about reference build for an empty context — we
@@ -105,14 +105,14 @@ class TestFromVariants:
     def test_default_completeness_is_complete(self):
         ctx = GermlineContext.from_variants(
             [self._v()], reference_name="GRCh38")
-        assert ctx.completeness is Sparseness.COMPLETE
+        assert ctx.completeness is Completeness.COMPLETE
 
     def test_completeness_override(self):
         ctx = GermlineContext.from_variants(
             [self._v()],
-            completeness=Sparseness.SPARSE,
+            completeness=Completeness.SPARSE,
             reference_name="GRCh38")
-        assert ctx.completeness is Sparseness.SPARSE
+        assert ctx.completeness is Completeness.SPARSE
 
     def test_metadata_passes_through(self):
         ctx = GermlineContext.from_variants(
@@ -254,7 +254,7 @@ class TestValidateAgainst:
         always a wrong-file or filter-too-aggressive bug. We don't
         want this to silently pass — warn so the user investigates."""
         germ = GermlineContext.from_variants(
-            [], completeness=Sparseness.COMPLETE,
+            [], completeness=Completeness.COMPLETE,
             reference_name="GRCh38")
         somatic = VariantCollection([self._v("GRCh38")])
         with warnings.catch_warnings(record=True) as captured:
@@ -307,7 +307,7 @@ class TestFromGermlineVCF:
         finally:
             os.unlink(path)
         assert len(ctx) == 2
-        assert ctx.completeness is Sparseness.COMPLETE
+        assert ctx.completeness is Completeness.COMPLETE
         assert ctx.reference_name == "GRCh38"
 
     def test_warns_on_zero_variant_load(self):
@@ -357,7 +357,7 @@ class TestFromMultiSampleVCF:
         try:
             ctx = GermlineContext.from_multi_sample_vcf(
                 path, sample="NORMAL",
-                completeness=Sparseness.SPARSE,
+                completeness=Completeness.SPARSE,
                 genome="GRCh38")
         finally:
             os.unlink(path)
@@ -384,7 +384,7 @@ class TestFromMultiSampleVCF:
             with pytest.raises(SampleNotFoundError) as exc_info:
                 GermlineContext.from_multi_sample_vcf(
                     path, sample="DOES_NOT_EXIST",
-                    completeness=Sparseness.COMPLETE,
+                    completeness=Completeness.COMPLETE,
                     genome="GRCh38")
             # Error message lists available samples so the user sees
             # what they could have asked for.
@@ -398,7 +398,7 @@ class TestFromMultiSampleVCF:
         try:
             ctx = GermlineContext.from_multi_sample_vcf(
                 path, sample="NORMAL",
-                completeness=Sparseness.SPARSE,
+                completeness=Completeness.SPARSE,
                 genome="GRCh38")
         finally:
             os.unlink(path)
@@ -431,13 +431,13 @@ class TestDunders:
         rare-call-set case where downstream code wants to know
         'they meant complete but couldn't load any.'"""
         ctx = GermlineContext.from_variants(
-            [], completeness=Sparseness.COMPLETE,
+            [], completeness=Completeness.COMPLETE,
             reference_name="GRCh38")
         assert bool(ctx) is False
 
     def test_bool_false_for_empty_sparse(self):
         ctx = GermlineContext.from_variants(
-            [], completeness=Sparseness.SPARSE,
+            [], completeness=Completeness.SPARSE,
             reference_name="GRCh38")
         assert bool(ctx) is False
 
@@ -453,4 +453,4 @@ class TestDunders:
         isn't accidentally relied on."""
         ctx = GermlineContext.empty()
         with pytest.raises(Exception):  # FrozenInstanceError or AttributeError
-            ctx.completeness = Sparseness.COMPLETE
+            ctx.completeness = Completeness.COMPLETE

--- a/tests/test_germline_context.py
+++ b/tests/test_germline_context.py
@@ -1,0 +1,456 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for :class:`varcode.germline.GermlineContext` (#268, slice 1).
+
+Slice 1 ships the input contract — constructors, validation,
+sparseness flag, window-based lookup. No effect-side logic yet
+(annotator dispatch, transcript construction with germline applied,
+phase enumeration, LOH detection are subsequent slices).
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import warnings
+
+import pytest
+
+from varcode import (
+    GenomeBuildMismatchError,
+    GermlineContext,
+    SampleNotFoundError,
+    Sparseness,
+    Variant,
+    load_vcf,
+)
+from varcode.variant_collection import VariantCollection
+
+
+# --------------------------------------------------------------------
+# Sparseness enum
+# --------------------------------------------------------------------
+
+
+class TestSparseness:
+    """The completeness flag is the load-bearing piece for correctness:
+    a downstream caller deciding whether absence-of-a-call means
+    ref/ref needs to read it, so its values must be stable and
+    comparable."""
+
+    def test_distinct_values(self):
+        # All four states distinguishable.
+        assert len({Sparseness.COMPLETE, Sparseness.SPARSE,
+                    Sparseness.HOTSPOTS_ONLY, Sparseness.EMPTY}) == 4
+
+    def test_round_trip_via_value(self):
+        # Stable string identifiers — important for serialization
+        # to CSVs / JSON evidence dicts in later slices.
+        for s in Sparseness:
+            assert Sparseness(s.value) is s
+
+
+# --------------------------------------------------------------------
+# Empty context
+# --------------------------------------------------------------------
+
+
+class TestEmptyContext:
+    def test_empty_is_falsy(self):
+        ctx = GermlineContext.empty()
+        assert not ctx
+        assert len(ctx) == 0
+        assert ctx.completeness is Sparseness.EMPTY
+
+    def test_empty_has_no_reference(self):
+        # No claim about reference build for an empty context — we
+        # don't want to falsely block a cross-VCF validation just
+        # because a default crept in.
+        assert GermlineContext.empty().reference_name is None
+
+    def test_empty_lookup_returns_empty_tuple(self):
+        ctx = GermlineContext.empty()
+        # Window lookup on an empty context is well-defined — no
+        # exceptions, just empty tuple. Lets callers treat the empty
+        # case the same as the no-overlap case in their loops.
+        assert ctx.variants_in_window("1", 1, 1_000_000) == ()
+
+
+# --------------------------------------------------------------------
+# from_variants — direct construction
+# --------------------------------------------------------------------
+
+
+class TestFromVariants:
+    def _v(self, **kwargs):
+        defaults = dict(contig="1", start=100, ref="A", alt="T",
+                        genome="GRCh38")
+        defaults.update(kwargs)
+        return Variant(**defaults)
+
+    def test_accepts_iterable(self):
+        ctx = GermlineContext.from_variants(
+            [self._v()], reference_name="GRCh38")
+        assert len(ctx) == 1
+
+    def test_accepts_existing_collection(self):
+        vc = VariantCollection([self._v()])
+        ctx = GermlineContext.from_variants(vc, reference_name="GRCh38")
+        # Reusing the same collection — no copy.
+        assert ctx.variants is vc
+
+    def test_default_completeness_is_complete(self):
+        ctx = GermlineContext.from_variants(
+            [self._v()], reference_name="GRCh38")
+        assert ctx.completeness is Sparseness.COMPLETE
+
+    def test_completeness_override(self):
+        ctx = GermlineContext.from_variants(
+            [self._v()],
+            completeness=Sparseness.SPARSE,
+            reference_name="GRCh38")
+        assert ctx.completeness is Sparseness.SPARSE
+
+    def test_metadata_passes_through(self):
+        ctx = GermlineContext.from_variants(
+            [self._v()],
+            metadata={"caller": "DeepVariant", "version": "1.6"},
+            reference_name="GRCh38")
+        assert ctx.metadata["caller"] == "DeepVariant"
+
+    def test_reference_inferred_from_variants_when_consistent(self):
+        ctx = GermlineContext.from_variants([self._v()])
+        # Variants all carry GRCh38 genome → context picks it up.
+        assert ctx.reference_name == "GRCh38"
+
+
+# --------------------------------------------------------------------
+# Window lookup
+# --------------------------------------------------------------------
+
+
+class TestWindowLookup:
+    """The window lookup is what slice 2's germline-application path
+    will call millions of times during effect prediction — pin
+    correctness on the boundary cases now while it's free to fix."""
+
+    def _ctx(self, variants):
+        return GermlineContext.from_variants(
+            variants, reference_name="GRCh38")
+
+    def _v(self, contig, start, ref="A", alt="T"):
+        return Variant(contig=contig, start=start, ref=ref, alt=alt,
+                       genome="GRCh38")
+
+    def test_overlap_returns_variant(self):
+        v = self._v("1", 100)
+        ctx = self._ctx([v])
+        assert v in ctx.variants_in_window("1", 50, 150)
+
+    def test_inclusive_lower_bound(self):
+        v = self._v("1", 100)
+        ctx = self._ctx([v])
+        # Window starts exactly at the variant.
+        assert ctx.variants_in_window("1", 100, 200) == (v,)
+
+    def test_inclusive_upper_bound(self):
+        v = self._v("1", 100)
+        ctx = self._ctx([v])
+        # Window ends exactly at the variant.
+        assert ctx.variants_in_window("1", 50, 100) == (v,)
+
+    def test_outside_window_excluded(self):
+        v = self._v("1", 100)
+        ctx = self._ctx([v])
+        assert ctx.variants_in_window("1", 200, 300) == ()
+        assert ctx.variants_in_window("1", 1, 50) == ()
+
+    def test_other_contig_excluded(self):
+        ctx = self._ctx([self._v("1", 100)])
+        assert ctx.variants_in_window("2", 50, 150) == ()
+        assert ctx.variants_in_window("X", 50, 150) == ()
+
+    def test_multiple_variants_in_window(self):
+        vs = [self._v("1", 100), self._v("1", 110), self._v("1", 105)]
+        ctx = self._ctx(vs)
+        result = ctx.variants_in_window("1", 95, 115)
+        assert len(result) == 3
+
+    def test_index_is_cached(self):
+        v = self._v("1", 100)
+        ctx = self._ctx([v])
+        # First call builds the index; cache attribute appears.
+        ctx.variants_in_window("1", 50, 150)
+        assert hasattr(ctx, "_index_cache")
+        cached = ctx._index_cache
+        # Second call returns the same index dict (no rebuild).
+        ctx.variants_in_window("1", 50, 150)
+        assert ctx._index_cache is cached
+
+    def test_returned_value_is_tuple(self):
+        # Tuple → callers can safely cache/share without worrying
+        # about downstream mutation.
+        v = self._v("1", 100)
+        ctx = self._ctx([v])
+        result = ctx.variants_in_window("1", 50, 150)
+        assert isinstance(result, tuple)
+
+
+# --------------------------------------------------------------------
+# Cross-VCF validation
+# --------------------------------------------------------------------
+
+
+class TestValidateAgainst:
+    def _v(self, genome):
+        return Variant(contig="1", start=100, ref="A", alt="T",
+                       genome=genome)
+
+    def test_matching_reference_passes(self):
+        germ = GermlineContext.from_variants(
+            [self._v("GRCh38")], reference_name="GRCh38")
+        somatic = VariantCollection([self._v("GRCh38")])
+        # No exception → pass.
+        germ.validate_against(somatic)
+
+    def test_mismatched_reference_raises(self):
+        germ = GermlineContext.from_variants(
+            [self._v("GRCh38")], reference_name="GRCh38")
+        somatic = VariantCollection([self._v("GRCh37")])
+        with pytest.raises(GenomeBuildMismatchError) as exc_info:
+            germ.validate_against(somatic)
+        # Error carries both names so the user can see what mismatched.
+        assert exc_info.value.somatic_reference == "GRCh37"
+        assert exc_info.value.germline_reference == "GRCh38"
+
+    def test_mismatch_opt_out_via_validate_reference_false(self):
+        """For users who've explicitly lifted over one VCF into the
+        other's build and know they're in sync. The hard error is the
+        default; the opt-out is one kwarg."""
+        germ = GermlineContext.from_variants(
+            [self._v("GRCh38")], reference_name="GRCh38")
+        somatic = VariantCollection([self._v("GRCh37")])
+        # No exception even with a clear mismatch.
+        germ.validate_against(somatic, validate_reference=False)
+
+    def test_unknown_reference_skips_check(self):
+        """If we couldn't determine either reference, we can't validate.
+        Don't raise on uncertainty — just no-op. Slice 2's annotator
+        plumbing will surface coordinate mismatches as
+        ReferenceMismatchError on first contact."""
+        germ = GermlineContext.from_variants([self._v("GRCh38")])
+        # Manually wipe the reference (simulates a context built from
+        # variants with no genome attribute).
+        object.__setattr__(germ, "reference_name", None)
+        somatic = VariantCollection([self._v("GRCh37")])
+        # No raise — we don't know enough to claim mismatch.
+        germ.validate_against(somatic)
+
+    def test_warns_on_empty_context_with_non_empty_completeness(self):
+        """A COMPLETE-flagged context with zero variants is almost
+        always a wrong-file or filter-too-aggressive bug. We don't
+        want this to silently pass — warn so the user investigates."""
+        germ = GermlineContext.from_variants(
+            [], completeness=Sparseness.COMPLETE,
+            reference_name="GRCh38")
+        somatic = VariantCollection([self._v("GRCh38")])
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            germ.validate_against(somatic)
+        assert any(
+            "zero variants" in str(w.message)
+            for w in captured), (
+                "Expected zero-variants warning, got %s" % [
+                    str(w.message) for w in captured])
+
+    def test_no_warning_on_genuinely_empty_context(self):
+        """An EMPTY-flagged context is the explicit fallback shape;
+        the user has opted into reference-relative annotation.
+        Warning here would be noise."""
+        germ = GermlineContext.empty()
+        somatic = VariantCollection([self._v("GRCh38")])
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            germ.validate_against(somatic)
+        assert not any(
+            "zero variants" in str(w.message) for w in captured)
+
+
+# --------------------------------------------------------------------
+# from_germline_vcf — load path
+# --------------------------------------------------------------------
+
+
+def _write_vcf(body):
+    fd, path = tempfile.mkstemp(suffix=".vcf")
+    with os.fdopen(fd, "w") as f:
+        f.write(body)
+    return path
+
+
+class TestFromGermlineVCF:
+    def test_loads_full_call_set(self):
+        body = (
+            "##fileformat=VCFv4.2\n"
+            "##reference=GRCh38\n"
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+            "1\t100\t.\tA\tT\t100\tPASS\t.\n"
+            "1\t200\t.\tC\tG\t100\tPASS\t.\n"
+        )
+        path = _write_vcf(body)
+        try:
+            ctx = GermlineContext.from_germline_vcf(
+                path, genome="GRCh38")
+        finally:
+            os.unlink(path)
+        assert len(ctx) == 2
+        assert ctx.completeness is Sparseness.COMPLETE
+        assert ctx.reference_name == "GRCh38"
+
+    def test_warns_on_zero_variant_load(self):
+        """The most common 'wrong file' symptom — a VCF with no
+        records. Catching this at load time saves debugging cycles
+        downstream when every somatic variant comes back
+        reference-relative."""
+        body = (
+            "##fileformat=VCFv4.2\n"
+            "##reference=GRCh38\n"
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        )
+        path = _write_vcf(body)
+        try:
+            with warnings.catch_warnings(record=True) as captured:
+                warnings.simplefilter("always")
+                ctx = GermlineContext.from_germline_vcf(
+                    path, genome="GRCh38")
+        finally:
+            os.unlink(path)
+        assert len(ctx) == 0
+        assert any("zero variants" in str(w.message) for w in captured)
+
+
+# --------------------------------------------------------------------
+# from_multi_sample_vcf
+# --------------------------------------------------------------------
+
+
+class TestFromMultiSampleVCF:
+    def _multi_sample_body(self):
+        return (
+            "##fileformat=VCFv4.2\n"
+            "##reference=GRCh38\n"
+            "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"genotype\">\n"
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNORMAL\tTUMOR\n"
+            "1\t100\t.\tA\tT\t100\tPASS\t.\tGT\t0/1\t0/1\n"
+            "1\t200\t.\tC\tG\t100\tPASS\t.\tGT\t0/0\t0/1\n"
+            "1\t300\t.\tG\tA\t100\tPASS\t.\tGT\t0/1\t1/1\n"
+        )
+
+    def test_extracts_calls_for_named_sample(self):
+        """The NORMAL column has calls at positions 100 and 300 (GT
+        non-ref) but not 200 (GT 0/0). Extracting NORMAL should give
+        us those two."""
+        path = _write_vcf(self._multi_sample_body())
+        try:
+            ctx = GermlineContext.from_multi_sample_vcf(
+                path, sample="NORMAL",
+                completeness=Sparseness.SPARSE,
+                genome="GRCh38")
+        finally:
+            os.unlink(path)
+        assert len(ctx) == 2
+        starts = {v.start for v in ctx}
+        assert starts == {100, 300}
+
+    def test_completeness_is_required(self):
+        """Multi-sample VCFs from somatic callers are sparse; pure-
+        germline multi-sample VCFs are complete. Forcing the caller
+        to declare prevents a class of correctness bugs."""
+        path = _write_vcf(self._multi_sample_body())
+        try:
+            with pytest.raises(TypeError):
+                # Missing required keyword-only arg: completeness=
+                GermlineContext.from_multi_sample_vcf(
+                    path, sample="NORMAL", genome="GRCh38")
+        finally:
+            os.unlink(path)
+
+    def test_unknown_sample_raises(self):
+        path = _write_vcf(self._multi_sample_body())
+        try:
+            with pytest.raises(SampleNotFoundError) as exc_info:
+                GermlineContext.from_multi_sample_vcf(
+                    path, sample="DOES_NOT_EXIST",
+                    completeness=Sparseness.COMPLETE,
+                    genome="GRCh38")
+            # Error message lists available samples so the user sees
+            # what they could have asked for.
+            assert "NORMAL" in str(exc_info.value)
+            assert "TUMOR" in str(exc_info.value)
+        finally:
+            os.unlink(path)
+
+    def test_metadata_records_source_and_sample(self):
+        path = _write_vcf(self._multi_sample_body())
+        try:
+            ctx = GermlineContext.from_multi_sample_vcf(
+                path, sample="NORMAL",
+                completeness=Sparseness.SPARSE,
+                genome="GRCh38")
+        finally:
+            os.unlink(path)
+        assert ctx.metadata["sample"] == "NORMAL"
+        assert ctx.metadata["source_path"] == path
+
+
+# --------------------------------------------------------------------
+# Iteration / __bool__ / __len__ contracts
+# --------------------------------------------------------------------
+
+
+class TestDunders:
+    """The dunder protocol matters for ergonomic use: ``if germline:``
+    has to read intuitively, and iteration / len have to behave like
+    a VariantCollection so callers can drop a context wherever a
+    collection used to flow."""
+
+    def test_bool_true_when_non_empty(self):
+        ctx = GermlineContext.from_variants(
+            [Variant(contig="1", start=1, ref="A", alt="T",
+                     genome="GRCh38")],
+            reference_name="GRCh38")
+        assert bool(ctx) is True
+
+    def test_bool_false_for_empty_complete(self):
+        """A COMPLETE context with zero variants is falsy too — there's
+        no germline data to apply, even though the caller intended
+        completeness. The completeness flag stays for the
+        rare-call-set case where downstream code wants to know
+        'they meant complete but couldn't load any.'"""
+        ctx = GermlineContext.from_variants(
+            [], completeness=Sparseness.COMPLETE,
+            reference_name="GRCh38")
+        assert bool(ctx) is False
+
+    def test_bool_false_for_empty_sparse(self):
+        ctx = GermlineContext.from_variants(
+            [], completeness=Sparseness.SPARSE,
+            reference_name="GRCh38")
+        assert bool(ctx) is False
+
+    def test_iteration_yields_variants(self):
+        v = Variant(contig="1", start=100, ref="A", alt="T",
+                    genome="GRCh38")
+        ctx = GermlineContext.from_variants([v], reference_name="GRCh38")
+        assert list(ctx) == [v]
+
+    def test_frozen_dataclass_immutable(self):
+        """Frozen so callers can hash/share contexts safely. Mutation
+        attempts should fail loudly so the immutability contract
+        isn't accidentally relied on."""
+        ctx = GermlineContext.empty()
+        with pytest.raises(Exception):  # FrozenInstanceError or AttributeError
+            ctx.completeness = Sparseness.COMPLETE

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -28,7 +28,7 @@ from .errors import ReferenceMismatchError, SampleNotFoundError
 from .germline import (
     GenomeBuildMismatchError,
     GermlineContext,
-    Sparseness,
+    Completeness,
 )
 from .genotype import Genotype, Zygosity
 from .mutant_transcript import (
@@ -156,7 +156,7 @@ __all__ = [
 
     # Germline-aware annotation input contract (openvax/varcode#268)
     "GermlineContext",
-    "Sparseness",
+    "Completeness",
 
     # file loading
     "load_maf",

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -25,6 +25,11 @@ from .annotators import (
     use_annotator,
 )
 from .errors import ReferenceMismatchError, SampleNotFoundError
+from .germline import (
+    GenomeBuildMismatchError,
+    GermlineContext,
+    Sparseness,
+)
 from .genotype import Genotype, Zygosity
 from .mutant_transcript import (
     MutantTranscript,
@@ -147,6 +152,11 @@ __all__ = [
     # exceptions
     "ReferenceMismatchError",
     "SampleNotFoundError",
+    "GenomeBuildMismatchError",
+
+    # Germline-aware annotation input contract (openvax/varcode#268)
+    "GermlineContext",
+    "Sparseness",
 
     # file loading
     "load_maf",

--- a/varcode/germline.py
+++ b/varcode/germline.py
@@ -1,0 +1,487 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Germline-aware annotation: input contract (#268, #289).
+
+Effect prediction against the reference genome is the wrong baseline
+for somatic-variant analysis in a real patient. The correct baseline
+is the patient's germline. This module ships the *input contract* for
+that — the :class:`GermlineContext` object — without yet wiring it
+through annotator dispatch (which lands in subsequent slices of #268).
+
+A :class:`GermlineContext` is the patient's germline plus enough
+metadata for the effect classifier to handle it correctly:
+
+* the variants themselves (as a :class:`~varcode.VariantCollection`);
+* a :class:`Sparseness` flag declaring whether the call set is a real
+  germline (every position is implicitly ref/ref unless listed) or a
+  sparser shape (somatic caller's "normal" column, hotspots-only,
+  panel of normals) where absence does not imply ref/ref;
+* the reference build, so a mismatch with the somatic VCF surfaces as
+  a hard error before any nonsense annotation gets emitted.
+
+The four canonical input shapes from #268 each have a constructor:
+
+============================== ===========================
+:meth:`GermlineContext.from_germline_vcf`         Route 1
+:meth:`GermlineContext.from_multi_sample_vcf`     Route 2
+:meth:`GermlineContext.from_variants`             Direct (tests, custom pipelines)
+:meth:`GermlineContext.empty`                     Route 3 explicit fallback
+============================== ===========================
+
+Route 5 (``INFO=GERMLINE`` flags on a single VCF) is deferred — it's a
+small adapter that lives in the loader once it has a clear consumer.
+
+This module *only* ships the input contract and validation. Effect-side
+work (window-based lookup, transcript construction with germline
+applied, phase enumeration → multi-outcome packaging, LOH detection,
+splice signal recomputation) lands in subsequent slices.
+"""
+from __future__ import annotations
+
+import bisect
+import enum
+import warnings
+from dataclasses import dataclass, field
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+)
+
+if TYPE_CHECKING:
+    from .variant_collection import VariantCollection
+
+
+class Sparseness(enum.Enum):
+    """Completeness of a :class:`GermlineContext`'s call set.
+
+    Determines how absence-of-a-call is interpreted at a given
+    genomic position:
+
+    * :attr:`COMPLETE` — full germline call set (e.g. DeepVariant /
+      HaplotypeCaller / Strelka2 germline output on the normal BAM).
+      Absence implies ref/ref. This is what users usually mean by
+      "the germline VCF" and the only shape that supports correct
+      possibility-set reasoning out of the box.
+    * :attr:`SPARSE` — calls only at positions the somatic caller
+      examined (e.g. the ``NORMAL`` column of a Mutect2 VCF). Absence
+      does *not* imply ref/ref; the position simply wasn't queried.
+      Effect prediction emits unknown-germline outcomes for somatic
+      variants in a window with sparse coverage.
+    * :attr:`HOTSPOTS_ONLY` — calls only at recurrently-mutated
+      positions (panel-of-normals filters, ClinVar pathogenic lists).
+      Absence definitely does not imply ref/ref. Strictly weaker
+      evidence than SPARSE.
+    * :attr:`EMPTY` — no germline data; equivalent to falling back to
+      reference-relative annotation, but explicit so users opt into it
+      rather than getting it by accident from a missing kwarg.
+    """
+    COMPLETE = "complete"
+    SPARSE = "sparse"
+    HOTSPOTS_ONLY = "hotspots_only"
+    EMPTY = "empty"
+
+
+class GenomeBuildMismatchError(ValueError):
+    """Raised when a germline VCF and a somatic VCF were called against
+    different reference genome builds (e.g. GRCh37 vs GRCh38). Effect
+    coordinates from the two VCFs cannot be meaningfully composed.
+
+    Subclasses :class:`ValueError` so callers that already catch
+    ``ValueError`` for ``ReferenceMismatchError`` continue to work.
+    Set ``validate_reference=False`` on the call site if the user
+    has explicitly lifted over one VCF into the other build and
+    knows what they're doing.
+    """
+
+    def __init__(self, somatic_reference, germline_reference):
+        self.somatic_reference = somatic_reference
+        self.germline_reference = germline_reference
+        super().__init__(
+            "Genome build mismatch: somatic VCF uses %r, germline "
+            "context uses %r. Effect coordinates from the two cannot "
+            "be composed without lift-over. If you've already lifted "
+            "over one VCF into the other build, pass "
+            "validate_reference=False to skip this check." % (
+                somatic_reference, germline_reference))
+
+
+@dataclass(frozen=True)
+class GermlineContext:
+    """The patient's germline, packaged with completeness metadata
+    and reference-build info for cross-VCF validation.
+
+    Construct via the ``from_*`` classmethods rather than instantiating
+    directly; the constructors apply the input-shape-specific
+    validation each route needs.
+
+    Attributes
+    ----------
+    variants
+        The germline variants as a :class:`~varcode.VariantCollection`.
+        Empty for :meth:`empty` contexts.
+    completeness
+        How to interpret absence-of-a-call (see :class:`Sparseness`).
+    reference_name
+        The genome reference these variants were called against —
+        ``"GRCh37"``, ``"GRCh38"``, ``"hg19"``, etc. ``None`` when the
+        context is empty or the reference is unknown. Used by
+        :meth:`validate_against` to fail fast on cross-VCF build
+        mismatches.
+    metadata
+        Open-ended dict for caller-supplied annotations (source
+        caller name, sample identifier, normalization tool, etc.).
+        Not interpreted by varcode; rides along for downstream
+        consumers and serialization.
+
+    Examples
+    --------
+    Route 1 — full germline call set::
+
+        ctx = GermlineContext.from_germline_vcf("normal.vcf")
+
+    Route 2 — multi-sample VCF, extract a column. The user must
+    declare completeness explicitly because absence-from-a-multi-
+    sample column rarely means ref/ref::
+
+        ctx = GermlineContext.from_multi_sample_vcf(
+            "merged.vcf", sample="NORMAL", completeness=Sparseness.SPARSE)
+
+    Direct construction (tests, custom pipelines)::
+
+        ctx = GermlineContext.from_variants(
+            germline_variants, completeness=Sparseness.COMPLETE,
+            reference_name="GRCh38")
+
+    Explicit empty context — opt-in to reference-relative fallback::
+
+        ctx = GermlineContext.empty()
+    """
+
+    variants: "VariantCollection"
+    completeness: Sparseness = Sparseness.COMPLETE
+    reference_name: Optional[str] = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    # --- Constructors -------------------------------------------------------
+
+    @classmethod
+    def from_germline_vcf(
+            cls,
+            path: str,
+            *,
+            completeness: Sparseness = Sparseness.COMPLETE,
+            metadata: Optional[Mapping[str, Any]] = None,
+            **load_vcf_kwargs) -> "GermlineContext":
+        """Load a full germline VCF into a context.
+
+        ``load_vcf_kwargs`` are passed through to
+        :func:`varcode.load_vcf` — for example ``genome=`` or
+        ``only_passing=False``. The returned context defaults to
+        ``Sparseness.COMPLETE``; pass ``completeness=`` only if the
+        VCF is something other than a real germline call set.
+        """
+        # Lazy import to avoid pulling vcf.py into the import graph
+        # for callers who don't need it.
+        from .vcf import load_vcf
+        vc = load_vcf(path, **load_vcf_kwargs)
+        if len(vc) == 0:
+            warnings.warn(
+                "Loaded germline VCF %r contains zero variants. This "
+                "is almost always a wrong-file error; effect "
+                "prediction will silently fall through to "
+                "reference-relative on every somatic variant." % path)
+        return cls(
+            variants=vc,
+            completeness=completeness,
+            reference_name=cls._reference_name_of(vc),
+            metadata=dict(metadata or {}),
+        )
+
+    @classmethod
+    def from_multi_sample_vcf(
+            cls,
+            path: str,
+            sample: str,
+            *,
+            completeness: Sparseness,
+            metadata: Optional[Mapping[str, Any]] = None,
+            **load_vcf_kwargs) -> "GermlineContext":
+        """Load a multi-sample VCF and extract one sample's calls as
+        the germline.
+
+        ``completeness`` is required (no default) — multi-sample VCFs
+        from somatic callers (Mutect2's ``NORMAL`` column, e.g.) are
+        almost always sparse, but pure-germline multi-sample VCFs
+        (1000G, gnomAD batch genotyping) are complete. Forcing the
+        caller to declare prevents subtle correctness bugs from
+        treating a sparse column as if absence implied ref/ref.
+
+        The sample is filtered post-load. If you need per-sample
+        zygosity information, pass ``include_info=True`` (the default)
+        and consult ``vc.metadata[variant]["sample_info"][sample]``
+        downstream.
+        """
+        from .vcf import load_vcf
+        vc = load_vcf(path, **load_vcf_kwargs)
+        if sample not in cls._samples_of(vc):
+            from .errors import SampleNotFoundError
+            raise SampleNotFoundError(
+                "Sample %r not present in %s. Available samples: %s" % (
+                    sample, path, sorted(cls._samples_of(vc))))
+        # Filter to variants where the named sample has a non-ref call.
+        # The base VariantCollection isn't intrinsically sample-aware;
+        # this is a conservative subset that the caller can refine.
+        filtered = cls._variants_called_in_sample(vc, sample)
+        meta = dict(metadata or {})
+        meta.setdefault("source_path", path)
+        meta.setdefault("sample", sample)
+        return cls(
+            variants=filtered,
+            completeness=completeness,
+            reference_name=cls._reference_name_of(vc),
+            metadata=meta,
+        )
+
+    @classmethod
+    def from_variants(
+            cls,
+            variants,
+            *,
+            completeness: Sparseness = Sparseness.COMPLETE,
+            reference_name: Optional[str] = None,
+            metadata: Optional[Mapping[str, Any]] = None) -> "GermlineContext":
+        """Construct from an already-built :class:`VariantCollection`
+        or any iterable of :class:`Variant` objects.
+
+        Useful for tests, hand-built pipelines, and downstream tools
+        that already have variants in memory and don't need to re-parse
+        a VCF. ``reference_name`` should be passed explicitly when not
+        carried by the variants themselves; otherwise cross-VCF
+        validation will be a no-op.
+        """
+        from .variant_collection import VariantCollection
+        if isinstance(variants, VariantCollection):
+            vc = variants
+        else:
+            vc = VariantCollection(list(variants))
+        if reference_name is None:
+            reference_name = cls._reference_name_of(vc)
+        return cls(
+            variants=vc,
+            completeness=completeness,
+            reference_name=reference_name,
+            metadata=dict(metadata or {}),
+        )
+
+    @classmethod
+    def empty(cls) -> "GermlineContext":
+        """Explicit no-germline context. Use this in pipelines where
+        ``germline=`` is structurally required but the caller has no
+        germline data — it documents intent better than passing
+        ``None``, and downstream code can rely on the kwarg always
+        being a :class:`GermlineContext`.
+
+        Effect prediction with an empty context falls through to
+        reference-relative annotation (no patient transcript
+        construction), with no warnings — the caller has explicitly
+        opted in to the fallback.
+        """
+        from .variant_collection import VariantCollection
+        return cls(
+            variants=VariantCollection([]),
+            completeness=Sparseness.EMPTY,
+            reference_name=None,
+            metadata={},
+        )
+
+    # --- Public API ---------------------------------------------------------
+
+    def __bool__(self) -> bool:
+        """Truthy when there's something to apply. ``EMPTY`` contexts
+        are falsy so ``if germline_context:`` reads idiomatically."""
+        return self.completeness is not Sparseness.EMPTY and len(self.variants) > 0
+
+    def __len__(self) -> int:
+        return len(self.variants)
+
+    def __iter__(self):
+        return iter(self.variants)
+
+    def validate_against(
+            self,
+            somatic,
+            *,
+            validate_reference: bool = True) -> None:
+        """Cross-validate this context with a somatic
+        :class:`VariantCollection`. Hard error on reference-build
+        mismatch unless ``validate_reference=False``; warn on
+        suspicious shapes (empty germline, sparse coverage with no
+        overlap with somatic, etc.).
+
+        Called automatically by :meth:`Variant.effects` /
+        :meth:`VariantCollection.effects` when a context is supplied;
+        callers running validation manually can do so up front to fail
+        fast before annotation.
+        """
+        if not isinstance(self, GermlineContext):
+            raise TypeError(
+                "validate_against expects self to be a GermlineContext")
+        somatic_ref = self._reference_name_of(somatic)
+        if validate_reference and self.reference_name and somatic_ref:
+            if self.reference_name != somatic_ref:
+                raise GenomeBuildMismatchError(
+                    somatic_reference=somatic_ref,
+                    germline_reference=self.reference_name)
+        if (self.completeness is not Sparseness.EMPTY
+                and len(self.variants) == 0):
+            warnings.warn(
+                "GermlineContext is non-empty by completeness flag (%s) "
+                "but holds zero variants — likely a wrong-file or "
+                "filter-too-aggressive error." % self.completeness.value)
+
+    def variants_in_window(
+            self,
+            contig: str,
+            start: int,
+            end: int) -> Tuple:
+        """Germline variants overlapping ``[start, end]`` on
+        ``contig`` (inclusive on both ends).
+
+        Used by the window-based lookup machinery (slice 2 of #268).
+        Lazy interval index is built on first call and cached on the
+        instance — subsequent calls are O(log N) per contig.
+
+        Returns a tuple (immutable) so callers can safely cache the
+        result without worrying about the underlying index mutating.
+        """
+        index = self._index()
+        starts, variants = index.get(contig, ((), ()))
+        if not starts:
+            return ()
+        # Variants are indexed by start. Find candidates whose
+        # start <= end, then filter by their actual end span. Most
+        # germline variants are SNVs / short indels so the candidate
+        # window is small.
+        cutoff = bisect.bisect_right(starts, end)
+        result = []
+        for i in range(cutoff):
+            v = variants[i]
+            v_end = getattr(v, "end", None) or v.start
+            if v_end >= start:
+                result.append(v)
+        return tuple(result)
+
+    # --- Internals ----------------------------------------------------------
+
+    def _index(self) -> Mapping[str, Tuple[List[int], List]]:
+        """Build (or return cached) a per-contig sorted index of
+        germline variants by start position.
+
+        Bisect-based lookup is plenty for typical germline sizes (a
+        few million variants); an interval tree would be faster only
+        for very wide windows, which we don't use.
+
+        Cached on the instance via ``object.__setattr__`` because the
+        dataclass is frozen.
+        """
+        cached = getattr(self, "_index_cache", None)
+        if cached is not None:
+            return cached
+        by_contig: dict = {}
+        for v in self.variants:
+            by_contig.setdefault(v.contig, []).append(v)
+        sorted_index = {
+            contig: ([v.start for v in sorted(vs, key=lambda x: x.start)],
+                     sorted(vs, key=lambda x: x.start))
+            for contig, vs in by_contig.items()
+        }
+        object.__setattr__(self, "_index_cache", sorted_index)
+        return sorted_index
+
+    @staticmethod
+    def _reference_name_of(vc) -> Optional[str]:
+        """Best-effort: pull the reference name off a
+        VariantCollection. Different load paths populate this
+        differently; we try a few attribute names and bail to None
+        if nothing matches."""
+        for attr in ("reference_name", "genome_reference_name"):
+            value = getattr(vc, attr, None)
+            if value:
+                return value
+        # VariantCollection.reference_names() returns a set; if all
+        # variants agree on one reference, use that.
+        try:
+            names = vc.reference_names()
+        except Exception:
+            return None
+        if len(names) == 1:
+            return next(iter(names))
+        return None
+
+    @staticmethod
+    def _samples_of(vc) -> Iterable[str]:
+        """Sample names declared on a VariantCollection — used by the
+        multi-sample-VCF constructor to validate the requested
+        sample exists before extracting it."""
+        # VariantCollection.metadata is a {variant: {...}} dict;
+        # sample names come from sample_info subdicts. Using a set
+        # keeps the lookup O(unique samples) rather than O(variants).
+        names: set = set()
+        meta = getattr(vc, "metadata", None)
+        if not meta:
+            return names
+        for per_variant in meta.values():
+            sample_info = per_variant.get("sample_info") if isinstance(
+                per_variant, Mapping) else None
+            if sample_info:
+                names.update(sample_info.keys())
+        return names
+
+    @staticmethod
+    def _variants_called_in_sample(vc, sample):
+        """Subset ``vc`` to variants where ``sample`` has a non-ref
+        genotype.
+
+        For slice 1 we keep this conservative: a variant is "called
+        in the sample" if the GT field is present and not all-ref
+        (``./.`` / ``0/0`` / ``0|0`` are ref-or-missing). Real
+        sample-aware extraction (handling ``.|0`` mixed phase,
+        somatic-vs-germline GT semantics, etc.) lives in slice 8 of
+        the umbrella — this is the minimal sufficient implementation
+        to ship the input contract.
+        """
+        from .variant_collection import VariantCollection
+        keep = []
+        meta = getattr(vc, "metadata", {})
+        # The collection's source_to_metadata_dict shape varies; pull
+        # per-variant metadata by lookup so we don't depend on a
+        # particular VariantCollection internal layout.
+        for v in vc:
+            per_variant = meta.get(v) if isinstance(meta, Mapping) else None
+            sample_info = (
+                per_variant.get("sample_info") if isinstance(
+                    per_variant, Mapping) else None)
+            if not sample_info:
+                continue
+            cell = sample_info.get(sample)
+            if not cell:
+                continue
+            gt = cell.get("GT") if isinstance(cell, Mapping) else None
+            if gt and gt not in ("./.", ".|.", "0/0", "0|0", "."):
+                keep.append(v)
+        return VariantCollection(keep)

--- a/varcode/germline.py
+++ b/varcode/germline.py
@@ -22,7 +22,7 @@ A :class:`GermlineContext` is the patient's germline plus enough
 metadata for the effect classifier to handle it correctly:
 
 * the variants themselves (as a :class:`~varcode.VariantCollection`);
-* a :class:`Sparseness` flag declaring whether the call set is a real
+* a :class:`Completeness` flag declaring whether the call set is a real
   germline (every position is implicitly ref/ref unless listed) or a
   sparser shape (somatic caller's "normal" column, hotspots-only,
   panel of normals) where absence does not imply ref/ref;
@@ -66,29 +66,88 @@ if TYPE_CHECKING:
     from .variant_collection import VariantCollection
 
 
-class Sparseness(enum.Enum):
-    """Completeness of a :class:`GermlineContext`'s call set.
+class Completeness(enum.Enum):
+    """How exhaustive the germline call set is — the load-bearing
+    flag that pins what *absence* of a call at a position means.
 
-    Determines how absence-of-a-call is interpreted at a given
-    genomic position:
+    The same data structure ("a list of germline variants") can come
+    from very different pipelines, and downstream effect prediction
+    cannot make the right call without knowing which:
 
-    * :attr:`COMPLETE` — full germline call set (e.g. DeepVariant /
-      HaplotypeCaller / Strelka2 germline output on the normal BAM).
-      Absence implies ref/ref. This is what users usually mean by
-      "the germline VCF" and the only shape that supports correct
-      possibility-set reasoning out of the box.
-    * :attr:`SPARSE` — calls only at positions the somatic caller
-      examined (e.g. the ``NORMAL`` column of a Mutect2 VCF). Absence
-      does *not* imply ref/ref; the position simply wasn't queried.
-      Effect prediction emits unknown-germline outcomes for somatic
-      variants in a window with sparse coverage.
-    * :attr:`HOTSPOTS_ONLY` — calls only at recurrently-mutated
-      positions (panel-of-normals filters, ClinVar pathogenic lists).
-      Absence definitely does not imply ref/ref. Strictly weaker
-      evidence than SPARSE.
-    * :attr:`EMPTY` — no germline data; equivalent to falling back to
-      reference-relative annotation, but explicit so users opt into it
-      rather than getting it by accident from a missing kwarg.
+    * If a position is **absent** from a real germline VCF emitted
+      by a germline caller that examined the entire normal BAM, the
+      patient is ref/ref there. Effect prediction proceeds
+      reference-relative at that codon.
+    * If a position is **absent** from the ``NORMAL`` column of a
+      somatic-caller VCF, it likely means the somatic caller didn't
+      emit a row — not that the position is ref/ref. The patient's
+      germline state at that codon is unknown. The honest output is
+      a possibility set including "unknown germline."
+    * If a position is **absent** from a panel-of-normals filter
+      list, it definitely doesn't imply ref/ref — the file only
+      lists curated hotspots.
+
+    Mis-treating "absent" as "ref/ref" silently produces wrong
+    germline-aware effects on somatic variants in long stretches of
+    the genome the somatic caller never touched. The flag exists so
+    that mistake fails loud (or at least produces an honest
+    possibility set) instead of silently corrupting clinical
+    annotation.
+
+    Values
+    ------
+
+    +-------------------+-----------------------------------+--------------------------+
+    | Value             | Typical pipeline of origin        | Absence at a position    |
+    +===================+===================================+==========================+
+    | :attr:`COMPLETE`  | Germline caller (DeepVariant,     | ⇒ ref/ref                |
+    |                   | HaplotypeCaller, Strelka2         |                          |
+    |                   | germline) on the normal BAM       |                          |
+    +-------------------+-----------------------------------+--------------------------+
+    | :attr:`SPARSE`    | ``NORMAL`` column of a somatic    | ⇒ unknown (probably      |
+    |                   | tumor-vs-normal VCF (Mutect2,     |   ref/ref but not        |
+    |                   | Strelka2 somatic, VarScan2        |   queried). Honest output|
+    |                   | somatic)                          |   is a possibility set.  |
+    +-------------------+-----------------------------------+--------------------------+
+    | :attr:`HOTSPOTS_  | Panel-of-normals filter list,     | ⇒ definitely unknown.    |
+    | ONLY`             | ClinVar pathogenic list, single-  |   Strictly weaker        |
+    |                   | hotspot allowlists                |   evidence than SPARSE.  |
+    +-------------------+-----------------------------------+--------------------------+
+    | :attr:`EMPTY`     | "I have no germline data" —       | n/a (no germline-aware   |
+    |                   | explicit fallback, used so users  | logic runs; equivalent to|
+    |                   | opt into reference-relative       | not passing germline= at |
+    |                   | annotation rather than getting it | all)                     |
+    |                   | by accident from a missing kwarg  |                          |
+    +-------------------+-----------------------------------+--------------------------+
+
+    What downstream slices do with this
+    -----------------------------------
+
+    Slice 3 of #268 wires ``germline=`` through annotator dispatch.
+    When a somatic variant lands in a transcript window that has no
+    germline calls, the annotator reads this flag to decide between:
+
+    * ``COMPLETE`` → patient is ref/ref in this window; emit a
+      single reference-relative effect.
+    * ``SPARSE`` / ``HOTSPOTS_ONLY`` → patient's germline is
+      unknown in this window; emit a possibility set including the
+      reference-relative effect plus "germline-unknown" outcomes
+      so the user sees the uncertainty.
+    * ``EMPTY`` → no germline-aware logic; reference-relative.
+
+    Constructors and defaults
+    -------------------------
+
+    :meth:`GermlineContext.from_germline_vcf` defaults to
+    ``COMPLETE`` because that's almost always what
+    a real germline VCF is.
+
+    :meth:`GermlineContext.from_multi_sample_vcf` requires the
+    caller to declare completeness explicitly (no default) — a
+    multi-sample VCF could be either, and silently defaulting
+    either direction is a correctness bug waiting to happen.
+
+    :meth:`GermlineContext.empty` always sets ``EMPTY``.
     """
     COMPLETE = "complete"
     SPARSE = "sparse"
@@ -135,7 +194,7 @@ class GermlineContext:
         The germline variants as a :class:`~varcode.VariantCollection`.
         Empty for :meth:`empty` contexts.
     completeness
-        How to interpret absence-of-a-call (see :class:`Sparseness`).
+        How to interpret absence-of-a-call (see :class:`Completeness`).
     reference_name
         The genome reference these variants were called against —
         ``"GRCh37"``, ``"GRCh38"``, ``"hg19"``, etc. ``None`` when the
@@ -159,12 +218,12 @@ class GermlineContext:
     sample column rarely means ref/ref::
 
         ctx = GermlineContext.from_multi_sample_vcf(
-            "merged.vcf", sample="NORMAL", completeness=Sparseness.SPARSE)
+            "merged.vcf", sample="NORMAL", completeness=Completeness.SPARSE)
 
     Direct construction (tests, custom pipelines)::
 
         ctx = GermlineContext.from_variants(
-            germline_variants, completeness=Sparseness.COMPLETE,
+            germline_variants, completeness=Completeness.COMPLETE,
             reference_name="GRCh38")
 
     Explicit empty context — opt-in to reference-relative fallback::
@@ -173,7 +232,7 @@ class GermlineContext:
     """
 
     variants: "VariantCollection"
-    completeness: Sparseness = Sparseness.COMPLETE
+    completeness: Completeness = Completeness.COMPLETE
     reference_name: Optional[str] = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
@@ -184,7 +243,7 @@ class GermlineContext:
             cls,
             path: str,
             *,
-            completeness: Sparseness = Sparseness.COMPLETE,
+            completeness: Completeness = Completeness.COMPLETE,
             metadata: Optional[Mapping[str, Any]] = None,
             **load_vcf_kwargs) -> "GermlineContext":
         """Load a full germline VCF into a context.
@@ -192,7 +251,7 @@ class GermlineContext:
         ``load_vcf_kwargs`` are passed through to
         :func:`varcode.load_vcf` — for example ``genome=`` or
         ``only_passing=False``. The returned context defaults to
-        ``Sparseness.COMPLETE``; pass ``completeness=`` only if the
+        ``Completeness.COMPLETE``; pass ``completeness=`` only if the
         VCF is something other than a real germline call set.
         """
         # Lazy import to avoid pulling vcf.py into the import graph
@@ -218,7 +277,7 @@ class GermlineContext:
             path: str,
             sample: str,
             *,
-            completeness: Sparseness,
+            completeness: Completeness,
             metadata: Optional[Mapping[str, Any]] = None,
             **load_vcf_kwargs) -> "GermlineContext":
         """Load a multi-sample VCF and extract one sample's calls as
@@ -262,7 +321,7 @@ class GermlineContext:
             cls,
             variants,
             *,
-            completeness: Sparseness = Sparseness.COMPLETE,
+            completeness: Completeness = Completeness.COMPLETE,
             reference_name: Optional[str] = None,
             metadata: Optional[Mapping[str, Any]] = None) -> "GermlineContext":
         """Construct from an already-built :class:`VariantCollection`
@@ -304,7 +363,7 @@ class GermlineContext:
         from .variant_collection import VariantCollection
         return cls(
             variants=VariantCollection([]),
-            completeness=Sparseness.EMPTY,
+            completeness=Completeness.EMPTY,
             reference_name=None,
             metadata={},
         )
@@ -314,7 +373,7 @@ class GermlineContext:
     def __bool__(self) -> bool:
         """Truthy when there's something to apply. ``EMPTY`` contexts
         are falsy so ``if germline_context:`` reads idiomatically."""
-        return self.completeness is not Sparseness.EMPTY and len(self.variants) > 0
+        return self.completeness is not Completeness.EMPTY and len(self.variants) > 0
 
     def __len__(self) -> int:
         return len(self.variants)
@@ -347,7 +406,7 @@ class GermlineContext:
                 raise GenomeBuildMismatchError(
                     somatic_reference=somatic_ref,
                     germline_reference=self.reference_name)
-        if (self.completeness is not Sparseness.EMPTY
+        if (self.completeness is not Completeness.EMPTY
                 and len(self.variants) == 0):
             warnings.warn(
                 "GermlineContext is non-empty by completeness flag (%s) "


### PR DESCRIPTION
## Summary

Slice 1 of the germline-aware annotation umbrella (#268). Ships the input contract — the `GermlineContext` object — without yet wiring it through annotator dispatch (subsequent slices).

This is the first slice under the design pivot proposed in [#268's design-update comment](https://github.com/openvax/varcode/issues/268#issuecomment-4407569408): treat germline as a transcript modifier consumed by effect prediction, not a wrapper attached to existing effects. This PR is purely about constructing and validating that input — no effect-side changes, so it's reversible if the design pivot itself draws an objection.

## What lands

- **`GermlineContext`** (frozen dataclass) with four constructors mirroring the input routes from #268:
  - `from_germline_vcf` — Route 1 (full call set, default COMPLETE)
  - `from_multi_sample_vcf` — Route 2 (extract a sample column; `completeness=` required, no default — multi-sample VCFs from somatic callers are sparse and pure-germline ones are complete; forcing the caller to declare prevents a class of correctness bugs)
  - `from_variants` — direct construction for tests / custom pipelines
  - `empty` — Route 3 explicit fallback
- **`Sparseness`** enum (COMPLETE / SPARSE / HOTSPOTS_ONLY / EMPTY) declaring how absence-of-a-call should be interpreted at a position. Load-bearing for correctness once slice 2/3 land — a downstream caller deciding whether absence ⇒ ref/ref reads this.
- **`GenomeBuildMismatchError`** (subclasses ValueError, mirrors existing `ReferenceMismatchError`) raised by `validate_against` when a germline VCF and a somatic VCF were called against different genome builds. Opt-out via `validate_reference=False`.
- **`variants_in_window`** — lazy bisect-indexed lookup, used by slice 2's germline-application path. Pinning the boundary semantics (inclusive both ends, contig-scoped) now while it's free to change.
- Validation: hard error on cross-VCF build mismatch, warn on zero-variant loads and COMPLETE-flagged contexts that hold no variants.

## Out of scope (deferred to subsequent slices)

- `apply_germline_to_transcript` + window-based germline application (slice 2)
- `germline=` kwarg on `Variant.effects` / `VariantCollection.effects` + annotator dispatch (slice 3)
- Phase enumeration → MultiOutcomeEffect packaging (slice 4)
- LOH detection (slice 5)
- Splice signal recomputation (slice 6)
- Docs + edge-case corpus (slice 7)

## Test plan

- [x] `./test.sh` — 1080 passed, 2 skipped (gained 36 tests in `tests/test_germline_context.py`)
- [x] `./lint.sh` — clean
- [x] Smoke: every constructor returns a usable context; window lookup boundary cases (inclusive bounds, off-contig, multi-variant windows) pass; cross-VCF build mismatch raises; opt-out works; warnings fire on suspicious shapes (zero-variant load, COMPLETE-with-no-variants).