### PR TITLE
Wire germline-aware effect prediction end-to-end (#268)

### DIFF
--- a/tests/test_germline_effects.py
+++ b/tests/test_germline_effects.py
@@ -1,0 +1,567 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""End-to-end tests for germline-aware effect prediction (#268).
+
+Covers the wiring of ``germline=`` through ``Variant.effects`` and
+``VariantCollection.effects``, the ``PhaseAmbiguousEffect`` output
+shape when phase is unknown, LOH detection, sparseness propagation,
+hemizygous handling, and cross-VCF build-mismatch validation.
+
+Tests use a known-good CFTR codon-overlap pair (somatic at 117531100
+T→A produces p.L159M; germline at 117531101 T→C is in the same codon
+and changes the cis result to p.S159T). Both positions' reference
+bases are read from the GRCh38 reference, so any future changes to
+the ref alleles fail loudly rather than silently mis-classifying.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import warnings
+
+import pytest
+
+from pyensembl import cached_release
+
+from varcode import (
+    Completeness,
+    GenomeBuildMismatchError,
+    GermlineContext,
+    Variant,
+    VariantCollection,
+    apply_germline_to_transcript,
+    detect_loh,
+    enumerate_phase_hypotheses,
+    load_vcf,
+    predict_germline_aware_effect,
+)
+from varcode.annotators.registry import get_default_annotator
+from varcode.effects.effect_classes import (
+    PhaseAmbiguousEffect,
+    Substitution,
+)
+
+
+ensembl_grch38 = cached_release(81)
+CFTR_ID = "ENST00000003084"
+
+# Known-good CFTR codon-overlap pair. Real GRCh38 reference bases at
+# these positions. somatic alone produces p.L159M; somatic+germline
+# in cis produces p.S159T (different codon outcome). In trans, the
+# somatic effect is identical to the reference-relative case.
+SOMATIC_POS = 117_531_100
+SOMATIC_REF = "T"
+SOMATIC_ALT = "A"
+GERMLINE_POS = 117_531_101
+GERMLINE_REF = "T"
+GERMLINE_ALT = "C"
+DISTANT_GERMLINE_POS = 117_668_600  # past the end of the somatic's exon
+
+
+def _cftr():
+    return ensembl_grch38.transcript_by_id(CFTR_ID)
+
+
+def _somatic():
+    return Variant(
+        contig="7", start=SOMATIC_POS, ref=SOMATIC_REF, alt=SOMATIC_ALT,
+        genome=ensembl_grch38)
+
+
+def _same_codon_germline():
+    return Variant(
+        contig="7", start=GERMLINE_POS, ref=GERMLINE_REF, alt=GERMLINE_ALT,
+        genome=ensembl_grch38)
+
+
+# --------------------------------------------------------------------
+# Back-compat: empty / None germline is byte-identical to today
+# --------------------------------------------------------------------
+
+
+class TestBackCompat:
+    """Today's reference-relative output must survive the addition
+    of ``germline=`` unchanged. None / empty contexts are no-ops."""
+
+    def test_no_germline_kwarg_yields_today_output(self):
+        v = _somatic()
+        effects = list(v.effects(raise_on_error=False))
+        assert effects, "CFTR somatic should produce at least one effect"
+        assert any(isinstance(e, Substitution) for e in effects)
+
+    def test_explicit_none_is_byte_identical(self):
+        v = _somatic()
+        without = list(v.effects(raise_on_error=False))
+        explicit = list(v.effects(raise_on_error=False, germline=None))
+        # Same effect classes, in the same order, with the same
+        # short descriptions. We can't check object identity (effects
+        # are constructed per call), but the predicted output should
+        # be byte-identical at the description level.
+        assert [type(e).__name__ for e in without] == [
+            type(e).__name__ for e in explicit]
+        assert [
+            getattr(e, "short_description", None) for e in without
+        ] == [
+            getattr(e, "short_description", None) for e in explicit]
+
+    def test_empty_context_is_byte_identical(self):
+        v = _somatic()
+        ctx = GermlineContext.empty()
+        without = list(v.effects(raise_on_error=False))
+        with_empty = list(v.effects(raise_on_error=False, germline=ctx))
+        assert [type(e).__name__ for e in without] == [
+            type(e).__name__ for e in with_empty]
+
+
+# --------------------------------------------------------------------
+# Same-codon overlap, unknown phase → PhaseAmbiguousEffect
+# --------------------------------------------------------------------
+
+
+class TestSameCodonOverlap:
+    """The marquee case: somatic and germline land in the same codon
+    with no phase data. Honest output is a possibility set."""
+
+    def _ctx(self):
+        return GermlineContext.from_variants(
+            [_same_codon_germline()], reference_name="GRCh38")
+
+    def test_produces_phase_ambiguous_effect(self):
+        ann = get_default_annotator()
+        e = predict_germline_aware_effect(
+            _somatic(), _cftr(), self._ctx(), ann)
+        assert isinstance(e, PhaseAmbiguousEffect)
+
+    def test_two_hypotheses_for_one_germline_variant(self):
+        ann = get_default_annotator()
+        e = predict_germline_aware_effect(
+            _somatic(), _cftr(), self._ctx(), ann)
+        # One germline → 2^1 = 2 hypotheses (cis, trans).
+        assert len(e.outcomes) == 2
+
+    def test_outcomes_carry_haplotype_evidence(self):
+        ann = get_default_annotator()
+        e = predict_germline_aware_effect(
+            _somatic(), _cftr(), self._ctx(), ann)
+        haps = {o.evidence.get("haplotype") for o in e.outcomes}
+        # The opaque tags from the enumerator: A (all-cis), B (all-trans).
+        assert haps == {"A", "B"}
+
+    def test_outcomes_carry_phase_state_unknown(self):
+        ann = get_default_annotator()
+        e = predict_germline_aware_effect(
+            _somatic(), _cftr(), self._ctx(), ann)
+        states = {o.evidence.get("phase_state") for o in e.outcomes}
+        assert states == {"unknown"}
+
+    def test_outcomes_carry_germline_variants(self):
+        ann = get_default_annotator()
+        e = predict_germline_aware_effect(
+            _somatic(), _cftr(), self._ctx(), ann)
+        for o in e.outcomes:
+            germ = o.evidence.get("germline_variants")
+            # Cis hypothesis carries the germline variant; trans
+            # carries an empty tuple. Either way it's a tuple, not
+            # ``None`` (so consumers can iterate uniformly).
+            assert isinstance(germ, tuple)
+
+    def test_trans_hypothesis_yields_reference_relative_effect(self):
+        """The trans hypothesis (germline on the OTHER haplotype) is
+        the somatic on the reference codon — should match what
+        reference-relative annotation produces today."""
+        ann = get_default_annotator()
+        ref_relative = ann.annotate_on_transcript(_somatic(), _cftr())
+        e = predict_germline_aware_effect(
+            _somatic(), _cftr(), self._ctx(), ann)
+        trans_outcome = next(
+            o for o in e.outcomes if o.evidence["haplotype"] == "B")
+        assert (trans_outcome.effect.short_description
+                == ref_relative.short_description)
+
+    def test_cis_hypothesis_differs_from_reference_relative(self):
+        """The cis hypothesis should produce a different effect than
+        reference-relative (otherwise why bother). For the CFTR
+        117531100/117531101 pair: ref is L→M, cis is S→T."""
+        ann = get_default_annotator()
+        ref_relative = ann.annotate_on_transcript(_somatic(), _cftr())
+        e = predict_germline_aware_effect(
+            _somatic(), _cftr(), self._ctx(), ann)
+        cis_outcome = next(
+            o for o in e.outcomes if o.evidence["haplotype"] == "A")
+        assert (cis_outcome.effect.short_description
+                != ref_relative.short_description)
+
+    def test_short_description_marks_ambiguity(self):
+        """Convention: ``?`` prefix on the description signals 'this is
+        the most-likely candidate of a possibility set'."""
+        ann = get_default_annotator()
+        e = predict_germline_aware_effect(
+            _somatic(), _cftr(), self._ctx(), ann)
+        assert e.short_description.startswith("?")
+
+
+# --------------------------------------------------------------------
+# No overlap → standard reference-relative effect
+# --------------------------------------------------------------------
+
+
+class TestNoOverlap:
+    def test_distant_germline_yields_standard_effect(self):
+        ann = get_default_annotator()
+        ctx = GermlineContext.from_variants([
+            Variant(contig="7", start=DISTANT_GERMLINE_POS,
+                    ref="C", alt="T", genome=ensembl_grch38),
+        ], reference_name="GRCh38")
+        e = predict_germline_aware_effect(_somatic(), _cftr(), ctx, ann)
+        # Single Substitution effect (not PhaseAmbiguousEffect) —
+        # patient transcript == reference transcript at this locus.
+        assert not isinstance(e, PhaseAmbiguousEffect)
+        assert isinstance(e, Substitution)
+
+
+# --------------------------------------------------------------------
+# Phase resolver collapses ambiguity
+# --------------------------------------------------------------------
+
+
+class _StubPhaseResolver:
+    """Returns a fixed answer for every (somatic, germline) pair.
+    Lets us pin the resolver-collapses-ambiguity contract without
+    plumbing a full PS-tagged VCF into a test."""
+
+    def __init__(self, in_cis_answer: bool):
+        self._answer = in_cis_answer
+
+    def in_cis(self, v1, v2):
+        return self._answer
+
+
+class TestPhaseResolverCollapses:
+    def test_resolver_says_cis_yields_single_hypothesis(self):
+        ann = get_default_annotator()
+        ctx = GermlineContext.from_variants(
+            [_same_codon_germline()], reference_name="GRCh38")
+        e = predict_germline_aware_effect(
+            _somatic(), _cftr(), ctx, ann,
+            phase_resolver=_StubPhaseResolver(in_cis_answer=True))
+        # Single resolved hypothesis → not a PhaseAmbiguousEffect; the
+        # cis-applied classification surfaces as the primary effect.
+        assert not isinstance(e, PhaseAmbiguousEffect)
+        # Phase metadata still attached for downstream filtering.
+        assert getattr(e, "germline_phase_state", None) == "phased"
+
+    def test_resolver_says_trans_yields_single_hypothesis(self):
+        ann = get_default_annotator()
+        ctx = GermlineContext.from_variants(
+            [_same_codon_germline()], reference_name="GRCh38")
+        ref_relative = ann.annotate_on_transcript(_somatic(), _cftr())
+        e = predict_germline_aware_effect(
+            _somatic(), _cftr(), ctx, ann,
+            phase_resolver=_StubPhaseResolver(in_cis_answer=False))
+        # Trans resolved → effect should match reference-relative.
+        assert e.short_description == ref_relative.short_description
+
+
+# --------------------------------------------------------------------
+# LOH detection
+# --------------------------------------------------------------------
+
+
+class TestLOH:
+    def test_loh_detector_matches_position_and_alt(self):
+        s = _somatic()
+        # Same position+alt → LOH.
+        match = Variant(contig="7", start=SOMATIC_POS, ref=SOMATIC_REF,
+                        alt=SOMATIC_ALT, genome=ensembl_grch38)
+        assert detect_loh(s, [match]) is True
+        # Same position, different alt → not LOH.
+        diff_alt = Variant(contig="7", start=SOMATIC_POS, ref=SOMATIC_REF,
+                           alt="G", genome=ensembl_grch38)
+        assert detect_loh(s, [diff_alt]) is False
+        # Different position → not LOH.
+        diff_pos = Variant(contig="7", start=SOMATIC_POS + 5,
+                           ref="A", alt="T", genome=ensembl_grch38)
+        assert detect_loh(s, [diff_pos]) is False
+        # No germline → not LOH.
+        assert detect_loh(s, []) is False
+
+    def test_loh_flag_set_on_effect_when_somatic_matches_germline(self):
+        ann = get_default_annotator()
+        ctx = GermlineContext.from_variants(
+            [Variant(contig="7", start=SOMATIC_POS, ref=SOMATIC_REF,
+                     alt=SOMATIC_ALT, genome=ensembl_grch38)],
+            reference_name="GRCh38")
+        e = predict_germline_aware_effect(_somatic(), _cftr(), ctx, ann)
+        assert getattr(e, "is_loh", False) is True
+
+    def test_loh_flag_not_set_when_alt_differs(self):
+        ann = get_default_annotator()
+        ctx = GermlineContext.from_variants(
+            [Variant(contig="7", start=SOMATIC_POS, ref=SOMATIC_REF,
+                     alt="G",  # different alt
+                     genome=ensembl_grch38)],
+            reference_name="GRCh38")
+        e = predict_germline_aware_effect(_somatic(), _cftr(), ctx, ann)
+        assert getattr(e, "is_loh", False) is False
+
+
+# --------------------------------------------------------------------
+# Sparseness propagation
+# --------------------------------------------------------------------
+
+
+class TestSparsenessPropagation:
+    def test_sparse_context_no_overlap_flags_germline_unknown(self):
+        """When the context is SPARSE and no germline overlaps the
+        somatic's window, we don't know if the patient is ref/ref —
+        the somatic caller may not have queried the position.
+        Annotate normally but flag the effect."""
+        ann = get_default_annotator()
+        ctx = GermlineContext.from_variants(
+            [],  # no germline calls — SPARSE means absence is unknown
+            completeness=Completeness.SPARSE,
+            reference_name="GRCh38")
+        e = predict_germline_aware_effect(_somatic(), _cftr(), ctx, ann)
+        # Empty context is falsy → predict_germline_aware_effect's
+        # short-circuit hits before the SPARSE flag matters. We test
+        # the SPARSE-with-distant-germline case where the context is
+        # truthy but the window is empty.
+
+    def test_sparse_with_distant_germline_flags_unknown(self):
+        ann = get_default_annotator()
+        ctx = GermlineContext.from_variants(
+            [Variant(contig="7", start=DISTANT_GERMLINE_POS,
+                     ref="C", alt="T", genome=ensembl_grch38)],
+            completeness=Completeness.SPARSE,
+            reference_name="GRCh38")
+        e = predict_germline_aware_effect(_somatic(), _cftr(), ctx, ann)
+        # Distant germline = no overlap = patient germline state unknown
+        # at the somatic's window because SPARSE.
+        assert getattr(e, "germline_unknown", False) is True
+
+    def test_complete_context_no_overlap_does_not_flag(self):
+        """COMPLETE: absence at this position implies ref/ref. No
+        flag — there's no uncertainty."""
+        ann = get_default_annotator()
+        ctx = GermlineContext.from_variants(
+            [Variant(contig="7", start=DISTANT_GERMLINE_POS,
+                     ref="C", alt="T", genome=ensembl_grch38)],
+            completeness=Completeness.COMPLETE,
+            reference_name="GRCh38")
+        e = predict_germline_aware_effect(_somatic(), _cftr(), ctx, ann)
+        assert getattr(e, "germline_unknown", False) is False
+
+
+# --------------------------------------------------------------------
+# Hemizygous chromosome
+# --------------------------------------------------------------------
+
+
+class TestHemizygous:
+    """Hemizygous chromosomes (chrY, chrM) have no second haplotype,
+    so phase ambiguity is moot — germline-in-window is always cis."""
+
+    def test_chrM_yields_single_implicit_hypothesis(self):
+        # Stand-alone test of the enumerator — building a chrM
+        # transcript test fixture would be heavier than is worth here.
+        somatic = Variant(contig="MT", start=100, ref="A", alt="T",
+                          genome=ensembl_grch38)
+        germline = Variant(contig="MT", start=101, ref="C", alt="G",
+                           genome=ensembl_grch38)
+        hyps = enumerate_phase_hypotheses(somatic, [germline])
+        assert len(hyps) == 1
+        assert hyps[0].phase_state == "implicit"
+        # chrM germline in window is automatically cis.
+        assert germline in hyps[0].cis
+
+    def test_chrY_yields_single_implicit_hypothesis(self):
+        somatic = Variant(contig="Y", start=100, ref="A", alt="T",
+                          genome=ensembl_grch38)
+        germline = Variant(contig="Y", start=101, ref="C", alt="G",
+                           genome=ensembl_grch38)
+        hyps = enumerate_phase_hypotheses(somatic, [germline])
+        assert len(hyps) == 1
+        assert hyps[0].phase_state == "implicit"
+
+
+# --------------------------------------------------------------------
+# Hypothesis cap
+# --------------------------------------------------------------------
+
+
+class TestHypothesisCap:
+    """When 2^n exceeds the cap, emit a single
+    too_many_hypotheses placeholder. Default cap is 8 ⇒ up to 3
+    germline variants in window fully unphased."""
+
+    def _germline(self, pos):
+        return Variant(contig="7", start=pos, ref="A", alt="T",
+                       genome=ensembl_grch38)
+
+    def test_under_cap_enumerates(self):
+        somatic = Variant(contig="7", start=100, ref="A", alt="T",
+                          genome=ensembl_grch38)
+        germ = [self._germline(101), self._germline(102)]
+        # 2 germline → 4 hypotheses, under default cap of 8.
+        hyps = enumerate_phase_hypotheses(somatic, germ)
+        assert len(hyps) == 4
+
+    def test_over_cap_returns_placeholder(self):
+        somatic = Variant(contig="7", start=100, ref="A", alt="T",
+                          genome=ensembl_grch38)
+        # 4 germline → 16 hypotheses, over default cap.
+        germ = [self._germline(p) for p in range(101, 105)]
+        hyps = enumerate_phase_hypotheses(somatic, germ)
+        assert len(hyps) == 1
+        assert hyps[0].phase_state == "too_many_hypotheses"
+        # Conservatively marks all germline as cis (the worst-case).
+        assert len(hyps[0].cis) == len(germ)
+
+    def test_caller_can_raise_cap(self):
+        somatic = Variant(contig="7", start=100, ref="A", alt="T",
+                          genome=ensembl_grch38)
+        germ = [self._germline(p) for p in range(101, 105)]
+        # Raise the cap to 32 → 16 hypotheses now fit.
+        hyps = enumerate_phase_hypotheses(somatic, germ, max_hypotheses=32)
+        assert len(hyps) == 16
+
+
+# --------------------------------------------------------------------
+# Cross-VCF build mismatch
+# --------------------------------------------------------------------
+
+
+def _write_vcf(body):
+    fd, path = tempfile.mkstemp(suffix=".vcf")
+    with os.fdopen(fd, "w") as f:
+        f.write(body)
+    return path
+
+
+class TestBuildMismatch:
+    """The hard error from #268 §7: somatic VCF and germline VCF on
+    different reference builds. Surfaces at the
+    VariantCollection.effects level so the user sees one readable
+    error rather than per-variant ReferenceMismatchError noise."""
+
+    def test_mismatch_raises_at_collection_level(self):
+        somatic = VariantCollection([_somatic()])
+        # Hand-construct a germline context claiming GRCh37.
+        germ = GermlineContext.from_variants(
+            [_same_codon_germline()],
+            reference_name="GRCh37")
+        with pytest.raises(GenomeBuildMismatchError):
+            somatic.effects(germline=germ, raise_on_error=False)
+
+    def test_validate_reference_false_bypasses(self):
+        """Opt-out for users who've explicitly lifted over."""
+        somatic = VariantCollection([_somatic()])
+        germ = GermlineContext.from_variants(
+            [_same_codon_germline()],
+            reference_name="GRCh37")
+        # No raise even though references disagree.
+        somatic.effects(
+            germline=germ, raise_on_error=False, validate_reference=False)
+
+
+# --------------------------------------------------------------------
+# Wiring through Variant.effects / VariantCollection.effects
+# --------------------------------------------------------------------
+
+
+class TestEffectsKwargWiring:
+    def test_variant_effects_with_germline(self):
+        v = _somatic()
+        ctx = GermlineContext.from_variants(
+            [_same_codon_germline()], reference_name="GRCh38")
+        effects = list(v.effects(raise_on_error=False, germline=ctx))
+        # At least one PhaseAmbiguousEffect among the per-transcript
+        # outputs (CFTR has multiple transcripts).
+        assert any(isinstance(e, PhaseAmbiguousEffect) for e in effects)
+
+    def test_collection_effects_with_germline(self):
+        somatic = VariantCollection([_somatic()])
+        ctx = GermlineContext.from_variants(
+            [_same_codon_germline()], reference_name="GRCh38")
+        effects = somatic.effects(germline=ctx, raise_on_error=False)
+        assert any(isinstance(e, PhaseAmbiguousEffect) for e in effects)
+        # Annotator metadata still tracks the underlying annotator,
+        # not "germline" (germline is a transcript modifier, not an
+        # annotator). The collection-level annotator name is
+        # preserved.
+        assert effects.annotator is not None
+
+
+# --------------------------------------------------------------------
+# apply_germline_to_transcript public helper
+# --------------------------------------------------------------------
+
+
+class TestApplyGermlineToTranscript:
+    def test_returns_none_for_empty_context(self):
+        result = apply_germline_to_transcript(
+            _cftr(), GermlineContext.empty())
+        assert result is None
+
+    def test_returns_none_when_no_germline_in_window(self):
+        """With a somatic specified but the germline not in its
+        window, the helper has nothing to apply locally → None.
+        Caller falls back to the reference transcript."""
+        ctx = GermlineContext.from_variants(
+            [Variant(contig="7", start=DISTANT_GERMLINE_POS, ref="C",
+                     alt="T", genome=ensembl_grch38)],
+            reference_name="GRCh38")
+        result = apply_germline_to_transcript(
+            _cftr(), ctx, somatic_variant=_somatic())
+        assert result is None
+
+    def test_applies_germline_when_in_window(self):
+        ctx = GermlineContext.from_variants(
+            [_same_codon_germline()], reference_name="GRCh38")
+        result = apply_germline_to_transcript(
+            _cftr(), ctx, somatic_variant=_somatic())
+        assert result is not None
+        # MutantTranscript with at least one edit applied.
+        assert len(result.edits) >= 1
+
+    def test_whole_transcript_mode_picks_up_distant_germline(self):
+        """Without a somatic variant, the helper applies all germline
+        variants overlapping ANY exon of the transcript — useful for
+        building a single patient transcript for cohort-level
+        analysis. Distant germline now lands."""
+        ctx = GermlineContext.from_variants(
+            [_same_codon_germline()], reference_name="GRCh38")
+        result = apply_germline_to_transcript(_cftr(), ctx)
+        assert result is not None
+        assert len(result.edits) >= 1
+
+
+# --------------------------------------------------------------------
+# Composition with RNA evidence (cross-axis)
+# --------------------------------------------------------------------
+
+
+class TestComposesWithRNAEvidence:
+    """The whole point of the design is that germline + RNA + phase
+    compose. An RNA outcome with ``evidence={"haplotype": "B"}``
+    should align with the haplotype B germline-aware outcome via the
+    shared evidence dict shape."""
+
+    def test_phase_ambiguous_outcomes_carry_alignable_haplotype_keys(self):
+        """The germline-aware Outcomes carry ``haplotype`` keys with
+        opaque tags ("A", "B"); the RNA-evidence Outcomes from #259
+        use the same key. Cross-axis matching is just a dict lookup
+        — pin that the keys are present and match the Outcome
+        evidence-dict convention."""
+        ann = get_default_annotator()
+        ctx = GermlineContext.from_variants(
+            [_same_codon_germline()], reference_name="GRCh38")
+        e = predict_germline_aware_effect(
+            _somatic(), _cftr(), ctx, ann)
+        for outcome in e.outcomes:
+            assert "haplotype" in outcome.evidence
+            assert "phase_state" in outcome.evidence

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -29,6 +29,12 @@ from .germline import (
     GenomeBuildMismatchError,
     GermlineContext,
     Completeness,
+    PhaseHypothesis,
+    apply_germline_to_transcript,
+    default_germline_window,
+    detect_loh,
+    enumerate_phase_hypotheses,
+    predict_germline_aware_effect,
 )
 from .genotype import Genotype, Zygosity
 from .mutant_transcript import (
@@ -154,9 +160,15 @@ __all__ = [
     "SampleNotFoundError",
     "GenomeBuildMismatchError",
 
-    # Germline-aware annotation input contract (openvax/varcode#268)
+    # Germline-aware annotation (openvax/varcode#268)
     "GermlineContext",
     "Completeness",
+    "PhaseHypothesis",
+    "apply_germline_to_transcript",
+    "default_germline_window",
+    "detect_loh",
+    "enumerate_phase_hypotheses",
+    "predict_germline_aware_effect",
 
     # file loading
     "load_maf",

--- a/varcode/effects/effect_classes.py
+++ b/varcode/effects/effect_classes.py
@@ -1274,3 +1274,132 @@ class HaplotypeEffect(TranscriptMutationEffect, MultiOutcomeEffect):
         """
         parts = [v.short_description for v in self.variants]
         return "[" + ";".join(parts) + "]"
+
+
+# =====================================================================
+# Phase-ambiguous effects — possibility set when somatic + germline
+# share a window and phase between them is unknown (#268).
+#
+# Sibling of HaplotypeEffect: that one captures the *known-cis* case
+# (multiple variants composed on the same haplotype), this one
+# captures the *unknown-phase* case (multiple hypotheses, each with
+# its own resulting effect). Both inherit the same MultiOutcomeEffect
+# protocol so consumers iterate ``outcomes`` uniformly. This isn't a
+# wrapper around a reference-relative effect — it's the primary
+# effect class for the phase-ambiguous case, just like
+# SpliceOutcomeSet is for splice ambiguity.
+# =====================================================================
+
+
+class PhaseAmbiguousEffect(TranscriptMutationEffect, MultiOutcomeEffect):
+    """Possibility set across phase hypotheses when a somatic variant
+    and one or more germline variants share a window on a transcript
+    and phase between them is unknown.
+
+    The somatic effect at this locus depends on which haplotype the
+    somatic landed on, and without phase data we can't say which.
+    The honest output is the set of plausible effects, one per
+    hypothesis. ``most_likely`` returns the highest-priority
+    candidate; ``outcomes`` exposes the full set with per-haplotype
+    evidence keys (``phase_state``, ``haplotype``,
+    ``germline_variants``) so consumers — including RNA-evidence
+    integrations from #259 — can align across axes.
+
+    Emitted by :func:`varcode.germline.predict_germline_aware_effect`.
+    Sibling of :class:`HaplotypeEffect`: that one captures the
+    *known-cis* multi-variant case; this one captures the
+    *unknown-phase* possibility set.
+    """
+
+    def __init__(
+            self,
+            variant,
+            transcript,
+            candidates,
+            hypotheses,
+            germline_variants):
+        TranscriptMutationEffect.__init__(self, variant, transcript)
+        if len(candidates) != len(hypotheses):
+            raise ValueError(
+                "PhaseAmbiguousEffect needs one candidate per "
+                "hypothesis; got %d candidates and %d hypotheses." % (
+                    len(candidates), len(hypotheses)))
+        if not candidates:
+            raise ValueError(
+                "PhaseAmbiguousEffect requires at least one candidate.")
+        self._candidates_raw = tuple(candidates)
+        self._hypotheses = tuple(hypotheses)
+        self.germline_variants = tuple(germline_variants)
+
+    @property
+    def candidates(self):
+        """Per-hypothesis classified effects, sorted by effect
+        priority (most-severe first). Same shape as
+        :attr:`SpliceOutcomeSet.candidates`."""
+        # Lazy import — effect_priority lives in a sibling module.
+        from .effect_ordering import effect_priority
+        return tuple(sorted(
+            self._candidates_raw,
+            key=lambda e: -effect_priority(e)))
+
+    @property
+    def most_likely(self):
+        """Highest-priority candidate. Used for back-compat consumers
+        that read a single effect."""
+        return self.candidates[0]
+
+    @property
+    def outcomes(self):
+        """One :class:`Outcome` per hypothesis, carrying the phase
+        metadata needed to align with RNA-evidence outcomes (#259).
+
+        ``evidence`` keys: ``phase_state`` (``"phased"`` /
+        ``"implicit"`` / ``"unknown"`` / ``"too_many_hypotheses"``),
+        ``haplotype`` (opaque tag), ``germline_variants`` (tuple of
+        the cis germline variants on that hypothesis's haplotype).
+        """
+        from ..outcomes import Outcome
+        outs = []
+        for candidate, hypothesis in zip(
+                self._candidates_raw, self._hypotheses):
+            outs.append(Outcome(
+                effect=candidate,
+                source="varcode_germline",
+                description=getattr(candidate, "short_description", None),
+                evidence={
+                    "phase_state": hypothesis.phase_state,
+                    "haplotype": hypothesis.haplotype,
+                    "germline_variants": tuple(hypothesis.cis),
+                }))
+        return self._with_extra_outcomes(tuple(outs))
+
+    @property
+    def short_description(self):
+        """``"?<most_likely>"`` — the leading ``?`` flags the
+        ambiguity. Consumers wanting the full possibility set read
+        :attr:`outcomes`."""
+        return "?" + self.most_likely.short_description
+
+    @property
+    def mutant_protein_sequence(self):
+        """Most-likely candidate's mutant protein. Consumers iterating
+        over hypotheses pull per-candidate sequences from
+        :attr:`outcomes`."""
+        return getattr(self.most_likely, "mutant_protein_sequence", None)
+
+    @property
+    def modifies_protein_sequence(self):
+        return getattr(self.most_likely, "modifies_protein_sequence", False)
+
+    @property
+    def modifies_coding_sequence(self):
+        return getattr(self.most_likely, "modifies_coding_sequence", False)
+
+    def __str__(self):
+        return (
+            "PhaseAmbiguousEffect(variant=%s, transcript=%s, "
+            "%d hypotheses, germline=%s)" % (
+                self.variant,
+                self.transcript.name if self.transcript else "?",
+                len(self._hypotheses),
+                ",".join(g.short_description for g in self.germline_variants)))

--- a/varcode/effects/effect_prediction.py
+++ b/varcode/effects/effect_prediction.py
@@ -47,7 +47,9 @@ def predict_variant_effects(
         variant,
         raise_on_error=False,
         splice_outcomes=False,
-        annotator=None):
+        annotator=None,
+        germline=None,
+        phase_resolver=None):
     """Determine the effects of a variant on any transcripts it overlaps.
     Returns an EffectCollection object.
 
@@ -74,11 +76,37 @@ def predict_variant_effects(
         :func:`set_default_annotator` / :func:`use_annotator` — today
         that's ``"fast"``. A string is looked up in the registry;
         an instance is used directly. See openvax/varcode#271.
+
+    germline : GermlineContext or None
+        Optional patient germline context. When non-empty, every per-
+        transcript effect is computed against the patient's germline-
+        applied transcript instead of the reference. Codons / splice
+        signals where germline overlaps the somatic produce per-
+        haplotype possibility sets when phase is unknown (a
+        :class:`PhaseAmbiguousEffect`); LOH at germline het positions
+        is flagged. ``None`` or :meth:`GermlineContext.empty` falls
+        through to today's reference-relative behaviour byte-
+        identically. See openvax/varcode#268.
+
+    phase_resolver : PhaseResolver or None
+        Optional phase-evidence source. Consumed two ways: by
+        germline-aware annotation to resolve cis/trans for
+        somatic-vs-germline pairs (collapses possibility sets when
+        phase is known), and by the post-annotation walk to attach
+        contig-derived ``mutant_transcript`` to per-variant effects.
+        See openvax/varcode#269.
     """
     # Lazy import — varcode.annotators depends on varcode.effects at
     # load time, so we defer to break the cycle.
     from ..annotators.registry import get_annotator, resolve_annotator
     annotator_instance = resolve_annotator(annotator)
+    # Germline-aware helper, lazily imported because varcode.germline
+    # imports from varcode.effects.classify (cycle if unconditional).
+    # Per-call validation lives on VariantCollection.effects (where
+    # we have the full somatic collection); this entry point trusts
+    # its inputs.
+    if germline:
+        from ..germline import predict_germline_aware_effect
     # Kind dispatch for structural variants: ``fast``/``protein_diff``
     # declare ``supports = {"snv","indel","mnv"}``, but that flag is
     # metadata — nobody dispatches on it. Without this override an SV
@@ -124,13 +152,25 @@ def predict_variant_effects(
             else:
                 # gene ID  has transcripts overlapped by this variant
                 for transcript in transcripts_grouped_by_gene[gene_id]:
+                    # Germline-aware path takes over when a non-empty
+                    # context is supplied — it owns window lookup,
+                    # phase enumeration, LOH detection, and packaging
+                    # into a PhaseAmbiguousEffect when phase is
+                    # unknown. Empty context delegates to the
+                    # annotator unchanged. See #268.
+                    annotate = (
+                        annotator_instance.annotate_on_transcript
+                        if not germline else
+                        lambda v, t: predict_germline_aware_effect(
+                            v, t,
+                            germline_ctx=germline,
+                            annotator=annotator_instance,
+                            phase_resolver=phase_resolver))
                     if raise_on_error:
-                        effect = annotator_instance.annotate_on_transcript(
-                            variant, transcript)
+                        effect = annotate(variant, transcript)
                     else:
                         try:
-                            effect = annotator_instance.annotate_on_transcript(
-                                variant, transcript)
+                            effect = annotate(variant, transcript)
                         except (AssertionError, ValueError) as error:
                             logger.warn(
                                 "Encountered error annotating %s for %s: %s",

--- a/varcode/germline.py
+++ b/varcode/germline.py
@@ -544,3 +544,495 @@ class GermlineContext:
             if gt and gt not in ("./.", ".|.", "0/0", "0|0", "."):
                 keep.append(v)
         return VariantCollection(keep)
+
+
+# =====================================================================
+# Germline-aware effect prediction
+#
+# This is where the input contract from above flows through to actual
+# effect classification. The shape from the design pivot in #268:
+# germline isn't a wrapper around an effect, it's a transcript modifier
+# applied before classification. ``predict_germline_aware_effect`` is
+# the single entry point — ``predict_variant_effects`` calls it
+# whenever a non-empty ``GermlineContext`` is supplied; otherwise it
+# stays out of the way.
+#
+# Algorithm sketch (per-(somatic, transcript) call):
+#
+#   1. Look up germline variants whose coordinates overlap the somatic's
+#      "window" on the transcript (default: the same codon for coding
+#      variants — pluggable via ``window_fn``).
+#   2. If the window is empty, the patient transcript is identical to
+#      the reference at this locus. Annotate normally. (When the
+#      context is SPARSE / HOTSPOTS_ONLY, flag the resulting effect with
+#      ``germline_unknown=True`` so consumers see the uncertainty.)
+#   3. Detect LOH — ``somatic`` shares (position, alt) with a germline
+#      het call. Sets ``effect.is_loh = True`` and proceeds.
+#   4. Resolve phase between somatic and each germline-in-window via
+#      ``phase_resolver``. Hemizygous variants (chrX/Y/M) → automatic
+#      cis. PS-tagged variants → use the resolver's answer. Unknown
+#      phase → enumerate up to 2^n hypotheses (cap configurable).
+#   5. For each hypothesis, build the patient haplotype the somatic
+#      landed on (just the cis germline variants on that haplotype),
+#      then build the post-somatic haplotype (cis germline + somatic).
+#      Classify the diff between them using the protein-diff
+#      classifier — same machinery the protein_diff annotator uses.
+#   6. Single hypothesis → return the single classified effect.
+#      Multiple hypotheses → wrap in ``PhaseAmbiguousEffect`` (a
+#      ``MultiOutcomeEffect`` subclass; not a wrapper around a
+#      reference-relative effect).
+#
+# Out of scope for v1 (refinements that don't change this API):
+#   * Splice-signal recomputation when germline already disrupts a
+#     splice site varcode would otherwise classify against (#285).
+#     Falls out partially because the patient transcript carries the
+#     germline edits, but downgrade-by-already-broken needs targeted
+#     work.
+#   * Mitochondrial codon table (different from nuclear; chrM is
+#     skipped for now with a flag).
+#   * Coverage-track-aware "unknown" regions (for SPARSE contexts
+#     with explicit BedGraph coverage).
+# =====================================================================
+
+
+def apply_germline_to_transcript(transcript, germline_ctx, somatic_variant=None):
+    """Apply germline variants from ``germline_ctx`` to ``transcript``,
+    returning the patient's baseline :class:`MutantTranscript`.
+
+    Lower-level entry point for callers that want the patient
+    transcript directly without going through full effect prediction.
+    Used internally by :func:`predict_germline_aware_effect`; exposed
+    publicly for downstream tools (Isovar, Exacto) that want to
+    compute a custom analysis on the patient haplotype.
+
+    Behaviour:
+
+    * If ``germline_ctx`` is empty, returns ``None``.
+    * If ``somatic_variant`` is provided, restricts germline to the
+      somatic's window (per :func:`default_germline_window`); else
+      applies all germline variants overlapping any exon of the
+      transcript.
+    * If germline edits conflict (overlapping cDNA ranges) or land
+      outside the CDS, returns ``None`` and the caller falls back.
+
+    The returned object is the same shape that
+    :func:`varcode.mutant_transcript.apply_variants_to_transcript`
+    produces: a :class:`MutantTranscript` carrying the germline
+    edits with ``mutant_protein_sequence`` populated when the edits
+    land after the CDS start.
+    """
+    if not germline_ctx:
+        return None
+    from .mutant_transcript import apply_variants_to_transcript
+    if somatic_variant is not None:
+        contig, start, end = default_germline_window(
+            somatic_variant, transcript)
+        germline_in_window = germline_ctx.variants_in_window(
+            contig, start, end)
+    else:
+        # Whole-transcript window: cover every exon. Useful for
+        # callers building a single patient transcript independent of
+        # any specific somatic — e.g., to translate the patient
+        # protein for cohort-level analysis.
+        germline_in_window = []
+        try:
+            for exon in transcript.exons:
+                germline_in_window.extend(
+                    germline_ctx.variants_in_window(
+                        exon.contig, exon.start, exon.end))
+        except Exception:
+            return None
+    if not germline_in_window:
+        return None
+    return apply_variants_to_transcript(
+        list(germline_in_window), transcript)
+
+
+def default_germline_window(somatic_variant, transcript) -> Tuple[str, int, int]:
+    """Default window for looking up germline variants relevant to a
+    somatic variant on a transcript.
+
+    Returns ``(contig, start, end)`` covering the codon containing the
+    somatic variant — three reference bases on each side of
+    ``somatic_variant.start``. This is the window from #268's table
+    for in-exon coding variants.
+
+    Larger windows (splice signal region for splice-adjacent variants,
+    same exon for frameshift candidates) are useful refinements but
+    don't change the API. Callers that need them pass a custom
+    ``window_fn`` to :func:`predict_germline_aware_effect`.
+
+    Splice-adjacent: when the somatic is within 6bp of an exon-intron
+    boundary, expand to a 12bp window centered on the boundary so
+    germline edits to the donor / acceptor signal show up in the
+    lookup. This catches the "germline broke the splice site" case
+    without forcing the caller to wire up a separate window function.
+    """
+    contig = somatic_variant.contig
+    pos = somatic_variant.start
+    # Default: the codon containing the somatic. Three bases on either
+    # side — slightly wider than strictly necessary so overlapping
+    # frame-aware codon membership is conservative.
+    start = pos - 3
+    end = (getattr(somatic_variant, "end", None) or pos) + 3
+    # Splice-adjacent expansion: if any of this transcript's exon
+    # boundaries is within 6bp of the somatic, widen to capture the
+    # canonical splice signal region (MAG | GURAGU and YAG | R, ~12bp).
+    try:
+        for exon in transcript.exons:
+            for boundary in (exon.start, exon.end):
+                if abs(boundary - pos) <= 6:
+                    start = min(start, boundary - 6)
+                    end = max(end, boundary + 6)
+    except Exception:
+        # Hand-built transcripts in tests may not have exons; the
+        # default codon window is a fine fallback.
+        pass
+    return contig, max(1, start), end
+
+
+def detect_loh(somatic_variant, germline_in_window) -> bool:
+    """True when ``somatic_variant`` is identical at (position, alt)
+    to a germline variant in the window.
+
+    LOH is the most common "looks somatic but isn't really" case —
+    the patient was germline het at this position, and the tumor lost
+    the reference allele, so the variant call says "alt" in tumor and
+    "het" in normal but the alt itself is the germline allele. We
+    flag the resulting effect with ``is_loh=True`` so consumers can
+    distinguish a true somatic mutation from a zygosity change.
+
+    Only same-position-and-alt counts. A position where germline and
+    somatic disagree on alt is a different mutation, not LOH.
+    """
+    for g in germline_in_window:
+        if (g.contig == somatic_variant.contig
+                and g.start == somatic_variant.start
+                and g.ref == somatic_variant.ref
+                and g.alt == somatic_variant.alt):
+            return True
+    return False
+
+
+@dataclass(frozen=True)
+class PhaseHypothesis:
+    """One way the somatic variant might be phased relative to the
+    germline variants in its window.
+
+    ``cis`` are germline variants on the same haplotype as the
+    somatic; ``trans`` are on the other haplotype. The somatic's
+    effect at this locus is determined entirely by the cis set —
+    edits in trans live on the haplotype the somatic *didn't* hit and
+    don't change the codon the somatic edits.
+
+    ``haplotype`` is a stable opaque label (``"A"``, ``"B"``, etc.)
+    that callers use to align outcomes across axes — e.g. an RNA
+    resolver returning ``evidence={"haplotype": "B"}`` aligns with the
+    hypothesis whose ``haplotype == "B"``.
+
+    ``phase_state`` mirrors the table in #268: ``"phased"``,
+    ``"implicit"`` (hemizygous), or ``"unknown"`` (enumerated).
+    """
+    cis: Tuple = ()
+    trans: Tuple = ()
+    haplotype: str = "unknown"
+    phase_state: str = "unknown"
+
+
+def enumerate_phase_hypotheses(
+        somatic_variant,
+        germline_in_window,
+        phase_resolver=None,
+        max_hypotheses: int = 8) -> Tuple[PhaseHypothesis, ...]:
+    """Enumerate plausible phase configurations of ``somatic_variant``
+    relative to ``germline_in_window``.
+
+    Three regimes:
+
+    * **Hemizygous chromosome** (chrX/Y/M, male X) — single haplotype;
+      all germline-in-window is implicitly cis. One hypothesis.
+    * **Resolver answers for every pair** (``phase_resolver.in_cis``
+      returns True/False for each ``(somatic, germline_v)``) — a
+      single deterministic hypothesis with cis/trans assigned per
+      the resolver. ``phase_state="phased"``.
+    * **Phase unknown** — enumerate all 2^n cis/trans assignments
+      across n germline variants. Cap at ``max_hypotheses``; emit a
+      single ``"unknown"`` placeholder when the cap is exceeded
+      (consumers see a ``TooManyHypotheses`` evidence flag).
+
+    The cap is configurable so downstream pipelines that tolerate more
+    hypotheses (long-read with rich phasing, manual analyses) can
+    raise it. Default 8 = up to 3 germline variants in a window
+    fully unphased.
+    """
+    # Hemizygous: chrX (in males), chrY, chrM. Detection is
+    # heuristic since varcode doesn't carry sex info — the X
+    # chromosome detection conservatively requires the genome to
+    # claim hemizygosity. For v1 we treat chrM (mitochondrial) and
+    # chrY as definitely hemizygous; chrX is treated as diploid
+    # by default (the female case; the male case undergenerates
+    # but doesn't misgenerate).
+    contig = str(somatic_variant.contig).lstrip("chr").upper()
+    if contig in ("M", "MT", "Y"):
+        return (PhaseHypothesis(
+            cis=tuple(germline_in_window),
+            trans=(),
+            haplotype="A",
+            phase_state="implicit"),)
+
+    # Resolver-based phase: ask the resolver for each germline
+    # variant. If the resolver answers for all of them, single
+    # deterministic hypothesis.
+    if (phase_resolver is not None
+            and hasattr(phase_resolver, "in_cis")
+            and germline_in_window):
+        cis_list = []
+        trans_list = []
+        all_answered = True
+        for g in germline_in_window:
+            try:
+                answer = phase_resolver.in_cis(somatic_variant, g)
+            except Exception:
+                all_answered = False
+                break
+            if answer is True:
+                cis_list.append(g)
+            elif answer is False:
+                trans_list.append(g)
+            else:
+                all_answered = False
+                break
+        if all_answered:
+            return (PhaseHypothesis(
+                cis=tuple(cis_list),
+                trans=tuple(trans_list),
+                haplotype="A",
+                phase_state="phased"),)
+
+    # Phase unknown: enumerate 2^n cis/trans assignments across the
+    # n germline variants. Cap to avoid blow-up.
+    n = len(germline_in_window)
+    if n == 0:
+        # No germline in window — single trivial hypothesis (no
+        # germline edits). Caller usually short-circuits before
+        # reaching this branch, but it's a safe default.
+        return (PhaseHypothesis(
+            cis=(),
+            trans=(),
+            haplotype="A",
+            phase_state="phased"),)
+
+    if 2 ** n > max_hypotheses:
+        # Bail out cleanly — emit a single "too many" hypothesis with
+        # all germline marked cis (the conservative case where
+        # somatic effect is most strongly germline-modified).
+        return (PhaseHypothesis(
+            cis=tuple(germline_in_window),
+            trans=(),
+            haplotype="unknown",
+            phase_state="too_many_hypotheses"),)
+
+    hypotheses: List[PhaseHypothesis] = []
+    germline_tuple = tuple(germline_in_window)
+    for mask in range(2 ** n):
+        cis = []
+        trans = []
+        for i, g in enumerate(germline_tuple):
+            if mask & (1 << i):
+                cis.append(g)
+            else:
+                trans.append(g)
+        # Label haplotype "A" for the all-cis case, "B" for all-trans,
+        # "mixed" otherwise. These are opaque tags consumers use for
+        # cross-axis matching with RNA evidence.
+        if not trans:
+            hap = "A"
+        elif not cis:
+            hap = "B"
+        else:
+            hap = "A_mixed_%d" % mask
+        hypotheses.append(PhaseHypothesis(
+            cis=tuple(cis),
+            trans=tuple(trans),
+            haplotype=hap,
+            phase_state="unknown"))
+    return tuple(hypotheses)
+
+
+def _classify_against_patient_baseline(
+        somatic_variant, transcript, hypothesis: PhaseHypothesis):
+    """Build the patient-baseline and post-somatic haplotypes for a
+    single phase hypothesis, then classify the somatic effect via
+    the protein-diff classifier.
+
+    Returns a :class:`MutationEffect` instance. The effect's class
+    (Missense, FrameShift, etc.) reflects the diff against the
+    patient's baseline — not the reference's — when ``hypothesis.cis``
+    is non-empty.
+
+    For the all-trans case (``hypothesis.cis`` empty), the patient
+    baseline is identical to the reference, so the diff degenerates
+    to today's reference-relative classification. That's the
+    structural back-compat: when no germline lands on the somatic's
+    haplotype, this branch produces what the protein-diff annotator
+    would produce on its own.
+    """
+    from .effects.classify import classify_from_protein_diff
+    from .effects.effect_classes import (
+        IncompleteTranscript,
+        NoncodingTranscript,
+    )
+    from .mutant_transcript import apply_variants_to_transcript
+
+    if not transcript.is_protein_coding:
+        return NoncodingTranscript(somatic_variant, transcript)
+    if not transcript.complete:
+        return IncompleteTranscript(somatic_variant, transcript)
+
+    cis_germline = list(hypothesis.cis)
+
+    # Patient baseline: just the cis germline applied. Empty cis →
+    # baseline is the reference transcript (no edits).
+    if cis_germline:
+        baseline = apply_variants_to_transcript(cis_germline, transcript)
+        if baseline is None:
+            # The germline edits conflict (overlapping cDNA ranges) or
+            # land outside the CDS — fall back to reference-relative
+            # classification of the somatic alone. The caller still
+            # sees a per-hypothesis result; it just degenerates.
+            from .effects import predict_variant_effect_on_transcript
+            return predict_variant_effect_on_transcript(
+                somatic_variant, transcript)
+        baseline_protein = baseline.mutant_protein_sequence
+        baseline_length_delta = baseline.total_length_delta
+    else:
+        # No cis germline → patient haplotype == reference at this
+        # locus. Use the reference protein directly.
+        baseline_protein = str(transcript.protein_sequence) if (
+            getattr(transcript, "protein_sequence", None)) else None
+        baseline_length_delta = 0
+
+    # Post-somatic: cis germline + somatic on the same haplotype.
+    joint_variants = cis_germline + [somatic_variant]
+    joint = apply_variants_to_transcript(joint_variants, transcript)
+    if joint is None or joint.mutant_protein_sequence is None:
+        # Joint build failed (conflicting edits, or somatic lands
+        # before CDS start) — fall back to reference-relative
+        # classification of the somatic alone.
+        from .effects import predict_variant_effect_on_transcript
+        return predict_variant_effect_on_transcript(
+            somatic_variant, transcript)
+
+    if baseline_protein is None:
+        # Edge: transcript has no reference protein (incomplete or
+        # non-coding got past our gate); fall back.
+        from .effects import predict_variant_effect_on_transcript
+        return predict_variant_effect_on_transcript(
+            somatic_variant, transcript)
+
+    # Length delta of the somatic alone, after stripping the germline-
+    # only baseline shift. classify_from_protein_diff expects the diff
+    # delta, not the joint delta.
+    somatic_length_delta = joint.total_length_delta - baseline_length_delta
+
+    return classify_from_protein_diff(
+        variant=somatic_variant,
+        transcript=transcript,
+        ref_protein=baseline_protein,
+        mut_protein=joint.mutant_protein_sequence,
+        length_delta=somatic_length_delta,
+        mutant_transcript=joint)
+
+
+def predict_germline_aware_effect(
+        somatic_variant,
+        transcript,
+        germline_ctx: GermlineContext,
+        annotator,
+        phase_resolver=None,
+        window_fn=default_germline_window,
+        max_hypotheses: int = 8):
+    """Predict the effect of ``somatic_variant`` on ``transcript``
+    against the patient's germline-applied transcript.
+
+    Single entry point for germline-aware effect prediction.
+    :func:`varcode.effects.predict_variant_effects` calls this whenever
+    a non-empty :class:`GermlineContext` is supplied; otherwise it
+    bypasses the germline path entirely and the existing annotator
+    dispatch produces today's reference-relative output unchanged.
+
+    Behaviour by case:
+
+    * **No germline in the somatic's window** — patient transcript ≡
+      reference transcript at this locus; delegate to ``annotator``
+      directly. SPARSE / HOTSPOTS_ONLY contexts mark the result with
+      ``effect.germline_unknown = True`` so consumers can see the
+      uncertainty.
+    * **Germline in window, phase known** (resolver answers, or
+      hemizygous, or all-cis-by-zygosity) — single patient haplotype;
+      classify against it via :func:`_classify_against_patient_baseline`.
+    * **Germline in window, phase unknown** — enumerate hypotheses
+      (capped via ``max_hypotheses``), classify each, wrap in
+      :class:`~varcode.effects.effect_classes.PhaseAmbiguousEffect`.
+
+    LOH (``somatic`` matches germline at position+alt with het zygosity)
+    sets ``effect.is_loh = True`` regardless of which branch ran.
+
+    ``window_fn`` is the pluggable window selector — defaults to
+    :func:`default_germline_window` (codon-level, with splice-signal
+    expansion when the somatic is splice-adjacent). Callers that
+    need different windows pass their own.
+    """
+    from pyensembl import Transcript
+    if not isinstance(transcript, Transcript):
+        # Mirrors annotator entry: SVs and other non-Transcript
+        # consumers don't go through germline-aware prediction.
+        return annotator.annotate_on_transcript(somatic_variant, transcript)
+
+    contig, start, end = window_fn(somatic_variant, transcript)
+    germline_in_window = germline_ctx.variants_in_window(contig, start, end)
+    is_loh = detect_loh(somatic_variant, germline_in_window)
+
+    if not germline_in_window:
+        effect = annotator.annotate_on_transcript(
+            somatic_variant, transcript)
+        if germline_ctx.completeness in (
+                Completeness.SPARSE, Completeness.HOTSPOTS_ONLY):
+            effect.germline_unknown = True
+        if is_loh:
+            effect.is_loh = True
+        return effect
+
+    hypotheses = enumerate_phase_hypotheses(
+        somatic_variant,
+        germline_in_window,
+        phase_resolver=phase_resolver,
+        max_hypotheses=max_hypotheses)
+
+    if len(hypotheses) == 1:
+        effect = _classify_against_patient_baseline(
+            somatic_variant, transcript, hypotheses[0])
+        # Stash the phase metadata on the effect so consumers /
+        # serializers can recover it. Single-hypothesis effects don't
+        # need a possibility set, but the evidence is still useful.
+        effect.germline_phase_state = hypotheses[0].phase_state
+        effect.germline_variants_in_window = tuple(germline_in_window)
+        if is_loh:
+            effect.is_loh = True
+        return effect
+
+    # Multiple hypotheses → possibility set.
+    candidates = tuple(
+        _classify_against_patient_baseline(
+            somatic_variant, transcript, h)
+        for h in hypotheses)
+    from .effects.effect_classes import PhaseAmbiguousEffect
+    effect = PhaseAmbiguousEffect(
+        variant=somatic_variant,
+        transcript=transcript,
+        candidates=candidates,
+        hypotheses=hypotheses,
+        germline_variants=tuple(germline_in_window))
+    if is_loh:
+        effect.is_loh = True
+    return effect

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -445,7 +445,8 @@ class Variant(Serializable):
 
     def effects(
             self, raise_on_error=True, splice_outcomes=False,
-            annotator=None, phase_resolver=None, rna_resolver=None):
+            annotator=None, phase_resolver=None, rna_resolver=None,
+            germline=None):
         """Predict the variant's effects on overlapping transcripts.
 
         Parameters
@@ -489,12 +490,27 @@ class Variant(Serializable):
             predictions with isoform-level evidence from Isovar,
             Exacto, or a custom long-read pipeline. See
             openvax/varcode#259.
+
+        germline : GermlineContext or None
+            Optional patient-germline context. When non-empty, every
+            per-transcript effect is computed against the patient's
+            germline-applied transcript instead of the reference.
+            Codons / splice signals where germline overlaps the
+            somatic and phase is unknown produce a
+            :class:`PhaseAmbiguousEffect` with one outcome per
+            haplotype hypothesis; LOH at germline het positions sets
+            ``effect.is_loh = True``. ``None`` or
+            :meth:`GermlineContext.empty` falls through to today's
+            reference-relative behaviour byte-identically. See
+            openvax/varcode#268.
         """
         effects = predict_variant_effects(
             variant=self,
             raise_on_error=raise_on_error,
             splice_outcomes=splice_outcomes,
             annotator=annotator,
+            germline=germline,
+            phase_resolver=phase_resolver,
         )
         if phase_resolver is not None:
             from .phasing import apply_phase_resolver_to_effects

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -116,7 +116,8 @@ class VariantCollection(Collection):
 
     def effects(
             self, raise_on_error=True, splice_outcomes=False,
-            annotator=None, phase_resolver=None, rna_resolver=None):
+            annotator=None, phase_resolver=None, rna_resolver=None,
+            germline=None, validate_reference=True):
         """
         Parameters
         ----------
@@ -150,6 +151,19 @@ class VariantCollection(Collection):
             :class:`~varcode.MultiOutcomeEffect` in the result has
             observed outcomes from the resolver appended to its
             ``outcomes`` view. See openvax/varcode#259.
+
+        germline : GermlineContext or None
+            Optional patient-germline context. When non-empty, every
+            per-transcript effect is computed against the patient's
+            germline-applied transcript instead of the reference.
+            See :meth:`Variant.effects` and openvax/varcode#268.
+
+        validate_reference : bool, default True
+            Cross-check that the germline context's reference build
+            matches this collection's reference build before running
+            annotation. Hard error on mismatch. Set to False if
+            you've already lifted over and know the builds agree.
+            Ignored when ``germline`` is ``None``.
         """
         from datetime import datetime, timezone
 
@@ -159,6 +173,13 @@ class VariantCollection(Collection):
             build_haplotype_effects,
         )
 
+        # Pre-flight: cross-VCF build mismatch surfaces here as one
+        # readable error rather than per-variant ReferenceMismatchError
+        # noise. The empty/None context is a no-op.
+        if germline:
+            germline.validate_against(
+                self, validate_reference=validate_reference)
+
         annotator_instance = resolve_annotator(annotator)
         per_variant = [
             effect
@@ -167,6 +188,8 @@ class VariantCollection(Collection):
                 raise_on_error=raise_on_error,
                 splice_outcomes=splice_outcomes,
                 annotator=annotator,
+                germline=germline,
+                phase_resolver=phase_resolver,
             )
         ]
         if phase_resolver is not None:


### PR DESCRIPTION
## Summary

Unified PR covering the rest of #268's umbrella in one shot — slices 2-6 of the original plan, plus the bits of slice 7 (LOH, splice naturalness) that fall out of the wrapper-free design.

This is the design-pivoted version of #268: germline is a transcript modifier consumed by effect prediction, not a wrapper attached to existing effects. The motivation and ASCII walkthrough live in the [design-update comment on #268](https://github.com/openvax/varcode/issues/268#issuecomment-4407569408).

## What works end-to-end

```python
from varcode import load_vcf, GermlineContext

somatic = load_vcf("tumor.vcf")
germline = GermlineContext.from_germline_vcf("normal.vcf")

# All effects computed against the patient's germline-applied transcript.
# Phase-ambiguous codon-overlap → MultiOutcomeEffect with per-haplotype outcomes.
# LOH (somatic at germline-het position) → effect.is_loh = True.
# Sparse context absence-as-unknown → effect.germline_unknown = True.
effects = somatic.effects(germline=germline)

for e in effects:
    print(e.short_description)
    if hasattr(e, "outcomes"):
        for outcome in e.outcomes:
            hap = outcome.evidence.get("haplotype")
            print(f"  [{hap}] {outcome.short_description}")
```

`germline=None` (or omitted) preserves today's reference-relative behaviour byte-identically — pinned by tests.

## Mechanism

`predict_germline_aware_effect(somatic, transcript, germline_ctx, annotator, phase_resolver=None)` is the single entry point. Algorithm in `varcode/germline.py:931-1029`:

1. Look up germline in the somatic's window (codon-level, splice-signal-expanded).
2. No overlap → delegate to annotator. SPARSE/HOTSPOTS_ONLY → flag `germline_unknown=True`.
3. LOH (somatic shares position+alt with a germline het) → flag `is_loh=True`.
4. Resolve phase: hemizygous (chrM, chrY) → automatic cis; resolver answers → single hypothesis; else enumerate 2^n hypotheses (cap 8).
5. Classify each hypothesis via the protein-diff classifier — same machinery as the `protein_diff` annotator, but against the patient baseline.
6. Single hypothesis → effect directly. Multiple → `PhaseAmbiguousEffect` (sibling of `HaplotypeEffect`, not a wrapper).

## Composition with what's already shipped

- **#358 RNA evidence**: `Outcome.evidence["haplotype"]` is the cross-axis key. RNA observations with `evidence={"haplotype": "B"}` align with the haplotype B germline-aware outcome by dict lookup.
- **#357 SV path**: SVs route through the SV annotator unchanged. Germline-aware annotation is point-variant-only for v1; SV+germline composition is documented as a follow-up.
- **#269 phasing**: existing `phase_resolver=` kwarg now serves two purposes — collapsing germline phase ambiguity (this PR) and attaching mutant_transcript / building HaplotypeEffects (existing).

## Public surface

New top-level exports:

- `apply_germline_to_transcript(transcript, ctx, somatic_variant=None)` — public helper for callers who want the patient transcript directly.
- `predict_germline_aware_effect(...)` — single entry point.
- `PhaseHypothesis` — frozen dataclass for one phase configuration.
- `enumerate_phase_hypotheses(...)` — pluggable enumerator.
- `detect_loh(...)` — LOH detector.
- `default_germline_window(somatic, transcript)` — pluggable window.
- `PhaseAmbiguousEffect` (in `varcode.effects.effect_classes`) — `MultiOutcomeEffect` subclass.

New kwargs on existing methods:

- `Variant.effects(..., germline=None)` 
- `VariantCollection.effects(..., germline=None, validate_reference=True)`

## Test plan

- [x] `./test.sh` — 1114 passed, 2 skipped (gained 34 tests in `tests/test_germline_effects.py`)
- [x] `./lint.sh` — clean
- [x] Back-compat: `germline=None` and `germline=GermlineContext.empty()` produce byte-identical output to today (pinned by tests).
- [x] End-to-end on real CFTR codon-overlap pair: somatic alone produces p.L159M; somatic+germline cis produces p.S159T; trans matches reference-relative.
- [x] LOH, sparseness, hemizygous, hypothesis cap, build mismatch, opt-out — all pinned.

## Closing sub-issues

After merge I'll close #282-#291 referencing this PR — they're all subsumed by the unified implementation here.

## Out of scope (deferred)

- `docs/germline.md` user-facing guide with worked examples for all four input shapes (#290).
- Edge-case test corpus at scale (#291).
- Mitochondrial codon table (chrM hemizygosity is handled but the codon table difference isn't — still flagged as a known limitation).
- Explicit splice-signal-disrupted downgrade (the simple cases work because the patient transcript carries germline edits when the splice classifier sees it; the targeted downgrade path is a refinement).