### PR TITLE
Remove stale mt codon-table limitation note (closes #365, #44)

### DIFF
--- a/docs/germline.md
+++ b/docs/germline.md
@@ -334,11 +334,6 @@ without going through full effect prediction. See `varcode.germline`.
   targets, the patient transcript carries the germline edit, so
   classification runs against the patient signal — but there's no
   separate "germline already broke this; downgrade severity" path.
-- **Mitochondrial variants use the nuclear codon table.** chrM is
-  correctly identified as hemizygous, but mitochondrial protein
-  translation uses a different codon table that varcode doesn't
-  apply. Amino-acid changes in chrM coding regions will be
-  mis-classified.
 - **Subclonal somatic and CNV dosage are not modeled.** Every somatic
   variant is treated as present in 100% of cells; copy-number changes
   don't affect per-haplotype protein prediction.

--- a/tests/test_mitochondrial.py
+++ b/tests/test_mitochondrial.py
@@ -215,6 +215,41 @@ def test_mt_ata_reference_is_met_not_ile():
 
 
 # ====================================================================
+# Germline-aware effect prediction on MT
+# ====================================================================
+
+
+def test_germline_aware_mt_classification_uses_vertebrate_table():
+    """Germline-aware classification on chrM must route through the
+    vertebrate mitochondrial codon table — the patient-baseline
+    translation has to use table 2 just like reference-relative
+    translation does, otherwise the same TGA->stop / AGA->Arg
+    mis-classifications would resurface in the germline path.
+    """
+    from varcode import GermlineContext, predict_germline_aware_effect
+    from varcode.annotators.registry import get_annotator
+
+    transcript = ensembl_grch38.transcript_by_id(MT_CO1_TRANSCRIPT_ID)
+    annotator = get_annotator("protein_diff")
+
+    # Somatic TCA->TGA at aa 279: Ser->Trp under mt (would be
+    # PrematureStop under standard).
+    somatic = Variant("MT", 6739, "C", "G", ensembl_grch38)
+    # Unrelated germline far upstream so phase enumeration is trivial.
+    germline = Variant("MT", 6098, "A", "T", ensembl_grch38)
+    gctx = GermlineContext.from_variants([germline])
+
+    effect = predict_germline_aware_effect(
+        somatic, transcript, gctx, annotator)
+    assert type(effect).__name__ == "Substitution", (
+        "Germline-aware mt classification regressed to nuclear table: "
+        "got %s (%s). Expected Substitution S->W under mt table."
+        % (type(effect).__name__, effect.short_description))
+    assert effect.aa_ref == "S"
+    assert effect.aa_alt == "W"
+
+
+# ====================================================================
 # Back-compat: module-level constants still point at standard table
 # ====================================================================
 

--- a/varcode/germline.py
+++ b/varcode/germline.py
@@ -584,14 +584,15 @@ class GermlineContext:
 #
 # Out of scope for v1 (refinements that don't change this API):
 #   * Splice-signal recomputation when germline already disrupts a
-#     splice site varcode would otherwise classify against (#285).
+#     splice site varcode would otherwise classify against (#363).
 #     Falls out partially because the patient transcript carries the
 #     germline edits, but downgrade-by-already-broken needs targeted
 #     work.
-#   * Mitochondrial codon table (different from nuclear; chrM is
-#     skipped for now with a flag).
 #   * Coverage-track-aware "unknown" regions (for SPARSE contexts
 #     with explicit BedGraph coverage).
+# Mitochondrial codon table (NCBI table 2) is selected automatically
+# from the transcript's contig — see
+# ``varcode.effects.codon_tables.codon_table_for_transcript``.
 # =====================================================================
 
 


### PR DESCRIPTION
## Summary

- The vertebrate mitochondrial codon table is already applied to chrM transcripts (since #294 / #300, commit d255d18). The dispatch in `varcode.effects.codon_tables.codon_table_for_transcript` threads through every translation path — `translate.py`, `protein_diff.py`, `fast_path.py`, `splice_outcomes.py`, `effect_prediction_coding_in_frame.py`, `effect_prediction_coding_frameshift.py`, `structural_variant.py`, and `mutant_transcript._translate_from_cds`.
- The limitation note in `docs/germline.md` and the matching out-of-scope comment in `varcode/germline.py` were copy-pasted from the original germline design and never refreshed when #294 landed. Removed both.
- Added a germline+mt integration test that locks in table-2 dispatch on the germline-aware path: a TGA-creating somatic variant on MT-CO1 must classify as `Substitution(S→W)` under the germline-aware annotator, not `PrematureStop`.

## NUMTs

Distinguishing NUMTs from real mt genes falls out of contig-based dispatch: NUMTs sit on nuclear contigs (chr1, chr5, ...) by construction, so `codon_table_for_transcript` selects the standard table for them. The MT contig in Ensembl annotations contains only the 13 real protein-coding mt genes + tRNAs + rRNAs.

## Test plan

- [x] `python -m pytest tests/test_mitochondrial.py` — 22 pass (was 21).
- [x] `python -m pytest tests/test_germline_effects.py tests/test_germline_context.py` — 70 pass.