### PR TITLE
varcode.transforms + pair_breakends (#364, planning + scaffold)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -169,6 +169,12 @@ Auto-generated from in-source docstrings via
 
 ::: varcode.default_germline_window
 
+## VariantCollection transforms
+
+### `varcode.transforms.pair_breakends`
+
+::: varcode.transforms.pair_breakends
+
 ## File loading
 
 ### `varcode.load_vcf`

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,9 @@ for a longer walkthrough and the effect-class table.
   possibility sets when phase is unknown; LOH detection. New in 4.19.
 - [**Genotypes and sample-aware queries**](genotype.md) — per-sample
   zygosity on multi-sample VCFs.
+- [**VariantCollection transforms**](transforms.md) — pure
+  `VC -> VC` refinements; ships `pair_breakends` for collapsing
+  MATEID-paired BND rows into one combined variant.
 - [**CSV round-trip and metadata headers**](csv.md) — `to_csv` /
   `from_csv` with genome recovered from the header.
 - [**Error handling**](errors.md) — `ReferenceMismatchError`,

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -1,0 +1,143 @@
+# VariantCollection transforms
+
+A **transform** is a pure function: given a `VariantCollection` and
+optional auxiliary inputs (reference, phase resolver, ...), it returns
+a new `VariantCollection`. Cardinality may be preserved, reduced, or
+increased. Composition is by application — no registry, no protocol.
+
+The pattern lives in `varcode.transforms`. As of 4.20.0 it ships one
+transform, `pair_breakends`; the module is designed to grow.
+
+## The contract
+
+Every transform owes three things, documented in its docstring:
+
+| Field | Meaning |
+|---|---|
+| **Cardinality** | `preserves`, `reduces`, or `increases`. |
+| **Provenance** | Every output variant carries `source_variants: tuple[Variant, ...]`. Empty tuple for pass-through; one element for derived-from-one; two or more for combined. Not part of hash/equality. |
+| **Metadata behavior** | Explicit rule for how `source_to_metadata_dict` entries flow through (which fields are inherited from which source, which require agreement, what happens on disagreement). |
+
+Transforms are **idempotent on inputs they don't recognize**. Running
+`pair_breakends` twice produces the same VC; the second pass finds no
+unpaired BNDs to combine because every combined row's `source_variants`
+is already populated.
+
+Composition is just function application:
+
+```python
+import varcode
+from varcode.transforms import pair_breakends
+
+vc = varcode.load_vcf("tumor.vcf", genome="GRCh38",
+                     parse_structural_variants=True)
+vc = pair_breakends(vc)
+effects = vc.effects()
+```
+
+## `pair_breakends`
+
+Merges MATEID-paired BND rows into a single combined
+`StructuralVariant`. **Reduces.**
+
+A VCF can represent the same translocation event two ways:
+
+| Caller pattern | Input rows | After `pair_breakends` |
+|---|---|---|
+| Manta / DELLY / SVABA / newer GRIDSS | Two BND rows linked by `MATEID` | One combined row, `source_variants=(a, b)` |
+| Older GRIDSS | Two BND rows linked by `PARID` | One combined row (PARID treated as MATEID alias) |
+| BreakDancer / CREST / older DELLY | One row, `SVTYPE=TRA`, `CHR2`/`END` in INFO | Pass-through, `source_variants=()` |
+| GRIDSS unresolved single-end | One BND row, no `MATEID` | Pass-through |
+
+The point is **caller-uniformity after the transform**: regardless of
+which caller produced the VCF, effect prediction sees one variant per
+rearrangement event.
+
+### Usage
+
+```python
+from varcode import load_vcf
+from varcode.transforms import pair_breakends
+
+vc = load_vcf("manta.vcf", genome="GRCh38",
+              parse_structural_variants=True)
+vc = pair_breakends(vc)
+
+# Each combined variant carries both endpoints + provenance.
+for v in vc:
+    if v.sv_type == "BND" and v.source_variants:
+        bnd_a, bnd_b = v.source_variants
+        print(f"{v.contig}:{v.start} <-> {v.mate_contig}:{v.mate_start} "
+              f"from rows {bnd_a.info.get('paired_with')} + "
+              f"{v.info.get('paired_with')}")
+
+effects = vc.effects()
+```
+
+### Pairing rules
+
+1. **Primary key**: `MATEID` on the variant's `info` dict matched
+   against VCF row IDs captured at load time.
+2. **Alias**: `PARID` (older GRIDSS) is treated as `MATEID`.
+3. **Symmetric**: A.mateid must equal B.id **and** B.mateid must equal
+   A.id. Asymmetric references log a warning and pass through.
+4. **In-degree 1**: each ID must be referenced by exactly one other
+   row's MATEID. If any ID has incoming degree > 1, the whole
+   connected component is left unpaired with a warning.
+5. **Mate present**: if a MATEID points to an ID not in this
+   collection (filtered out, chunked load), the half passes through
+   with a warning.
+
+### Metadata merge
+
+The combined variant's per-source metadata entry is built fresh:
+
+| Field | Rule |
+|---|---|
+| `id` | A's ID (lex-earlier of the two). |
+| `qual` | `min(A.qual, B.qual)` when both present. |
+| `filter` | Union of FILTER tokens; `PASS` drops out if any non-PASS label appears. |
+| `info` | A's values; `MATEID`/`PARID` removed (no longer meaningful); `paired_with` added pointing at B's ID. |
+| `sample_info` | Per-sample: GT must match across A and B (raises on disagreement); other FORMAT fields taken from A. |
+| `alt_assembly` | One populated -> use it. Both equal -> use shared. Both differ -> A's wins with warning. |
+
+The strict-GT rule is intentional: both halves of a legitimate paired
+BND describe the same biological event, so disagreement indicates
+either a caller bug (asymmetric filtering, separate re-genotyping per
+half) or a real analytical concern. The transform raises with both
+row IDs and both GT values so the problem surfaces.
+
+### Trade-off: single fusion direction post-collapse
+
+A reciprocal translocation produces two derivative chromosomes
+(`der(15)t(15;19)` and `der(19)t(15;19)` for BRD4-NUTM1). Pre-pair,
+varcode emits one `GeneFusion` effect per half × overlapping
+transcript — so both fusion directions are represented. Post-pair,
+the combined variant is anchored at the lex-earlier endpoint, so
+effects represent that single direction.
+
+The other direction is reachable: `combined.source_variants` returns
+both originals, and you can annotate the other half directly:
+
+```python
+combined = next(v for v in vc if v.source_variants)
+other_direction = combined.source_variants[1].effects()
+```
+
+If you want both directions in the same effect collection without
+running `pair_breakends`, just don't run it — the parser already
+emits both halves.
+
+## Roadmap
+
+Transforms planned for future PRs. Each lands as its own ticket; all
+follow the contract above.
+
+| Transform | Cardinality | Brief |
+|---|---|---|
+| `combine_cis_snvs(vc, phase_resolver)` | reduces | Adjacent in-codon SNVs sharing a phase set merge into MNVs. |
+| `left_align_indels(vc, reference)` | preserves | Canonical-position indel normalization. |
+| `split_multiallelic(vc)` | increases | One variant per ALT for multi-ALT rows (today's implicit parse-time behavior, as an explicit transform). |
+| `decompose_mnvs(vc)` | increases | Inverse of `combine_cis_snvs`. Useful for cross-tool comparison. |
+
+See the [API reference](api.md) for `varcode.transforms.pair_breakends`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
       - Effect annotation: effect_annotation.md
       - Germline-aware annotation: germline.md
       - Genotypes & sample queries: genotype.md
+      - VariantCollection transforms: transforms.md
       - CSV round-trip: csv.md
       - Error handling: errors.md
   - API reference: api.md

--- a/tests/test_transforms_pair_breakends.py
+++ b/tests/test_transforms_pair_breakends.py
@@ -1,0 +1,467 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for :func:`varcode.transforms.pair_breakends` (#364).
+
+Covers the test matrix from PR #367:
+
+* Paired BND collapse across Manta / DELLY / GRIDSS-style inputs.
+* Pass-through cases — non-BND, single-row TRA, single-ended BND.
+* Edge cases — mate-missing-from-VC, N-way collision, asymmetric
+  MATEID, disagreeing genotypes, disagreeing alt_assembly.
+* Idempotence, mixed VC, empty VC, source_variants provenance.
+"""
+
+import os
+import tempfile
+import warnings
+
+import pytest
+
+from varcode import StructuralVariant, Variant, load_vcf
+from varcode.transforms import pair_breakends
+
+
+# --------------------------------------------------------------------
+# Fixture helpers
+# --------------------------------------------------------------------
+
+
+def _write_vcf(body: str) -> str:
+    fd, path = tempfile.mkstemp(suffix=".vcf")
+    with os.fdopen(fd, "w") as f:
+        f.write(body)
+    return path
+
+
+_HEADER = (
+    "##fileformat=VCFv4.2\n"
+    "##reference=GRCh38\n"
+    "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"type\">\n"
+    "##INFO=<ID=END,Number=1,Type=Integer,Description=\"end\">\n"
+    "##INFO=<ID=MATEID,Number=1,Type=String,Description=\"mate\">\n"
+    "##INFO=<ID=PARID,Number=1,Type=String,Description=\"partner\">\n"
+    "##INFO=<ID=INSSEQ,Number=1,Type=String,Description=\"inserted seq\">\n"
+    "##INFO=<ID=CHR2,Number=1,Type=String,Description=\"mate chrom\">\n"
+    "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+)
+
+
+def _load(body: str, only_passing: bool = True):
+    path = _write_vcf(_HEADER + body)
+    try:
+        return load_vcf(
+            path, genome="GRCh38",
+            parse_structural_variants=True,
+            only_passing=only_passing)
+    finally:
+        os.unlink(path)
+
+
+def _bnds(vc):
+    return [v for v in vc if getattr(v, "sv_type", None) == "BND"]
+
+
+# --------------------------------------------------------------------
+# 1. Manta paired BND
+# --------------------------------------------------------------------
+
+
+def test_manta_paired_bnd_collapses_to_single_combined():
+    """Two symmetric BND rows merge into one combined StructuralVariant
+    with source_variants pointing at both originals."""
+    body = (
+        "19\t15250000\tbnd1\tG\tG]15:34350000]\t100\tPASS\tMATEID=bnd2\n"
+        "15\t34350000\tbnd2\tA\tA[19:15250000[\t100\tPASS\tMATEID=bnd1\n"
+    )
+    vc = _load(body)
+    assert len(_bnds(vc)) == 2
+
+    out = pair_breakends(vc)
+    bnds = _bnds(out)
+    assert len(bnds) == 1
+    combined = bnds[0]
+    # Deterministic primary: lex-earlier source row ID is "bnd1" -> chr19.
+    assert combined.contig == "19"
+    assert combined.start == 15_250_000
+    assert combined.mate_contig == "15"
+    assert combined.mate_start == 34_350_000
+    assert len(combined.source_variants) == 2
+    source_contigs = sorted(v.contig for v in combined.source_variants)
+    assert source_contigs == ["15", "19"]
+
+
+# --------------------------------------------------------------------
+# 2. DELLY-style paired BND (different ID format)
+# --------------------------------------------------------------------
+
+
+def test_delly_paired_bnd_with_long_ids():
+    """DELLY-style IDs are longer (``DEL00000001`` etc.) but the
+    MATEID mechanism is identical."""
+    body = (
+        "19\t15250000\tDEL00000001_1\tG\tG]15:34350000]\t100\tPASS\t"
+        "MATEID=DEL00000001_2\n"
+        "15\t34350000\tDEL00000001_2\tA\tA[19:15250000[\t100\tPASS\t"
+        "MATEID=DEL00000001_1\n"
+    )
+    vc = _load(body)
+    out = pair_breakends(vc)
+    bnds = _bnds(out)
+    assert len(bnds) == 1
+    assert len(bnds[0].source_variants) == 2
+
+
+# --------------------------------------------------------------------
+# 3. GRIDSS paired BND with PARID
+# --------------------------------------------------------------------
+
+
+def test_gridss_paired_bnd_with_parid_alias():
+    """Older GRIDSS uses PARID instead of MATEID. The transform treats
+    them as aliases."""
+    body = (
+        "19\t15250000\tgridss1o\tG\tG]15:34350000]\t100\tPASS\t"
+        "PARID=gridss1h\n"
+        "15\t34350000\tgridss1h\tA\tA[19:15250000[\t100\tPASS\t"
+        "PARID=gridss1o\n"
+    )
+    vc = _load(body)
+    out = pair_breakends(vc)
+    bnds = _bnds(out)
+    assert len(bnds) == 1
+    assert len(bnds[0].source_variants) == 2
+
+
+# --------------------------------------------------------------------
+# 4. BreakDancer-style single-row TRA (no MATEID)
+# --------------------------------------------------------------------
+
+
+def test_single_row_translocation_passes_through():
+    """A BreakDancer/CREST-style single-row TRA (symbolic ALT, no
+    MATEID) passes through unchanged."""
+    body = (
+        "19\t15250000\ttra1\tN\t<TRA>\t100\tPASS\tSVTYPE=TRA;CHR2=15;END=34350000\n"
+    )
+    vc = _load(body)
+    # The symbolic <TRA> currently falls back to sv_type="BND" via the
+    # parser's unknown-token path, which is the right shape for pairing
+    # to skip it (no MATEID).
+    out = pair_breakends(vc)
+    assert len(out) == 1
+    assert out[0].source_variants == ()
+
+
+# --------------------------------------------------------------------
+# 5. Single-ended BND (no MATEID)
+# --------------------------------------------------------------------
+
+
+def test_single_ended_bnd_without_mateid_passes_through():
+    """A BND without MATEID — e.g. GRIDSS's unresolved single-end
+    breakend representation — passes through."""
+    body = (
+        "19\t15250000\tbnd1\tG\tG]15:34350000]\t100\tPASS\t.\n"
+    )
+    vc = _load(body)
+    out = pair_breakends(vc)
+    bnds = _bnds(out)
+    assert len(bnds) == 1
+    assert bnds[0].source_variants == ()
+
+
+# --------------------------------------------------------------------
+# 6. Mate-missing-from-VC
+# --------------------------------------------------------------------
+
+
+def test_mate_missing_from_vc_warns_and_passes_through():
+    """When MATEID references an ID not in this collection, the
+    half passes through with a warning."""
+    body = (
+        "19\t15250000\tbnd1\tG\tG]15:34350000]\t100\tPASS\tMATEID=bnd2\n"
+    )
+    vc = _load(body)
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        out = pair_breakends(vc)
+    msgs = [str(w.message) for w in captured]
+    assert any("mate" in m.lower() and "bnd2" in m for m in msgs), msgs
+    bnds = _bnds(out)
+    assert len(bnds) == 1
+    assert bnds[0].source_variants == ()
+
+
+# --------------------------------------------------------------------
+# 7. N-way MATEID collision
+# --------------------------------------------------------------------
+
+
+def test_three_way_mateid_collision_leaves_group_unpaired():
+    """Three rows referencing the same MATEID group are left
+    unpaired with a warning. (Each row's MATEID points at the
+    same id, creating a degenerate pairing group.)"""
+    body = (
+        "19\t15250000\tbnd1\tG\tG]15:34350000]\t100\tPASS\tMATEID=bnd2\n"
+        "15\t34350000\tbnd2\tA\tA[19:15250000[\t100\tPASS\tMATEID=bnd1\n"
+        "19\t15260000\tbnd3\tG\tG]15:34350000]\t100\tPASS\tMATEID=bnd2\n"
+    )
+    vc = _load(body)
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        out = pair_breakends(vc)
+    msgs = [str(w.message) for w in captured]
+    assert any("ambiguous" in m.lower() or "members" in m.lower()
+               for m in msgs), msgs
+    # All three pass through unpaired.
+    bnds = _bnds(out)
+    assert len(bnds) == 3
+    assert all(b.source_variants == () for b in bnds)
+
+
+# --------------------------------------------------------------------
+# 8. Asymmetric MATEID
+# --------------------------------------------------------------------
+
+
+def test_asymmetric_mateid_leaves_pair_unpaired():
+    """A.mateid == B.id but B.mateid != A.id is asymmetric. The pair
+    is left unpaired with a warning."""
+    body = (
+        "19\t15250000\tbnd1\tG\tG]15:34350000]\t100\tPASS\tMATEID=bnd2\n"
+        "15\t34350000\tbnd2\tA\tA[19:15250000[\t100\tPASS\tMATEID=bndX\n"
+    )
+    vc = _load(body)
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        out = pair_breakends(vc)
+    msgs = [str(w.message) for w in captured]
+    assert any("asymmetric" in m.lower() or "mate" in m.lower()
+               for m in msgs), msgs
+    bnds = _bnds(out)
+    assert len(bnds) == 2
+    assert all(b.source_variants == () for b in bnds)
+
+
+# --------------------------------------------------------------------
+# 9. Disagreeing genotypes raise
+# --------------------------------------------------------------------
+
+
+def test_disagreeing_genotypes_raise():
+    """Both halves of a paired BND describe the same biological event;
+    disagreeing per-sample GT indicates a caller bug. The transform
+    raises rather than silently coercing."""
+    header_with_sample = (
+        "##fileformat=VCFv4.2\n"
+        "##reference=GRCh38\n"
+        "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"t\">\n"
+        "##INFO=<ID=MATEID,Number=1,Type=String,Description=\"m\">\n"
+        "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"gt\">\n"
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tTUMOR\n"
+        "19\t15250000\tbnd1\tG\tG]15:34350000]\t100\tPASS\tMATEID=bnd2\tGT\t0/1\n"
+        "15\t34350000\tbnd2\tA\tA[19:15250000[\t100\tPASS\tMATEID=bnd1\tGT\t1/1\n"
+    )
+    path = _write_vcf(header_with_sample)
+    try:
+        vc = load_vcf(path, genome="GRCh38", parse_structural_variants=True)
+    finally:
+        os.unlink(path)
+    with pytest.raises(ValueError, match="disagree on genotype"):
+        pair_breakends(vc)
+
+
+# --------------------------------------------------------------------
+# 10. Disagreeing alt_assembly warns, A wins
+# --------------------------------------------------------------------
+
+
+def test_disagreeing_alt_assembly_warns_a_wins():
+    """When the two halves carry different INSSEQ assemblies, the
+    transform warns and keeps A's (lex-earlier ID). Both originals
+    remain reachable via source_variants."""
+    # INS-style assembly carried on BND rows is non-standard but
+    # representative — Manta's BND output sometimes ships partial
+    # INSSEQ when local assembly partially resolved the join.
+    a = StructuralVariant(
+        contig="19", start=15_250_000, sv_type="BND",
+        alt="G]15:34350000]", mate_contig="15",
+        mate_start=34_350_000, alt_assembly="ACGTA",
+        info={"mateid": "bnd2"},
+        genome="GRCh38",
+    )
+    b = StructuralVariant(
+        contig="15", start=34_350_000, sv_type="BND",
+        alt="A[19:15250000[", mate_contig="19",
+        mate_start=15_250_000, alt_assembly="TTTTT",
+        info={"mateid": "bnd1"},
+        genome="GRCh38",
+    )
+    from varcode import VariantCollection
+    metadata = {
+        "synth": {
+            a: {"id": "bnd1", "info": {"MATEID": "bnd2"}},
+            b: {"id": "bnd2", "info": {"MATEID": "bnd1"}},
+        }
+    }
+    vc = VariantCollection(
+        variants=[a, b],
+        sources={"synth"},
+        source_to_metadata_dict=metadata,
+    )
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        out = pair_breakends(vc)
+    msgs = [str(w.message) for w in captured]
+    assert any("alt_assembly" in m for m in msgs), msgs
+    bnds = _bnds(out)
+    assert len(bnds) == 1
+    # A's id is "bnd1" -> lex-earlier; combined inherits its assembly.
+    assert bnds[0].alt_assembly == "ACGTA"
+
+
+# --------------------------------------------------------------------
+# 11. Mixed VC: SNVs + paired BNDs + DEL + single-row TRA
+# --------------------------------------------------------------------
+
+
+def test_mixed_vc_only_paired_bnds_collapse():
+    body = (
+        "1\t1000\t.\tA\tT\t100\tPASS\t.\n"
+        "1\t2000\t.\tG\tC\t100\tPASS\t.\n"
+        "22\t51179178\tdel1\tA\t<DEL>\t100\tPASS\tSVTYPE=DEL;END=51179500\n"
+        "19\t15250000\tbnd1\tG\tG]15:34350000]\t100\tPASS\tMATEID=bnd2\n"
+        "15\t34350000\tbnd2\tA\tA[19:15250000[\t100\tPASS\tMATEID=bnd1\n"
+    )
+    vc = _load(body)
+    assert len(vc) == 5  # 2 SNVs + DEL + 2 BNDs
+    out = pair_breakends(vc)
+    assert len(out) == 4  # 2 SNVs + DEL + 1 combined BND
+
+    bnds = _bnds(out)
+    assert len(bnds) == 1
+    assert len(bnds[0].source_variants) == 2
+
+    # Non-BND variants pass through with empty source_variants.
+    non_bnd = [v for v in out if getattr(v, "sv_type", None) != "BND"]
+    assert all(v.source_variants == () for v in non_bnd)
+
+
+# --------------------------------------------------------------------
+# 12. Idempotence
+# --------------------------------------------------------------------
+
+
+def test_idempotent_on_already_paired_input():
+    """Running pair_breakends twice produces the same VC the second
+    time — the combined variant's source_variants is non-empty, so it
+    skips re-pairing."""
+    body = (
+        "19\t15250000\tbnd1\tG\tG]15:34350000]\t100\tPASS\tMATEID=bnd2\n"
+        "15\t34350000\tbnd2\tA\tA[19:15250000[\t100\tPASS\tMATEID=bnd1\n"
+    )
+    vc = _load(body)
+    once = pair_breakends(vc)
+    twice = pair_breakends(once)
+    assert len(once) == len(twice) == 1
+    # Same combined variant (object identity not required; semantic
+    # equality is enough).
+    assert once[0].contig == twice[0].contig
+    assert once[0].start == twice[0].start
+    assert once[0].mate_contig == twice[0].mate_contig
+    assert once[0].mate_start == twice[0].mate_start
+    # source_variants preserved across the second call.
+    assert len(twice[0].source_variants) == 2
+
+
+# --------------------------------------------------------------------
+# 13. Empty VC
+# --------------------------------------------------------------------
+
+
+def test_empty_vc_passes_through():
+    from varcode import VariantCollection
+    vc = VariantCollection(variants=[], source_to_metadata_dict={})
+    out = pair_breakends(vc)
+    assert len(out) == 0
+
+
+# --------------------------------------------------------------------
+# 14. source_variants is not part of hash/equality
+# --------------------------------------------------------------------
+
+
+def test_source_variants_not_in_hash_or_equality():
+    """``source_variants`` is provenance, not identity. Two variants
+    with the same (contig, start, ref, alt, reference_name) but
+    different source_variants compare equal and hash identically."""
+    v_plain = Variant("1", 100, "A", "T", "GRCh38")
+    v_with_source = Variant("1", 100, "A", "T", "GRCh38")
+    v_with_source.source_variants = (Variant("1", 99, "A", "T", "GRCh38"),)
+    assert v_plain == v_with_source
+    assert hash(v_plain) == hash(v_with_source)
+
+
+# --------------------------------------------------------------------
+# 15. Metadata round-trip — combined variant has its own metadata
+# --------------------------------------------------------------------
+
+
+def test_combined_variant_has_merged_metadata_entry():
+    """After pairing, the combined variant has a single metadata
+    entry per source path with the merged qual/filter/info."""
+    body = (
+        "19\t15250000\tbnd1\tG\tG]15:34350000]\t50\tPASS\tMATEID=bnd2\n"
+        "15\t34350000\tbnd2\tA\tA[19:15250000[\t30\tLowQual\tMATEID=bnd1\n"
+    )
+    vc = _load(body, only_passing=False)
+    out = pair_breakends(vc)
+    combined = _bnds(out)[0]
+    # Single source path, one metadata entry for the combined variant.
+    source_path = next(iter(out.source_to_metadata_dict))
+    meta = out.source_to_metadata_dict[source_path][combined]
+    # qual: min(50, 30) = 30.
+    assert meta["qual"] == 30
+    # filter: union; LowQual wins over PASS.
+    assert "LowQual" in meta["filter"]
+    assert "PASS" not in meta["filter"]
+    # info: paired_with populated to B's ID.
+    assert meta["info"]["paired_with"] == "bnd2"
+
+
+# --------------------------------------------------------------------
+# 16. End-to-end: combined fusion produces single GeneFusion class
+# --------------------------------------------------------------------
+
+
+def test_paired_bnd_in_genes_produces_single_event_after_pairing():
+    """Reciprocal BND between BRD4 (chr19) and NUTM1 (chr15) gives N
+    GeneFusion effects per BRD4 transcript pre-pair (one fusion
+    direction per half × transcripts), and only the primary-side
+    direction × transcripts after pair_breakends — the second
+    direction is reachable via combined.source_variants."""
+    body = (
+        "19\t15250000\tbnd1\tG\tG]15:34350000]\t100\tPASS\tMATEID=bnd2\n"
+        "15\t34350000\tbnd2\tA\tA[19:15250000[\t100\tPASS\tMATEID=bnd1\n"
+    )
+    vc = _load(body)
+    out = pair_breakends(vc)
+    effects_post = out.effects(raise_on_error=False)
+    fusion_post = [e for e in effects_post
+                   if type(e).__name__ == "GeneFusion"]
+    # All post-pair fusion effects share the same combined variant.
+    assert fusion_post, "expected at least one GeneFusion post-pair"
+    variants_seen = {id(e.variant) for e in fusion_post}
+    assert len(variants_seen) == 1
+    # That variant has both halves in source_variants.
+    assert len(fusion_post[0].variant.source_variants) == 2

--- a/varcode/sv_allele_parser.py
+++ b/varcode/sv_allele_parser.py
@@ -198,7 +198,8 @@ def parse_symbolic_alt(
             mate_contig=mate_contig,
             mate_start=mate_pos,
             mate_orientation=orientation,
-            info={"mateid": _extract_info(info, "MATEID"),
+            info={"mateid": (_extract_info(info, "MATEID")
+                             or _extract_info(info, "PARID")),
                   "bnd_anchor": prefix or suffix},
             genome=genome,
         )

--- a/varcode/transforms/__init__.py
+++ b/varcode/transforms/__init__.py
@@ -1,0 +1,108 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``VariantCollection`` -> ``VariantCollection`` transforms.
+
+A transform is a pure function: given a ``VariantCollection`` and
+optional auxiliary inputs (reference, phase resolver, ...), it returns
+a new ``VariantCollection``. Cardinality may be preserved, reduced,
+or increased; the docstring of each transform states which.
+
+Every variant in the output carries a ``source_variants`` attribute
+recording its provenance:
+
+* ``()`` — pass-through; the variant was not derived from any other.
+* ``(v,)`` — derived from a single source variant
+  (e.g. left-aligned position).
+* ``(v1, v2, ...)`` — combined from multiple source variants
+  (e.g. paired breakends merged into one combined SV row).
+
+Transforms compose by application. The intermediate indices a
+transform builds (MATEID -> variant, phase set -> variants, ...) live
+inside the function and are dropped on return.
+
+Shipped transforms:
+
+* :func:`pair_breakends` — merges MATEID-paired BND rows into a
+  single combined ``StructuralVariant``. (reduces)
+
+Planned (separate PRs):
+
+* ``combine_cis_snvs`` — combine adjacent in-codon SNVs into MNVs
+  given phase. (reduces)
+* ``left_align_indels`` — canonical-position indel normalization.
+  (preserves)
+* ``split_multiallelic`` — split a multi-ALT row into one variant
+  per ALT, making today's implicit parse-time behavior explicit.
+  (increases)
+* ``decompose_mnvs`` — inverse of ``combine_cis_snvs``: split MNVs
+  into constituent SNVs for cross-tool comparison. (increases)
+"""
+
+
+def pair_breakends(vc):
+    """Merge MATEID-paired BND rows into a single combined
+    ``StructuralVariant`` per rearrangement event. (reduces)
+
+    For each pair of :class:`~varcode.StructuralVariant` rows where
+    row A's ``MATEID`` references row B's VCF ID (and vice versa),
+    emit one combined row carrying both endpoints. The combined
+    variant's ``source_variants`` attribute holds the two originals.
+
+    Non-BND variants, single-row TRA, and single-ended BNDs (no
+    ``MATEID``) pass through unchanged with ``source_variants=()``.
+
+    Pairing rules:
+
+    * Primary key: ``MATEID`` field on each variant's ``info`` dict
+      against the VCF row ID stored in the collection's source
+      metadata.
+    * Alias: ``PARID`` (used by older GRIDSS) is treated as ``MATEID``.
+    * Symmetric: row A's ``MATEID`` must equal row B's ID and row B's
+      ``MATEID`` must equal row A's ID. Asymmetric references are
+      logged and left unpaired.
+    * If a ``MATEID`` points to an ID not present in this collection
+      (filtered out, chunked load), a warning is emitted and the
+      variant passes through unpaired.
+    * If three or more rows share a ``MATEID`` group, the whole group
+      is left unpaired with a warning (caller bug; pairing is
+      ambiguous).
+
+    Metadata merge for paired rows:
+
+    * Genotype: both halves must agree on the per-sample ``GT``. The
+      combined variant inherits the shared genotype. Disagreement
+      raises (caller bug).
+    * ``alt_assembly``: if exactly one half carries an assembled
+      sequence, the combined variant inherits it. If both differ,
+      the lexicographically earlier source row wins (deterministic
+      across runs).
+    * Other INFO fields: preserved from the lexicographically earlier
+      source row; the other half's INFO is available via
+      ``combined.source_variants``.
+
+    Parameters
+    ----------
+    vc : VariantCollection
+        Input collection. May contain a mix of structural and
+        non-structural variants.
+
+    Returns
+    -------
+    VariantCollection
+        A new collection. SV rows that were halves of paired BNDs
+        are replaced by combined rows; everything else (including
+        SNVs/indels/MNVs and unpaired SVs) passes through.
+    """
+    raise NotImplementedError(
+        "varcode.transforms.pair_breakends — implementation in progress, "
+        "tracked in openvax/varcode#364")

--- a/varcode/transforms/__init__.py
+++ b/varcode/transforms/__init__.py
@@ -48,6 +48,256 @@ Planned (separate PRs):
   into constituent SNVs for cross-tool comparison. (increases)
 """
 
+import warnings
+
+from ..structural_variant import StructuralVariant
+from ..variant_collection import VariantCollection
+
+
+__all__ = ["pair_breakends"]
+
+
+def _is_breakend(variant):
+    return getattr(variant, "sv_type", None) == "BND"
+
+
+def _mate_reference(variant):
+    """Return the MATEID/PARID string for a BND variant, or ``None``.
+
+    Looks in the variant's ``info`` dict for ``mateid`` / ``MATEID`` /
+    ``parid`` / ``PARID`` — the SV parser writes the lowercase form;
+    callers constructing variants directly may use either.
+    """
+    info = getattr(variant, "info", None) or {}
+    for key in ("mateid", "MATEID", "parid", "PARID"):
+        value = info.get(key)
+        if value is None or value == ".":
+            continue
+        if isinstance(value, (list, tuple)):
+            if not value:
+                continue
+            value = value[0]
+        return str(value)
+    return None
+
+
+def _build_id_indices(vc):
+    """Return ``(variant_to_id, id_to_variants)`` from VC source metadata.
+
+    ``id_to_variants`` is a list because a VCF ID is, in principle, only
+    unique within a single VCF — when multiple sources merge, two rows
+    can technically share an ID. We keep the multiplicity so pairing
+    can detect ambiguity instead of silently picking one.
+    """
+    variant_to_id = {}
+    id_to_variants = {}
+    for by_variant in vc.source_to_metadata_dict.values():
+        for variant, metadata in by_variant.items():
+            row_id = (metadata or {}).get("id")
+            if row_id is None or row_id == "." or row_id == "":
+                continue
+            row_id = str(row_id)
+            variant_to_id.setdefault(variant, row_id)
+            id_to_variants.setdefault(row_id, []).append(variant)
+    return variant_to_id, id_to_variants
+
+
+def _merge_alt_assembly(a, b, a_id, b_id):
+    """Pick the combined variant's ``alt_assembly`` from the two halves.
+
+    None+None -> None; one populated -> that one; both equal -> shared;
+    both different -> warn and take A's (deterministic via lex source
+    ordering).
+    """
+    aa, ba = a.alt_assembly, b.alt_assembly
+    if aa is None and ba is None:
+        return None
+    if aa is None:
+        return ba
+    if ba is None:
+        return aa
+    if aa == ba:
+        return aa
+    warnings.warn(
+        "pair_breakends: paired BND rows %r and %r carry different "
+        "alt_assembly sequences; keeping %r's. Inspect "
+        "combined.source_variants for both originals."
+        % (a_id, b_id, a_id),
+        stacklevel=3)
+    return aa
+
+
+def _merge_info(a, b, a_id, b_id):
+    """Merge two BND halves' ``info`` dicts into the combined variant's.
+
+    Per-key rules:
+      * Both halves agree -> agreed value.
+      * Exactly one half has it -> that value.
+      * Both halves disagree -> A's value (log at debug-warning level
+        if it's a non-trivial field; agree-or-warn would be
+        configurable later if needed).
+
+    ``paired_with`` is added pointing at B's row ID for round-trip
+    debugging — same info reachable via ``source_variants``, but cheap
+    enough to keep as a first-class hint.
+    """
+    a_info = dict(a.info or {})
+    b_info = dict(b.info or {})
+    merged = {}
+    all_keys = set(a_info) | set(b_info)
+    for key in all_keys:
+        if key in ("mateid", "MATEID", "parid", "PARID"):
+            # The mate pointers no longer apply to the combined row.
+            continue
+        if key in a_info and key in b_info:
+            if a_info[key] == b_info[key]:
+                merged[key] = a_info[key]
+            else:
+                merged[key] = a_info[key]
+        elif key in a_info:
+            merged[key] = a_info[key]
+        else:
+            merged[key] = b_info[key]
+    if b_id is not None:
+        merged["paired_with"] = b_id
+    return merged
+
+
+def _build_combined(a, b, a_id, b_id):
+    """Construct the combined ``StructuralVariant`` for a paired BND.
+
+    A is the lex-earlier source row by VCF ID. The combined variant's
+    primary endpoint is A's; the mate hint resolves to B's contig/start
+    when A doesn't already carry it (which is the common case — A's
+    ``mate_contig`` already points at B's contig).
+    """
+    mate_contig = a.mate_contig if a.mate_contig is not None else b.contig
+    mate_start = a.mate_start if a.mate_start is not None else b.start
+    combined = StructuralVariant(
+        contig=a.contig,
+        start=a.start,
+        end=a.start,
+        sv_type="BND",
+        alt=a.symbolic_alt,
+        ref=a.ref,
+        mate_contig=mate_contig,
+        mate_start=mate_start,
+        mate_orientation=a.mate_orientation,
+        ci_start=a.ci_start,
+        ci_end=a.ci_end,
+        alt_assembly=_merge_alt_assembly(a, b, a_id, b_id),
+        info=_merge_info(a, b, a_id, b_id),
+        genome=a.genome,
+        normalize_contig_names=False,
+    )
+    combined.source_variants = (a, b)
+    return combined
+
+
+def _merge_sample_info(a_sample, b_sample, a_id, b_id):
+    """Merge per-sample dicts. GT must match across halves; raises on
+    disagreement so caller bugs (asymmetric filter application,
+    half-only re-genotyping) surface instead of being silently coerced.
+
+    All non-GT FORMAT fields are taken from A.
+    """
+    if a_sample is None and b_sample is None:
+        return None
+    if a_sample is None:
+        return dict(b_sample)
+    if b_sample is None:
+        return dict(a_sample)
+    merged = {}
+    for sample_name in set(a_sample) | set(b_sample):
+        a_fields = a_sample.get(sample_name) or {}
+        b_fields = b_sample.get(sample_name) or {}
+        a_gt = a_fields.get("GT")
+        b_gt = b_fields.get("GT")
+        if (a_gt is not None and b_gt is not None
+                and a_gt != b_gt):
+            raise ValueError(
+                "pair_breakends: paired BND rows %r and %r disagree on "
+                "genotype for sample %r (%r vs %r). Both halves of a "
+                "paired breakend describe the same biological event "
+                "and should share the same per-sample GT; the mismatch "
+                "indicates a caller bug or asymmetric filter "
+                "application. Drop one half before pairing if this is "
+                "intentional." % (a_id, b_id, sample_name, a_gt, b_gt))
+        out_fields = dict(a_fields)
+        for key, value in b_fields.items():
+            out_fields.setdefault(key, value)
+        merged[sample_name] = out_fields
+    return merged
+
+
+def _merge_filter(a_filter, b_filter):
+    """Union the two halves' FILTER sets — the stricter filter wins.
+
+    VCF FILTER comes through as a list, a string, or ``None``/``PASS``.
+    Normalize to a sorted tuple; ``PASS``-only stays ``("PASS",)``;
+    any non-PASS label demotes the row.
+    """
+    def _norm(f):
+        if f is None:
+            return frozenset()
+        if isinstance(f, (list, tuple, set, frozenset)):
+            tokens = [str(x) for x in f if x]
+        else:
+            tokens = [t for t in str(f).split(";") if t]
+        return frozenset(tokens) - {"PASS", ".", ""}
+    union = _norm(a_filter) | _norm(b_filter)
+    if not union:
+        return ["PASS"]
+    return sorted(union)
+
+
+def _merge_metadata(a_meta, b_meta, a_id, b_id):
+    """Build the combined variant's per-source metadata entry."""
+    if a_meta is None and b_meta is None:
+        return None
+    a_meta = a_meta or {}
+    b_meta = b_meta or {}
+    qual_a = a_meta.get("qual")
+    qual_b = b_meta.get("qual")
+    if qual_a is not None and qual_b is not None:
+        qual = min(qual_a, qual_b)
+    else:
+        qual = qual_a if qual_a is not None else qual_b
+    return {
+        "id": a_id,
+        "qual": qual,
+        "filter": _merge_filter(a_meta.get("filter"), b_meta.get("filter")),
+        "info": _merge_info_from_metadata(a_meta.get("info"),
+                                          b_meta.get("info"),
+                                          a_id, b_id),
+        "sample_info": _merge_sample_info(a_meta.get("sample_info"),
+                                          b_meta.get("sample_info"),
+                                          a_id, b_id),
+        "alt_allele_index": a_meta.get("alt_allele_index"),
+    }
+
+
+def _merge_info_from_metadata(a_info, b_info, a_id, b_id):
+    """Merge metadata-level INFO dicts. Same rules as ``_merge_info``
+    but operating on the dict captured at VCF load time (which may be
+    richer than the slim ``StructuralVariant.info``)."""
+    if a_info is None and b_info is None:
+        return None
+    a_info = dict(a_info or {})
+    b_info = dict(b_info or {})
+    merged = {}
+    for key in set(a_info) | set(b_info):
+        if key in ("MATEID", "PARID"):
+            continue
+        if key in a_info and key in b_info:
+            merged[key] = a_info[key]
+        elif key in a_info:
+            merged[key] = a_info[key]
+        else:
+            merged[key] = b_info[key]
+    merged["paired_with"] = b_id
+    return merged
+
 
 def pair_breakends(vc):
     """Merge MATEID-paired BND rows into a single combined
@@ -69,26 +319,29 @@ def pair_breakends(vc):
     * Alias: ``PARID`` (used by older GRIDSS) is treated as ``MATEID``.
     * Symmetric: row A's ``MATEID`` must equal row B's ID and row B's
       ``MATEID`` must equal row A's ID. Asymmetric references are
-      logged and left unpaired.
+      warned and left unpaired.
     * If a ``MATEID`` points to an ID not present in this collection
       (filtered out, chunked load), a warning is emitted and the
       variant passes through unpaired.
     * If three or more rows share a ``MATEID`` group, the whole group
-      is left unpaired with a warning (caller bug; pairing is
-      ambiguous).
+      is left unpaired with a warning (pairing is ambiguous).
+    * Already-paired input (``source_variants`` non-empty) passes
+      through unchanged — :func:`pair_breakends` is idempotent.
 
     Metadata merge for paired rows:
 
     * Genotype: both halves must agree on the per-sample ``GT``. The
       combined variant inherits the shared genotype. Disagreement
-      raises (caller bug).
+      raises :class:`ValueError`.
     * ``alt_assembly``: if exactly one half carries an assembled
       sequence, the combined variant inherits it. If both differ,
-      the lexicographically earlier source row wins (deterministic
-      across runs).
-    * Other INFO fields: preserved from the lexicographically earlier
-      source row; the other half's INFO is available via
-      ``combined.source_variants``.
+      A's wins (deterministic via lex source-ID ordering) with a
+      warning.
+    * ``filter``: union of both halves' FILTER tokens; ``PASS`` is
+      dropped if any non-PASS label is present (stricter wins).
+    * ``qual``: minimum of the two halves' quality scores.
+    * Other INFO fields: prefer A's; the other half is reachable
+      via ``combined.source_variants``.
 
     Parameters
     ----------
@@ -103,6 +356,103 @@ def pair_breakends(vc):
         are replaced by combined rows; everything else (including
         SNVs/indels/MNVs and unpaired SVs) passes through.
     """
-    raise NotImplementedError(
-        "varcode.transforms.pair_breakends — implementation in progress, "
-        "tracked in openvax/varcode#364")
+    variant_to_id, id_to_variants = _build_id_indices(vc)
+
+    # Build candidate pairing groups: frozenset({id_a, id_b}) -> list of
+    # variants in this VC that participate in the group. Groups of size 2
+    # with symmetric MATEID references are paired; everything else is left
+    # alone with a warning.
+    candidate_groups = {}
+    for variant in vc:
+        if not _is_breakend(variant):
+            continue
+        if getattr(variant, "source_variants", ()):
+            continue
+        mate_id = _mate_reference(variant)
+        if mate_id is None:
+            continue
+        own_id = variant_to_id.get(variant)
+        if own_id is None:
+            continue
+        if mate_id not in id_to_variants:
+            warnings.warn(
+                "pair_breakends: BND %r references MATEID/PARID %r "
+                "which is not in this collection; left unpaired. "
+                "This typically means the mate row was filter-dropped "
+                "or split across chunked loads."
+                % (own_id, mate_id),
+                stacklevel=2)
+            continue
+        key = frozenset({own_id, mate_id})
+        candidate_groups.setdefault(key, []).append(variant)
+
+    # Resolve groups -> paired/unpaired decisions.
+    replacement = {}  # original variant -> combined variant
+    for key, group in candidate_groups.items():
+        if len(group) > 2:
+            warnings.warn(
+                "pair_breakends: MATEID group %r has %d members; "
+                "ambiguous, left unpaired. Each rearrangement should "
+                "produce exactly two BND rows linked by MATEID."
+                % (sorted(key), len(group)),
+                stacklevel=2)
+            continue
+        if len(group) != 2:
+            # Singleton — mate row is in id_to_variants but not in the
+            # candidate group, meaning the mate didn't reference back.
+            solo = group[0]
+            warnings.warn(
+                "pair_breakends: BND %r mate reference is asymmetric "
+                "(this row -> %r but mate doesn't point back); "
+                "left unpaired."
+                % (variant_to_id[solo], _mate_reference(solo)),
+                stacklevel=2)
+            continue
+        a, b = sorted(group, key=lambda v: variant_to_id[v])
+        a_id = variant_to_id[a]
+        b_id = variant_to_id[b]
+        combined = _build_combined(a, b, a_id, b_id)
+        replacement[a] = combined
+        replacement[b] = combined
+
+    # Build output VC. Pass-through variants land first-occurrence; paired
+    # variants are replaced by their combined variant the first time either
+    # half is encountered, then the second half is skipped to preserve
+    # ordering and cardinality.
+    out_variants = []
+    emitted_combined = set()
+    for variant in vc:
+        combined = replacement.get(variant)
+        if combined is None:
+            out_variants.append(variant)
+            continue
+        if id(combined) in emitted_combined:
+            continue
+        emitted_combined.add(id(combined))
+        out_variants.append(combined)
+
+    # Build output metadata. Pass-through variants reuse the existing
+    # metadata entries by reference; combined variants get a freshly
+    # merged entry written to every source path that contained either
+    # half.
+    out_metadata = {path: {} for path in vc.source_to_metadata_dict}
+    for path, by_variant in vc.source_to_metadata_dict.items():
+        out_by_variant = out_metadata[path]
+        for variant, meta in by_variant.items():
+            combined = replacement.get(variant)
+            if combined is None:
+                out_by_variant[variant] = meta
+            elif combined not in out_by_variant:
+                a, b = combined.source_variants
+                a_meta = by_variant.get(a)
+                b_meta = by_variant.get(b)
+                a_id = variant_to_id[a]
+                b_id = variant_to_id[b]
+                out_by_variant[combined] = _merge_metadata(
+                    a_meta, b_meta, a_id, b_id)
+
+    return VariantCollection(
+        variants=out_variants,
+        sources=vc.sources,
+        source_to_metadata_dict=out_metadata,
+    )

--- a/varcode/transforms/__init__.py
+++ b/varcode/transforms/__init__.py
@@ -358,11 +358,8 @@ def pair_breakends(vc):
     """
     variant_to_id, id_to_variants = _build_id_indices(vc)
 
-    # Build candidate pairing groups: frozenset({id_a, id_b}) -> list of
-    # variants in this VC that participate in the group. Groups of size 2
-    # with symmetric MATEID references are paired; everything else is left
-    # alone with a warning.
-    candidate_groups = {}
+    # For each BND variant, what does it claim as its mate?
+    bnd_to_mateid = {}
     for variant in vc:
         if not _is_breakend(variant):
             continue
@@ -371,8 +368,58 @@ def pair_breakends(vc):
         mate_id = _mate_reference(variant)
         if mate_id is None:
             continue
+        bnd_to_mateid[variant] = mate_id
+
+    # How many rows reference each ID as their mate? An ID with
+    # in-degree > 1 indicates ambiguity — a clean pair requires the
+    # MATEID pointer to be 1:1.
+    mate_in_degree = {}
+    for mate_id in bnd_to_mateid.values():
+        mate_in_degree[mate_id] = mate_in_degree.get(mate_id, 0) + 1
+
+    # Walk BND variants and resolve each to one of: paired (with a
+    # specific mate variant), ambiguous (skip with warning naming the
+    # connected component), missing-mate (warn), asymmetric (warn).
+    replacement = {}     # original variant -> combined variant
+    processed = set()    # variants whose pairing decision is final
+    ambiguity_warned = set()   # connected-component ids already warned about
+
+    def _component_ids(seed_id):
+        """Connected component of mate references reachable from
+        ``seed_id``. Used to produce one warning per ambiguous group
+        rather than one per row."""
+        visited = set()
+        stack = [seed_id]
+        while stack:
+            node = stack.pop()
+            if node in visited:
+                continue
+            visited.add(node)
+            # Outgoing: variants whose ID is `node` -- find their mateids.
+            for v in id_to_variants.get(node, ()):
+                mid = bnd_to_mateid.get(v)
+                if mid is not None and mid not in visited:
+                    stack.append(mid)
+            # Incoming: any mateid pointing AT `node`.
+            for v, mid in bnd_to_mateid.items():
+                if mid == node:
+                    own = variant_to_id.get(v)
+                    if own is not None and own not in visited:
+                        stack.append(own)
+        return visited
+
+    for variant in vc:
+        if not _is_breakend(variant):
+            continue
+        if variant in processed:
+            continue
+        if getattr(variant, "source_variants", ()):
+            continue
         own_id = variant_to_id.get(variant)
         if own_id is None:
+            continue
+        mate_id = bnd_to_mateid.get(variant)
+        if mate_id is None:
             continue
         if mate_id not in id_to_variants:
             warnings.warn(
@@ -382,38 +429,65 @@ def pair_breakends(vc):
                 "or split across chunked loads."
                 % (own_id, mate_id),
                 stacklevel=2)
+            processed.add(variant)
             continue
-        key = frozenset({own_id, mate_id})
-        candidate_groups.setdefault(key, []).append(variant)
-
-    # Resolve groups -> paired/unpaired decisions.
-    replacement = {}  # original variant -> combined variant
-    for key, group in candidate_groups.items():
-        if len(group) > 2:
+        # Ambiguity: this variant or its claimed mate has incoming
+        # mate-degree > 1, meaning at least one other row also points
+        # at the same target. Whole connected component is unsafe.
+        if (mate_in_degree.get(own_id, 0) > 1
+                or mate_in_degree.get(mate_id, 0) > 1):
+            component = _component_ids(own_id)
+            component_key = frozenset(component)
+            if component_key not in ambiguity_warned:
+                ambiguity_warned.add(component_key)
+                warnings.warn(
+                    "pair_breakends: BND ID group %r has ambiguous "
+                    "MATEID/PARID references (at least one ID is "
+                    "referenced by more than one row); left unpaired. "
+                    "Each rearrangement should produce exactly two BND "
+                    "rows with 1:1 mate pointers."
+                    % sorted(component),
+                    stacklevel=2)
+            # Mark every variant in the component as processed so we
+            # don't re-warn from a different vantage point.
+            for cid in component:
+                for v in id_to_variants.get(cid, ()):
+                    processed.add(v)
+            continue
+        # Identify the specific mate variant. With in-degree 1 there's
+        # exactly one BND row at `mate_id`.
+        mate_candidates = [
+            v for v in id_to_variants[mate_id]
+            if _is_breakend(v)
+        ]
+        if not mate_candidates:
             warnings.warn(
-                "pair_breakends: MATEID group %r has %d members; "
-                "ambiguous, left unpaired. Each rearrangement should "
-                "produce exactly two BND rows linked by MATEID."
-                % (sorted(key), len(group)),
+                "pair_breakends: BND %r references MATEID %r but that "
+                "ID is held by a non-BND variant; left unpaired."
+                % (own_id, mate_id),
                 stacklevel=2)
+            processed.add(variant)
             continue
-        if len(group) != 2:
-            # Singleton — mate row is in id_to_variants but not in the
-            # candidate group, meaning the mate didn't reference back.
-            solo = group[0]
+        mate = mate_candidates[0]
+        # Symmetric check: mate must point back at us.
+        if bnd_to_mateid.get(mate) != own_id:
             warnings.warn(
                 "pair_breakends: BND %r mate reference is asymmetric "
-                "(this row -> %r but mate doesn't point back); "
-                "left unpaired."
-                % (variant_to_id[solo], _mate_reference(solo)),
+                "(this row -> %r but mate -> %r); left unpaired."
+                % (own_id, mate_id, bnd_to_mateid.get(mate)),
                 stacklevel=2)
+            processed.add(variant)
+            processed.add(mate)
             continue
-        a, b = sorted(group, key=lambda v: variant_to_id[v])
+        # Clean pair.
+        a, b = sorted([variant, mate], key=lambda v: variant_to_id[v])
         a_id = variant_to_id[a]
         b_id = variant_to_id[b]
         combined = _build_combined(a, b, a_id, b_id)
         replacement[a] = combined
         replacement[b] = combined
+        processed.add(a)
+        processed.add(b)
 
     # Build output VC. Pass-through variants land first-occurrence; paired
     # variants are replaced by their combined variant the first time either

--- a/varcode/variant.py
+++ b/varcode/variant.py
@@ -118,6 +118,14 @@ class Variant(Serializable):
         self._gene_ids = None
         self._gene_names = None
 
+        # Provenance: when this variant was produced by a
+        # ``varcode.transforms`` operation (e.g. ``pair_breakends``,
+        # ``combine_cis_snvs``), the source rows are recorded here.
+        # Empty tuple for variants loaded directly from a VCF/MAF.
+        # Not part of hash/equality — identity is still
+        # (contig, start, ref, alt, reference_name).
+        self.source_variants: tuple = ()
+
         # store the options which affect how properties of this variant
         # may be changed/transformed
         self.normalize_contig_names = normalize_contig_names


### PR DESCRIPTION
Planning PR for #364 and the broader `varcode.transforms` shape that came out of design discussion. The commit here is **scaffold only** — `Variant.source_variants` attribute and the `pair_breakends` signature with its full contract docstring. Implementation lands in follow-up commits on this branch. Open for review of the design before the body is filled in.

## The general pattern

`VariantCollection` -> `VariantCollection` pure functions. Each takes a VC and returns a new VC, possibly smaller, equal, or larger in cardinality. Intermediate indices the transform needs (`MATEID -> variant`, phase set -> variants, repeat-structure tries) live inside the function and are dropped on return. No new VC-level concepts.

Composition is application:

```python
import varcode
from varcode.transforms import (
    pair_breakends,
    combine_cis_snvs,        # planned, separate PR
    left_align_indels,       # planned, separate PR
)

vc = varcode.load_vcf(\"tumor.vcf\", genome=\"GRCh38\",
                      parse_structural_variants=True)
vc = left_align_indels(vc, reference=genome)
vc = combine_cis_snvs(vc, phase_resolver=phasing)
vc = pair_breakends(vc)
effects = vc.effects()
```

Every transform owes three things, written into its docstring:

1. **Cardinality direction** — preserved, reduced, or increased.
2. **Provenance** — every output variant carries `source_variants: tuple[Variant, ...]`. Empty for pass-through, length 1 for derived-from-one, length >=2 for combined. One new optional attribute on `Variant`/`StructuralVariant`; that's the only structural addition.
3. **Metadata behavior** — explicit rule for how `source_to_metadata_dict` entries flow through (e.g. \"both halves must agree on GT or raise\").

Variants the transform doesn't touch flow through with `source_variants=()` and identical metadata.

## Why this dissolves the BND uniformity problem

The question that prompted this: across Manta-paired BNDs, BreakDancer-single-row TRAs, and GRIDSS single-end breakends, how do we get \"one effect per rearrangement event\" uniformly?

Answer: it's a post-condition of `pair_breakends`, not a property of varcode's parse model.

| Caller | After `pair_breakends(vc)` |
|---|---|
| Manta paired BND | 2 rows merged -> 1 combined `StructuralVariant`, `source_variants=(bnd1, bnd2)` |
| DELLY paired BND | same |
| BreakDancer single-row TRA | pass-through, `source_variants=()` |
| GRIDSS single-end | pass-through, `source_variants=()` |
| Long-read TRA (PBSV/Sniffles) | pass-through, `source_variants=()` |

Effect prediction emits one fusion / translocation per output row uniformly. No `BreakendPair` class, no VC-level event index, no effect-collection collapse step. Just one variant per rearrangement, by construction, in the VC the user actually annotates.

## `pair_breakends` specification

Full contract is in the scaffolded docstring. Summary:

**Pairing rules**
- Primary key: `MATEID` field on each variant's `info` against the VCF row ID stored in collection source metadata.
- Alias: `PARID` (older GRIDSS).
- Symmetric: A.MATEID == B.ID AND B.MATEID == A.ID. Asymmetric references are logged and left unpaired.
- MATEID points to an ID not in the VC -> warn, pass through unpaired.
- >=3 rows share a MATEID group -> warn, leave the whole group unpaired (caller bug).

**Metadata merge for paired rows**
- Genotype: both halves must agree on per-sample GT; combined inherits. Disagreement raises (caller bug, not transform's job to silently coerce).
- `alt_assembly`: if exactly one half carries an assembled sequence, combined inherits it.
- Other INFO: from the lexicographically-earlier source row (deterministic); the other half is still reachable via `source_variants`.

**Output variant shape**
- A single `StructuralVariant` with `sv_type=\"BND\"`, both endpoints populated (`start` from row A, `mate_start` from row B; mate_orientation chosen from row A's perspective).
- `source_variants=(bnd_a, bnd_b)`, ordered by source row ID (deterministic).
- `info['paired_with']` set to the other row's ID for round-trip / debugging.

## SV annotator changes

`_annotate_breakend` needs to detect a combined variant (has `source_variants` of length 2) and use both endpoints for partner-transcript selection plus `alt_assembly` propagation. Single warn on reverse-complement instead of double. No new code path — the existing logic already uses `mate_contig`/`mate_start`, which combined rows populate naturally.

## Test matrix

Fixture VCFs covering:
- Manta paired BND (BRD4-NUTM1 reciprocal) — 2 rows merge, 1 GeneFusion effect.
- DELLY paired BND — same expectation, different MATEID style.
- BreakDancer single-row TRA — pass-through, `source_variants=()`.
- GRIDSS single-end BND — pass-through.
- Mate-missing-from-VC — pass-through with warning.
- 3+ rows share MATEID — group left unpaired with warning.
- PARID alias — same as MATEID.
- Disagreeing genotypes — raises with a useful message.

Effect count uniformly = 1 per rearrangement event after the transform across all fixture types.

## Out of scope (separate tickets)

Future `varcode.transforms` functions, listed in the module docstring as planned:

- `combine_cis_snvs(vc, phase_resolver)` — combine adjacent in-codon SNVs into MNVs given phase. Reduces. Removes the need for `HaplotypeEffect` wrapping in the common case.
- `left_align_indels(vc, reference)` — canonical-position indel normalization. Preserves.
- `split_multiallelic(vc)` — split a multi-ALT row into one variant per ALT. Increases. Makes today's implicit parse-time behavior explicit.
- `decompose_mnvs(vc)` — inverse of `combine_cis_snvs`. Increases.

Each lands as its own PR; this PR only ships `pair_breakends` plus the module skeleton.

## Plan to merge

1. **This commit (scaffold)** — `Variant.source_variants`, module skeleton, full docstring contract. (done; this PR)
2. `pair_breakends` body — MATEID pairing pass, combined variant construction, metadata merge.
3. SV annotator: consume combined variants (`_annotate_breakend` uses both endpoints).
4. Test matrix (8 fixture cases above).
5. Docs page `docs/transforms.md` + mkdocs nav entry.
6. Follow-up tickets for `combine_cis_snvs`, `left_align_indels`, `split_multiallelic`, `decompose_mnvs`.
7. Lift draft -> ready, merge.

## Test plan

- [ ] `pytest tests/test_transforms_pair_breakends.py` — all 8 cases above pass.
- [ ] `pytest tests/test_structural_variant_annotator.py` — no regressions; existing single-half tests still pass.
- [ ] `pytest tests/` — full suite green across 3.9 / 3.10 / 3.11.
- [ ] Manual: load a real Manta VCF (BRD4-NUTM1 fixture) and verify `len(vc.effects())` for SV rows equals the rearrangement count, not the BND row count.