### PR TITLE
Audit docs + README: remove ASCII flowcharts, defrost stale roadmap claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 [![Tests](https://github.com/openvax/varcode/actions/workflows/tests.yml/badge.svg)](https://github.com/openvax/varcode/actions/workflows/tests.yml)
-<a href="https://coveralls.io/github/openvax/varcode?branch=master">
-<img src="https://coveralls.io/repos/openvax/varcode/badge.svg?branch=master&service=github" alt="Coverage Status" />
-</a>
-<a href="https://pypi.python.org/pypi/varcode/">
-<img src="https://img.shields.io/pypi/v/varcode.svg?maxAge=1000" alt="PyPI" />
-</a>
+[![Coverage Status](https://coveralls.io/repos/openvax/varcode/badge.svg?branch=main&service=github)](https://coveralls.io/github/openvax/varcode?branch=main)
+[![PyPI](https://img.shields.io/pypi/v/varcode.svg?maxAge=1000)](https://pypi.python.org/pypi/varcode/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/varcode.svg)](https://pypistats.org/packages/varcode)
 
 # Varcode
@@ -83,16 +79,21 @@ If you are looking for a quick start guide, you can check out [this iPython book
 
 ## Further reading
 
-Feature guides live in [`docs/`](./docs/):
+Feature guides live in [`docs/`](./docs/) and on the [docs site](https://openvax.github.io/varcode/):
 
-- [**Genotypes and sample-aware queries**](./docs/genotype.md) — per-sample
-  zygosity on multi-sample VCFs (`Genotype`, `Zygosity`, `VariantCollection.for_sample`,
-  `.heterozygous_in`, `.homozygous_alt_in`). New in 2.3.
-- [**CSV round-trip and metadata headers**](./docs/csv.md) — `to_csv` /
-  `from_csv` on both collection types, with `#`-prefixed provenance
-  headers. New in 2.1, refined in 2.2.
+- [**Effect annotation**](./docs/effect_annotation.md) — how variants
+  become effects, splice outcome representations, pluggable annotators,
+  and structural variants.
+- [**Germline-aware annotation**](./docs/germline.md) — classify
+  somatic variants against the patient's germline-applied transcript;
+  possibility sets when phase is unknown; LOH detection.
+- [**Genotypes and sample-aware queries**](./docs/genotype.md) —
+  per-sample zygosity on multi-sample VCFs.
+- [**CSV round-trip and metadata headers**](./docs/csv.md) —
+  `to_csv` / `from_csv` with `#`-prefixed provenance headers.
 - [**Error handling**](./docs/errors.md) — `ReferenceMismatchError`,
-  `SampleNotFoundError`, and the `raise_on_error=False` escape hatch.
+  `GenomeBuildMismatchError`, `SampleNotFoundError`, and
+  `raise_on_error=False`.
 
 See [`CHANGELOG.md`](./CHANGELOG.md) for the release history.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,18 @@ Auto-generated from in-source docstrings via
 
 ::: varcode.VariantCollection
 
+### `varcode.StructuralVariant`
+
+::: varcode.StructuralVariant
+
+### `varcode.parse_symbolic_alt`
+
+::: varcode.parse_symbolic_alt
+
+### `varcode.SV_TYPES`
+
+::: varcode.SV_TYPES
+
 ## Genotypes
 
 ### `varcode.Genotype`
@@ -33,15 +45,129 @@ Auto-generated from in-source docstrings via
 
 ::: varcode.NonsilentCodingMutation
 
+### `varcode.MultiOutcomeEffect`
+
+::: varcode.MultiOutcomeEffect
+
 ### `varcode.EffectCollection`
 
 ::: varcode.EffectCollection
+
+### `varcode.Outcome`
+
+::: varcode.Outcome
 
 ### Priority ordering
 
 ::: varcode.effect_priority
 
 ::: varcode.top_priority_effect
+
+## Mutant transcripts
+
+### `varcode.MutantTranscript`
+
+::: varcode.MutantTranscript
+
+### `varcode.apply_variant_to_transcript`
+
+::: varcode.apply_variant_to_transcript
+
+### `varcode.apply_variants_to_transcript`
+
+::: varcode.apply_variants_to_transcript
+
+## Annotators
+
+### `varcode.EffectAnnotator`
+
+::: varcode.EffectAnnotator
+
+### `varcode.FastEffectAnnotator`
+
+::: varcode.FastEffectAnnotator
+
+### `varcode.ProteinDiffEffectAnnotator`
+
+::: varcode.ProteinDiffEffectAnnotator
+
+### `varcode.StructuralVariantAnnotator`
+
+::: varcode.StructuralVariantAnnotator
+
+### Registry
+
+::: varcode.register_annotator
+
+::: varcode.get_annotator
+
+::: varcode.get_default_annotator
+
+::: varcode.set_default_annotator
+
+::: varcode.use_annotator
+
+## Phasing
+
+### `varcode.IsovarPhaseResolver`
+
+::: varcode.IsovarPhaseResolver
+
+### `varcode.VCFPhaseResolver`
+
+::: varcode.VCFPhaseResolver
+
+### `varcode.apply_phase_resolver_to_effects`
+
+::: varcode.apply_phase_resolver_to_effects
+
+## RNA evidence
+
+### `varcode.RNAEvidenceResolver`
+
+::: varcode.RNAEvidenceResolver
+
+### `varcode.NullRNAEvidenceResolver`
+
+::: varcode.NullRNAEvidenceResolver
+
+### `varcode.apply_rna_evidence_to_effects`
+
+::: varcode.apply_rna_evidence_to_effects
+
+### `varcode.make_rna_outcome`
+
+::: varcode.make_rna_outcome
+
+## Germline-aware annotation
+
+### `varcode.GermlineContext`
+
+::: varcode.GermlineContext
+
+### `varcode.Completeness`
+
+::: varcode.Completeness
+
+### `varcode.predict_germline_aware_effect`
+
+::: varcode.predict_germline_aware_effect
+
+### `varcode.apply_germline_to_transcript`
+
+::: varcode.apply_germline_to_transcript
+
+### `varcode.enumerate_phase_hypotheses`
+
+::: varcode.enumerate_phase_hypotheses
+
+### `varcode.detect_loh`
+
+::: varcode.detect_loh
+
+### `varcode.default_germline_window`
+
+::: varcode.default_germline_window
 
 ## File loading
 
@@ -64,3 +190,11 @@ Auto-generated from in-source docstrings via
 ### `varcode.SampleNotFoundError`
 
 ::: varcode.SampleNotFoundError
+
+### `varcode.GenomeBuildMismatchError`
+
+::: varcode.GenomeBuildMismatchError
+
+### `varcode.UnsupportedVariantError`
+
+::: varcode.UnsupportedVariantError

--- a/docs/csv.md
+++ b/docs/csv.md
@@ -109,5 +109,4 @@ meta = read_metadata_header("variants.csv")
 ```
 
 Annotator provenance fields (`annotator`, `annotator_version`) use
-the same `# key=value` convention (tracked in
-[#271](https://github.com/openvax/varcode/issues/271)).
+the same `# key=value` convention.

--- a/docs/effect_annotation.md
+++ b/docs/effect_annotation.md
@@ -1,26 +1,18 @@
 # Effect annotation
 
-How varcode turns a variant into one or more `MutationEffect`
-objects, and how the pieces fit together across the basic case,
-splice-disrupting variants, and (eventually) structural variants.
+How varcode turns a variant into one or more `MutationEffect` objects.
 
-## The pipeline
+## How it composes
 
-```
-Variant ─(Annotator)─> MutantTranscript(s) ─(Classifier)─> Effect(s)
-                              │
-                              └── wrapped in MultiOutcomeEffect
-                                   when >1 plausible outcome
-                                       │
-                                       └── narrowed by RNA evidence
-                                           (isovar / Exacto plug-ins)
-```
-
-Single DNA event can produce one or more plausible mutant
-proteins. varcode represents each concrete mutant as a
-`MutantTranscript`. When the DNA alone is ambiguous, the
-possibility set is wrapped in a `MultiOutcomeEffect`. RNA
-evidence (when available) narrows the set.
+A single DNA event can produce one or more plausible mutant proteins.
+varcode represents each concrete mutant as a `MutantTranscript`. The
+annotator turns a variant into one or more of these; the classifier
+turns each `MutantTranscript` into a typed `MutationEffect`. When the
+DNA alone admits multiple plausible outcomes — splice ambiguity, SV
+breakpoint resolution, unphased germline-overlapping codons — the
+results are packaged in a `MultiOutcomeEffect` whose `outcomes`
+property exposes the set. An optional RNA-evidence resolver narrows
+the set to observed isoforms or appends observed-only outcomes.
 
 ## The four primitives
 
@@ -107,117 +99,61 @@ disrupting variant produces a `SpliceOutcomeSet`.
 
 ### Relationship between the two
 
-`SpliceOutcomeSet` is the N-outcome case of the same idea
-`alternate_effect` expresses with 2 outcomes. The
-`NORMAL_SPLICING` candidate is `alternate_effect` promoted to
-first-class; the other candidates express alternatives you
-don't see from the default form. Both are progressions of
-the same pattern:
-
 | # candidates | Class |
 |---|---|
 | 1 | plain `Substitution` / `Silent` / etc. — not wrapped |
 | 2 | `ExonicSpliceSite` with `alternate_effect` |
-| N (≥3) | `SpliceOutcomeSet` (opt-in via `splice_outcomes=True`) |
+| N | `SpliceOutcomeSet` (opt-in via `splice_outcomes=True`) |
 
-`ExonicSpliceSite` is a `MultiOutcomeEffect` subclass since
-[#299][i299] Part 1. Downstream code can write
-`isinstance(e, MultiOutcomeEffect)` and iterate `.candidates`
-uniformly, regardless of richness level. `alternate_effect` is
-available on both `ExonicSpliceSite` (the 2-outcome case, as a
-first-class instance attribute) and `SpliceOutcomeSet` (where it
-resolves to the `NORMAL_SPLICING` candidate's `coding_effect`).
-Same field, same meaning, works on both shapes — no parallel
-mechanism.
+Both `ExonicSpliceSite` and `SpliceOutcomeSet` are `MultiOutcomeEffect`
+subclasses, so consumers iterate `.outcomes` uniformly without caring
+about which form they're holding. `alternate_effect` works on both:
+on `ExonicSpliceSite` it's the splicing-proceeds outcome directly; on
+`SpliceOutcomeSet` it resolves to the `NORMAL_SPLICING` candidate's
+`coding_effect`. The element types inside `.outcomes` differ
+(`MutationEffect` vs `SpliceCandidate`), but `outcome.effect.short_description`
+is uniform.
 
-```python
-# Both now work:
-if isinstance(effect, MultiOutcomeEffect):
-    for candidate in effect.candidates:
-        ...
-if effect.alternate_effect is not None:
-    coding_consequence = effect.alternate_effect
-```
-
-The element types in `.candidates` differ by shape —
-`ExonicSpliceSite.candidates` yields `MutationEffect` instances
-directly (self + alternate_effect); `SpliceOutcomeSet.candidates`
-yields `SpliceCandidate` objects with `.outcome` / `.plausibility`
-/ `.coding_effect` fields. Downstream code that needs the richer
-per-candidate metadata can branch on element type; code that just
-wants "is there a coding consequence" reads `.alternate_effect`
-and gets a `MutationEffect`-or-None regardless of which class
-produced it.
-
-### Variants in the CDS and in the splice window simultaneously
-
-A missense at the last exonic base is biologically *both* a
-splice effect (disrupts the splice signal) AND a protein-level
-coding effect (changes a residue). This is exactly what
-`ExonicSpliceSite` exists for:
-
-```python
-# Default: 2 outcomes
-effect = ExonicSpliceSite
-effect.alternate_effect      # the coding change, if splicing proceeds
-
-# Opt-in: N outcomes including the coding change as NORMAL_SPLICING
-for c in SpliceOutcomeSet.candidates:
-    if c.outcome is SpliceOutcome.NORMAL_SPLICING:
-        coding_change = c.coding_effect
-```
-
-Both representations encode the "splice + coding" case; the
-richer `SpliceOutcomeSet` just adds the other candidates
-(exon skipping, intron retention, cryptic splice).
-
-### What varcode does NOT classify as splice-affecting today
+### Limitations
 
 The splice classifier is **position-based** — it fires on the
-canonical window and nothing else. Variants that affect
-splicing through *sequence-based* signals aren't flagged:
-
-- **Exonic splicing enhancer / silencer (ESE / ESS) disruption**
-  mid-exon: ~6–10 nt motifs that recruit or repel SR proteins.
-  A missense that disrupts an ESE can cause exon skipping but
-  gets classified as plain `Substitution` today.
-- **Branch points** ~20–50 nt upstream of the acceptor.
-- **Deep intronic cryptic splice sites** far from canonical
-  boundaries.
-
-Detecting these needs ML predictors (SpliceAI, Pangolin,
-MMSplice, SpliceTransformer) trained on RNA-seq, or direct RNA
-evidence. Tracked as [#297][i297].
+canonical window (last 3 exonic, first 3-6 intronic, donor/acceptor)
+and nothing else. Sequence-based signals are not flagged: exonic
+splicing enhancer/silencer disruption mid-exon (~6-10nt SR-protein
+motifs), branch points (~20-50nt upstream of the acceptor), deep
+intronic cryptic sites. Detecting these needs ML predictors (SpliceAI,
+Pangolin, MMSplice, SpliceTransformer) or direct RNA evidence;
+tracked in [#297][i297].
 
 ## Annotator selection
 
-Two annotators coexist behind the `EffectAnnotator` protocol:
+Three annotators ship behind the `EffectAnnotator` protocol:
 
-| Annotator | Algorithm | Status |
+| Annotator | Algorithm | Used for |
 |---|---|---|
-| `FastEffectAnnotator` | Offset arithmetic against the reference CDS | Default |
-| `ProteinDiffEffectAnnotator` | Materializes `MutantTranscript`, translates, diffs against reference protein | [#309][i309] — WIP |
+| `ProteinDiffEffectAnnotator` | Builds a `MutantTranscript`, translates, diffs against the reference protein | Default for SNVs / indels / MNVs |
+| `FastEffectAnnotator` | Offset arithmetic against the reference CDS | Opt-in for byte-for-byte 2.x parity or perf-sensitive paths |
+| `StructuralVariantAnnotator` | Reassembles SV outcomes (deletions, duplications, inversions, fusions, translocations) | Routed automatically when the variant is a `StructuralVariant` |
 
-Both emit the same `MutationEffect` classes, share a fast path
-for trivial SNVs, and are interchangeable at the output level.
-The difference is internal: protein-diff catches
-boundary-codon cases and frameshift realignments that offset
-arithmetic can miss.
+All three emit the same `MutationEffect` hierarchy. `protein_diff`
+catches boundary-codon and frameshift-realignment cases that
+offset-arithmetic can miss; for trivial SNVs the two produce
+identical output. The SV annotator dispatches on `variant.is_structural`
+and isn't user-selectable for point variants.
 
 ```python
-# Default (fast):
+# Default (protein_diff for point variants, structural_variant for SVs):
 effects = variant.effects()
 
-# Opt into protein-diff (once available):
-effects = variant.effects(annotator="protein_diff")
+# Opt into the legacy fast path:
+effects = variant.effects(annotator="fast")
 
-# Scoped default swap:
-with varcode.use_annotator("protein_diff"):
+# Scoped swap:
+with varcode.use_annotator("fast"):
     effects = variant_collection.effects()
 ```
 
-Third-party annotators (isovar, Exacto) register via the
-registry:
+Third-party annotators (isovar, Exacto) register via the registry:
 
 ```python
 varcode.register_annotator(my_annotator)
@@ -248,63 +184,50 @@ raises a warning on load; wrap `from_csv` in
 `use_annotator(<csv's annotator>)` if you need the original
 annotator's output specifically.
 
-## Structural variants (roadmap)
+## Structural variants
 
-The current `MutantTranscript` handles point variants and
-indels. Fusions, translocations, inversions, and large
-duplications need a multi-source generalization — a
-`reference_segments` alternative to the single
-`reference_transcript` field, where a fusion is two segments
-from two transcripts and a translocation-to-intergenic is one
-transcript segment plus a genomic-interval segment.
+`StructuralVariant` (a `Variant` subclass) carries SV-specific fields:
+`sv_type` (one of `DEL`, `DUP`, `INV`, `INS`, `CNV`, `BND`), `end`,
+breakend mate fields, confidence intervals, and an open-ended `info`
+dict. Pass `parse_structural_variants=True` to `load_vcf` to load
+symbolic ALTs (`<DEL>`, `<INS:ME:ALU>`, `<CN0>`, breakends) as
+`StructuralVariant` objects rather than dropping them.
 
-One DNA event can produce many candidate ORFs that only RNA
-evidence can resolve (long-read transcript assembly from
-Exacto, assembled contigs from isovar). SV annotators return
-`List[MutantTranscript]` wrapped in a `MultiOutcomeEffect`;
-each class gets a prior over outcomes so DNA-only callers can
-still read `.most_likely`:
+```python
+from varcode import load_vcf
 
-- Splice outcomes → existing plausibility tables.
-- Fusions → canonical-transcript preferred, known recurrent
-  junctions short-circuit to possibility-set size 1.
-- Translocations → rank by `(in-frame, ORF length,
-  canonical-transcript involvement)`.
+vc = load_vcf("manta.vcf", parse_structural_variants=True)
+sv_effects = [
+    e for e in vc.effects()
+    if e.variant.__class__.__name__ == "StructuralVariant"
+]
+```
 
-`classify_from_protein_diff` (the 3d classifier) is unchanged
-for SVs — once the mutant protein is materialized,
-classification is the same. The difference is upstream: how
-you build the `MutantTranscript`.
+SV effects (`LargeDeletion`, `LargeDuplication`, `Inversion`,
+`GeneFusion`, `TranslocationToIntergenic`) are `MultiOutcomeEffect`
+subclasses — `e.outcomes` exposes the candidate ORFs / cryptic-splice
+outcomes the annotator generated, ordered by a per-class prior.
+External scorers (RNA evidence, long-read assembly) plug in via
+`apply_rna_evidence_to_effects` to narrow the set or append observed
+outcomes; see [Germline-aware annotation](germline.md) for the same
+composition pattern applied to germline.
 
-Tracked across [#252][i252] (fusions), [#257][i257] (SV
-types), [#259][i259] (RNA evidence), [#299][i299]
-(MultiOutcomeEffect formalization), [#305][i305]
-(splice_outcomes rewrite on MutantTranscript).
+Limitations:
+
+- Mate breakend pairing (joining two `BND` rows that are halves of one
+  translocation) is deferred. Each `BND` row produces its own
+  `StructuralVariant`; consumers can match `MATEID` themselves.
+- `parse_structural_variants=False` is the default. Without the flag,
+  symbolic ALTs are dropped with a warning that names the flag.
 
 ## Downstream consumers
 
-- **topiary** consumes mutant proteins as `ProteinFragment`.
-  The `MutantTranscript` → `ProteinFragment` conversion is 1:1
-  at the prediction boundary: `fragment.sequence =
-  mt.mutant_protein_sequence`; provenance fields carry through
-  as fragment metadata. Use `MutantTranscript` for
-  transcript-level reasoning (splicing, UTR readthrough,
-  codon tables); convert at the prediction boundary.
-- **vaxrank** consumes the `EffectCollection` +
-  `ProteinFragment` pair to score neoantigens. After
-  [#305][i305], splice outcomes deliver `MutantTranscript`s
-  directly; after fusion support, SV events deliver
-  `MultiOutcomeEffect[List[MutantTranscript]]` consumable the
-  same way.
-- **isovar** / **Exacto** plug in as registered annotators,
-  producing `MutantTranscript`s from assembled RNA evidence
-  rather than inferred from DNA alone.
+`MutantTranscript` is the prediction-boundary type for downstream
+neoantigen pipelines (topiary reads `mt.mutant_protein_sequence`;
+vaxrank consumes the `EffectCollection` + protein pair to score
+neoantigens). RNA-evidence callers (isovar, Exacto) plug in either as
+registered annotators or via the `RNAEvidenceResolver` protocol —
+see [Germline-aware annotation](germline.md) for the resolver pattern,
+which the same evidence shape uses across germline / phase / RNA.
 
-[i252]: https://github.com/openvax/varcode/issues/252
-[i257]: https://github.com/openvax/varcode/issues/257
-[i259]: https://github.com/openvax/varcode/issues/259
-[i271]: https://github.com/openvax/varcode/issues/271
 [i297]: https://github.com/openvax/varcode/issues/297
-[i299]: https://github.com/openvax/varcode/issues/299
-[i305]: https://github.com/openvax/varcode/issues/305
-[i309]: https://github.com/openvax/varcode/issues/309

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -79,6 +79,29 @@ assert any(isinstance(e, Failure) for e in effects)
 This is the right choice for batch pipelines that would rather log and
 skip a bad row than halt.
 
+## `GenomeBuildMismatchError`
+
+*New in varcode 4.19.0
+([#268](https://github.com/openvax/varcode/issues/268)).*
+
+Raised by `VariantCollection.effects(germline=...)` when the somatic
+collection and the germline context were called against different
+reference genome builds (e.g. GRCh37 vs GRCh38). Distinct from
+`ReferenceMismatchError`, which is per-variant: this is a top-level
+pre-flight that fails fast on the whole pair so you don't see N
+per-variant errors caused by a build mismatch.
+
+```python
+try:
+    effects = somatic.effects(germline=germline)
+except varcode.GenomeBuildMismatchError as e:
+    e.somatic_reference   # the somatic collection's reference (e.g. 'GRCh38')
+    e.germline_reference  # the germline context's reference (e.g. 'GRCh37')
+```
+
+Subclasses `ValueError`. Pass `validate_reference=False` if you've
+explicitly lifted over and know the builds agree.
+
 ## `SampleNotFoundError`
 
 *New in varcode 2.3.0

--- a/docs/genotype.md
+++ b/docs/genotype.md
@@ -108,21 +108,21 @@ This means `vc.heterozygous_in("tumor")` on a row where tumor is `1/2`
 yields two entries, one per alt — the correct biological
 interpretation.
 
-## What this doesn't do yet
+## Beyond zygosity: phased and germline-aware effects
 
-Three capabilities are deliberately out of scope for 2.3.0:
+The Genotype API gives you the data; downstream effect prediction
+uses it via separate features that landed later:
 
-1. **Effect prediction that uses zygosity.** `variant.effects()` still
-   returns the same output regardless of zygosity. Compound-het
-   reasoning and germline-aware effect prediction depend on the
-   `Genotype` API landing first and will arrive in the personal-genome
-   work tracked under [#270](https://github.com/openvax/varcode/issues/270).
+- **Phased effects of cis variants** — when two variants share a
+  phase set, varcode builds a joint `HaplotypeEffect` via
+  `effects(phase_resolver=...)`. See
+  [#269](https://github.com/openvax/varcode/issues/269).
+- **Germline-aware somatic annotation** — pass a `GermlineContext` to
+  `effects(germline=...)` and somatic variants are classified against
+  the patient's germline-applied transcript. See
+  [Germline-aware annotation](germline.md).
 
-2. **Phased effects.** Phased GTs (`0|1`) and `PS` phase-set tags are
-   preserved on `Genotype` but not yet used to predict joint effects
-   of nearby variants on the same haplotype. Tracked in
-   [#269](https://github.com/openvax/varcode/issues/269).
-
-3. **Dedicated joint-analysis helpers** like `vc.de_novo_in(...)` or
-   `vc.somatic(...)`. The set-operation pattern above covers them;
-   built-in shortcuts will be added if a clear use case emerges.
+Dedicated joint-analysis helpers like `vc.de_novo_in(...)` or
+`vc.somatic(...)` aren't shipped — the set-operation pattern above
+covers them, and shortcuts get added only when a clear use case
+shows up.

--- a/docs/germline.md
+++ b/docs/germline.md
@@ -34,35 +34,17 @@ output is the **possibility set** `{Val→Ile, Ala→Thr}`. With phase
 data, the set collapses to one. varcode produces both shapes
 automatically.
 
-## The pipeline
+## How it composes
 
-```
-Reference transcript
-       │
-       ▼
-GermlineContext applied (in window) ─► patient transcript
-       │                                       │
-       │                              (one or more — phase
-       │                               hypotheses when
-       │                               somatic + germline
-       │                               share a codon and
-       │                               phase is unknown)
-       ▼                                       │
-Somatic variant ──────────────────────────────►│
-                                               │
-                                  ┌────────────┴───────────┐
-                                  ▼                        ▼
-                            Single hypothesis       Multiple hypotheses
-                                  │                        │
-                                  ▼                        ▼
-                           MutationEffect        PhaseAmbiguousEffect
-                          (Substitution, etc.)   (one outcome per
-                                  │                hypothesis)
-                                  ▼                        │
-                            Optional: RNA evidence ────────┘
-                            (collapses set or adds
-                             observed isoforms)
-```
+Germline is a transcript modifier, applied before the somatic variant
+is classified. Effect prediction with `germline=ctx` builds the
+patient haplotype from any germline variants in the somatic's window,
+then asks the annotator how the somatic changes the patient protein.
+When phase between the somatic and one or more germline variants in
+the same codon is unknown, the result is a `PhaseAmbiguousEffect` —
+one classified `MutationEffect` per phase hypothesis, packaged
+together. A `phase_resolver=` collapses the set; an `rna_resolver=`
+collapses it further (or adds observed-isoform outcomes).
 
 ## Quickstart
 
@@ -338,69 +320,39 @@ effects = somatic.effects(germline=germline, validate_reference=False)
 
 ## Lower-level helpers
 
-For callers building custom pipelines, the components are all
-public:
+The high-level `effects(germline=...)` path delegates to
+`predict_germline_aware_effect`. Both that function and
+`apply_germline_to_transcript` (which returns a `MutantTranscript`
+with germline edits applied) are public — call them directly if you
+have a custom annotator or want to translate the patient protein
+without going through full effect prediction. See `varcode.germline`.
 
-```python
-from varcode import (
-    apply_germline_to_transcript,
-    default_germline_window,
-    detect_loh,
-    enumerate_phase_hypotheses,
-    predict_germline_aware_effect,
-)
-```
+## Limitations
 
-`apply_germline_to_transcript(transcript, germline_ctx, somatic=None)`
-returns a `MutantTranscript` with germline edits applied — useful
-if you want to translate the patient protein for cohort analysis
-without going through full effect prediction.
-
-`predict_germline_aware_effect(somatic, transcript, germline_ctx, annotator, phase_resolver=None)`
-is the single entry point that the high-level `effects(germline=)`
-kwarg dispatches to. Call it directly if you have a custom
-annotator or want per-(variant, transcript) control.
-
-## Limitations and what's deferred
-
-v1 ships the input contract, transcript modification, phase
-enumeration, LOH detection, and basic splice-signal handling. The
-following are documented limitations, not bugs:
-
-- **Splice-signal-disrupted germline downgrade**: when germline
-  already disrupts a splice site that the somatic also targets,
-  the patient transcript carries the germline edit so the simple
-  cases work — but an explicit "germline already broke this;
-  downgrade severity" path is not separately encoded.
-- **Mitochondrial codon table**: chrM is correctly identified as
-  hemizygous (single-haplotype) but uses the standard nuclear
-  codon table for translation. Mitochondrial variants in the
-  protein-coding region will produce mis-classified amino acid
-  changes.
-- **Tumor heterogeneity / subclonal somatic**: every somatic
-  variant is treated as if present in 100% of cells. Allele
-  frequencies in the somatic VCF are not used to weight effects.
-- **CNV-aware dosage**: copy number changes in the tumor affect
-  effective dosage of variants but not the per-haplotype protein
-  sequence varcode predicts.
-- **Compound interactions across more than 3 germline variants in a
-  window**: caps at 8 hypotheses by default (raise via
-  `max_hypotheses=` if your pipeline tolerates more).
-- **VCF normalization**: differences in left-alignment / MNV split
-  between the somatic and germline VCFs cause apparent
-  position mismatches. Normalize both with the same tool
-  (`bcftools norm`) before loading.
-- **Population-frequency-based germline**: gnomAD / ExAC as a
-  probabilistic germline substitute for tumor-only callers is a
-  future direction.
-- **Trio joint analysis**: pass one germline at a time.
-- **`docs/germline.md` is what you're reading; the edge-case test
-  corpus at scale (real trio data, multi-allelic, etc.) is still
-  to come.**
+- **Germline-disrupted splice sites get no explicit downgrade.** When
+  germline already breaks a splice signal that the somatic also
+  targets, the patient transcript carries the germline edit, so
+  classification runs against the patient signal — but there's no
+  separate "germline already broke this; downgrade severity" path.
+- **Mitochondrial variants use the nuclear codon table.** chrM is
+  correctly identified as hemizygous, but mitochondrial protein
+  translation uses a different codon table that varcode doesn't
+  apply. Amino-acid changes in chrM coding regions will be
+  mis-classified.
+- **Subclonal somatic and CNV dosage are not modeled.** Every somatic
+  variant is treated as present in 100% of cells; copy-number changes
+  don't affect per-haplotype protein prediction.
+- **Hypothesis cap of 8** by default when phase is unknown across
+  multiple germline variants in a window. Raise via `max_hypotheses=`
+  if your pipeline tolerates more.
+- **Normalization mismatch between germline and somatic VCFs** (left-
+  alignment, MNV split) causes apparent position mismatches.
+  Normalize both with the same tool before loading.
+- **Population-frequency germline (gnomAD/ExAC) as a substitute for
+  patient germline** is not in v1.
 
 ## See also
 
-- [#268](https://github.com/openvax/varcode/issues/268) — umbrella issue with full v1 acceptance criteria.
-- [#360](https://github.com/openvax/varcode/pull/360) — unified PR that landed germline-aware effect prediction.
+- [#268](https://github.com/openvax/varcode/issues/268) — umbrella issue with the v1 acceptance criteria.
 - [Effect annotation](effect_annotation.md) — pipeline overview.
-- [Genotypes & sample queries](genotype.md) — sample-aware filtering on `VariantCollection`.
+- [Genotypes & sample queries](genotype.md) — sample-aware filtering.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,16 +31,20 @@ for a longer walkthrough and the effect-class table.
 
 ## Feature guides
 
-- [**Effect annotation**](effect_annotation.md) — how variants
-  become effects, splice outcome representations, pluggable
-  annotators, possibility sets for ambiguous outcomes, and the
-  SV-extensibility roadmap. Start here.
+- [**Effect annotation**](effect_annotation.md) — how variants become
+  effects, splice outcome representations, pluggable annotators,
+  possibility sets for ambiguous outcomes, and structural variants.
+  Start here.
+- [**Germline-aware annotation**](germline.md) — classify somatic
+  variants against the patient's germline-applied transcript;
+  possibility sets when phase is unknown; LOH detection. New in 4.19.
 - [**Genotypes and sample-aware queries**](genotype.md) — per-sample
-  zygosity on multi-sample VCFs. New in 2.3.
+  zygosity on multi-sample VCFs.
 - [**CSV round-trip and metadata headers**](csv.md) — `to_csv` /
-  `from_csv`, genome recovered from the header. New in 2.1, refined in 2.2.
+  `from_csv` with genome recovered from the header.
 - [**Error handling**](errors.md) — `ReferenceMismatchError`,
-  `SampleNotFoundError`, and `raise_on_error=False`.
+  `GenomeBuildMismatchError`, `SampleNotFoundError`, and
+  `raise_on_error=False`.
 
 ## API reference
 


### PR DESCRIPTION
## Summary

User flagged the ASCII flowcharts I'd put in \`germline.md\` and asked for a wider docs audit. Did both. Net change: 333 lines added / 297 removed across 8 files.

## What changed

**Removed user-flagged ASCII art.**
- \`germline.md\`: dropped the 25-line pipeline diagram. Replaced with a 5-line "How it composes" prose paragraph that names the same flow.
- \`effect_annotation.md\`: dropped the smaller box-arrow diagram at the top. Replaced with prose.

**Defrosted stale roadmap-y claims** where the work shipped:
- \`effect_annotation.md\` described \`ProteinDiffEffectAnnotator\` as "#309 — WIP" but it's been the default since 4.18. Now lists all three annotators (\`protein_diff\` / \`fast\` / \`structural_variant\`) with their actual selection rules.
- \`effect_annotation.md\`'s "Structural variants (roadmap)" section described unimplemented work; #357 shipped end-to-end SV loading and annotation. Rewritten as a working-feature description with the real remaining limitations (mate breakend pairing, \`parse_structural_variants=False\` default).
- \`effect_annotation.md\`'s splice section had ~100 lines explaining the relationship between \`ExonicSpliceSite\` and \`SpliceOutcomeSet\`. Trimmed to the essential table + one paragraph. Same content, half the words.
- \`effect_annotation.md\`'s "Downstream consumers" section was a forward-looking description of topiary/vaxrank/isovar integration. Replaced with a brief note pointing at the resolver pattern in \`germline.md\`.
- \`genotype.md\`'s "What this doesn't do yet" listed phased effects (#269) and germline-aware (#268) as deferred; both shipped. Replaced with a "Beyond zygosity" section pointing at the live features.
- \`csv.md\` dropped the "(tracked in #271)" parenthetical — #271 is closed.

**Filled public-surface gaps:**
- \`docs/index.md\` links the germline guide.
- \`README.md\`: refreshed Further-reading list (effect annotation, germline, genotypes, CSV, errors), points at the live docs site, fixed coverage badge URL (\`master\` → \`main\`).
- \`docs/api.md\`: added entries for everything missing since the file was last touched — \`StructuralVariant\`, \`parse_symbolic_alt\`, \`SV_TYPES\`, \`MultiOutcomeEffect\`, \`Outcome\`, \`MutantTranscript\`, the annotator classes and registry, the phasing resolvers, the RNA-evidence protocol + helpers, the germline-aware API, \`GenomeBuildMismatchError\`, \`UnsupportedVariantError\`. Reorganized into per-feature sections.
- \`errors.md\`: added \`GenomeBuildMismatchError\` (4.19.0).

**Trimmed slop in my own germline.md** (last release): 80-line "limitations and what's deferred" reduced to 6 bullets covering the actually-load-bearing limits. "Lower-level helpers" subsection was a roadmap; trimmed to a 4-line pointer at the public functions. Page drops from 406 lines to ~290.

## Test plan

- [x] \`mkdocs build --strict\` — clean (modulo the unrelated Material theme deprecation banner)
- [x] \`./test.sh\` — 1114 passed, 2 skipped
- [x] \`./lint.sh\` — clean
- [x] Spot-checked rendered HTML: no ASCII art remains, "How it composes" prose renders, helpers section trimmed
- [x] Auto-deploys to GitHub Pages on merge.