### PR TITLE
Attach optional genome FASTA + tiered reference lookup (#372, planning + scaffold)

### DIFF
--- a/tests/test_genome_sequence.py
+++ b/tests/test_genome_sequence.py
@@ -329,6 +329,30 @@ def test_reference_range_rejects_inverted_range(genome):
 # --------------------------------------------------------------------
 
 
+def test_attach_resets_cryptic_exons_warn_cache(genome, cftr_position):
+    """The ``cryptic_exons`` warn-once dedup keyed on ``id(genome)``
+    would otherwise persist across attach/detach cycles. Any explicit
+    attach (or detach) is user action — the next missing-FASTA
+    signal should be fresh, not suppressed.
+    """
+    from varcode import cryptic_exons
+    contig, pos, base = cftr_position
+
+    # Seed the cache as if a previous warning had fired.
+    cryptic_exons._MISSING_REFERENCE_WARNED.add(id(genome))
+    assert id(genome) in cryptic_exons._MISSING_REFERENCE_WARNED
+
+    # Attach -> cache should be cleared (fresh signal post-attach).
+    attach_genome_fasta(genome, _build_fasta_around(contig, pos, base),
+                        verify=False)
+    assert id(genome) not in cryptic_exons._MISSING_REFERENCE_WARNED
+
+    # Re-seed, then detach -> also cleared.
+    cryptic_exons._MISSING_REFERENCE_WARNED.add(id(genome))
+    attach_genome_fasta(genome, None)
+    assert id(genome) not in cryptic_exons._MISSING_REFERENCE_WARNED
+
+
 def test_load_vcf_attaches_genome_fasta(genome):
     """``load_vcf(..., genome_fasta=...)`` attaches the FASTA to the
     resolved genome before parsing — equivalent to a separate

--- a/tests/test_genome_sequence.py
+++ b/tests/test_genome_sequence.py
@@ -10,18 +10,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for :mod:`varcode.genome_sequence` (#372).
+"""Tests for :class:`varcode.Genome` + :mod:`varcode.genome_sequence` (#372).
 
-Covers the test matrix in the PR description:
+Covers:
 
-* ``attach_genome_fasta`` accepts paths, pyfaidx objects, and
-  duck-typed FASTA-shaped objects; rejects garbage; detaches via
-  ``None``; verifies content against transcript cDNA when asked.
-* ``reference_base`` and ``reference_range`` walk the three tiers
-  (FASTA -> transcript cDNA -> empty) including the Tier 2 range
-  fast path and the strand-aware base lookup.
-* ``cryptic_exons`` migration: silently-bailing flanking-region
-  scan replaced by loud warning when no reference covers the range.
+* ``varcode.Genome`` construction — int / string / pyensembl.Genome /
+  varcode.Genome (rewrap) accepted; FASTA path / pyfaidx-shaped object
+  / None / garbage handled; verify-on-construct catches mismatched
+  FASTAs.
+* ``__getattr__`` delegation makes the wrapper a drop-in for
+  pyensembl.Genome.
+* ``Genome.sequence`` / ``Genome.reference_base`` / ``Genome.reference_range``
+  honor the tiered fallback (Tier 1 FASTA -> Tier 2 transcript cDNA ->
+  Tier 3 empty), strand handling included.
+* Module-level :func:`reference_base` / :func:`reference_range` work
+  against either ``varcode.Genome`` or bare ``pyensembl.Genome``.
+* ``load_vcf(genome_fasta=...)`` wraps the resolved genome.
+* ``cryptic_exons`` migration: silently-bailing flanking scan
+  replaced by a per-genome warn-once.
 """
 
 import warnings
@@ -30,12 +36,8 @@ import pytest
 from pyensembl import cached_release
 
 import varcode
-from varcode.genome_sequence import (
-    _VARCODE_FASTA_ATTR,
-    attach_genome_fasta,
-    reference_base,
-    reference_range,
-)
+from varcode import Genome
+from varcode.genome_sequence import reference_base, reference_range
 
 
 # --------------------------------------------------------------------
@@ -47,8 +49,8 @@ class _DictBackedFasta:
     """``{contig: sequence_string}`` adapter shaped like pyfaidx.Fasta.
 
     ``offset`` is the 1-based genome position of the first character of
-    each contig's sequence (most test fixtures embed a small window
-    around a known locus rather than a full chromosome).
+    each contig's sequence (most fixtures embed a small window around
+    a known locus rather than a full chromosome).
     """
     def __init__(self, contig_to_seq, *, offset=1):
         self._d = dict(contig_to_seq)
@@ -81,46 +83,30 @@ class _Span:
 # --------------------------------------------------------------------
 
 
-_ENSEMBL_GRCh38 = cached_release(81)
 # CFTR (chr7, + strand) — well-known protein coding transcript.
 _CFTR_TRANSCRIPT_ID = "ENST00000003084"
 
 
 @pytest.fixture
-def genome():
-    """Fresh genome reference, with any prior FASTA attachment cleared.
-
-    ``cached_release`` returns a process-wide singleton so a test that
-    forgets to detach would leak the FASTA into other tests. The
-    teardown defends against that. Also clears the cryptic_exons
-    once-per-genome warn cache so the warning fixture is exercised
-    on every test that reaches it.
-    """
-    from varcode import cryptic_exons
-    g = cached_release(81)
-    if hasattr(g, _VARCODE_FASTA_ATTR):
-        delattr(g, _VARCODE_FASTA_ATTR)
-    cryptic_exons._MISSING_REFERENCE_WARNED.discard(id(g))
-    yield g
-    if hasattr(g, _VARCODE_FASTA_ATTR):
-        delattr(g, _VARCODE_FASTA_ATTR)
-    cryptic_exons._MISSING_REFERENCE_WARNED.discard(id(g))
+def ensembl():
+    """Bare pyensembl genome — for tests that exercise the Tier 2-only
+    code path (consumers passing a non-wrapped genome)."""
+    return cached_release(81)
 
 
 @pytest.fixture
-def cftr_position(genome):
-    """A (contig, position, expected_plus_strand_base) tuple inside
-    CFTR's first exon — known to be covered by Tier 2 (transcript cDNA)
-    and useful as an anchor for Tier 1 fixtures."""
-    t = genome.transcript_by_id(_CFTR_TRANSCRIPT_ID)
+def cftr_position(ensembl):
+    """``(contig, position, expected_plus_strand_base)`` inside CFTR's
+    first exon — known to be covered by Tier 2."""
+    t = ensembl.transcript_by_id(_CFTR_TRANSCRIPT_ID)
     pos = t.exons[0].start + 5
     expected = t.sequence[5].upper()
     return (t.contig, pos, expected)
 
 
 def _build_fasta_around(contig, position, base, window=200):
-    """Build a tiny _DictBackedFasta with ``base`` at ``position`` and
-    'N' elsewhere within a +/-``window`` window."""
+    """``_DictBackedFasta`` with ``base`` at ``position`` and ``'N'``
+    elsewhere within +/-``window``."""
     start_offset = position - window
     seq = ['N'] * (2 * window + 1)
     seq[position - start_offset] = base
@@ -128,57 +114,64 @@ def _build_fasta_around(contig, position, base, window=200):
 
 
 # --------------------------------------------------------------------
-# attach_genome_fasta
+# varcode.Genome construction
 # --------------------------------------------------------------------
 
 
-def test_attach_with_dict_backed_object_sets_attribute(genome, cftr_position):
+def test_genome_from_int_release_no_fasta(ensembl):
+    g = Genome(81)
+    assert g.fasta is None
+    # __getattr__ delegation passes pyensembl attribute access through.
+    assert g.reference_name == ensembl.reference_name
+
+
+def test_genome_from_pyensembl_object_passes_through(ensembl):
+    g = Genome(ensembl)
+    assert g._ensembl is ensembl
+    assert g.fasta is None
+
+
+def test_genome_rewrap_inherits_fasta(ensembl, cftr_position):
     contig, pos, base = cftr_position
     fasta = _build_fasta_around(contig, pos, base)
-    result = attach_genome_fasta(genome, fasta, verify=False)
-    assert result is genome  # returns the genome for chaining
-    assert getattr(genome, _VARCODE_FASTA_ATTR) is fasta
+    g1 = Genome(ensembl, fasta=fasta, verify=False)
+    # Rewrapping without override inherits the fasta.
+    g2 = Genome(g1)
+    assert g2.fasta is fasta
+    # Explicit None overrides to detach.
+    # (Construction takes fasta=None as "no override" per the constructor
+    # signature; this is the documented behavior.)
 
 
-def test_attach_with_integer_raises_typeerror(genome):
-    with pytest.raises(TypeError, match="pyfaidx-style protocol"):
-        attach_genome_fasta(genome, 42, verify=False)
-
-
-def test_attach_with_list_raises_typeerror(genome):
-    with pytest.raises(TypeError, match="pyfaidx-style protocol"):
-        attach_genome_fasta(genome, [1, 2, 3], verify=False)
-
-
-def test_reattach_overwrites_silently(genome, cftr_position):
+def test_genome_rewrap_overrides_fasta(ensembl, cftr_position):
     contig, pos, base = cftr_position
-    first = _build_fasta_around(contig, pos, base)
-    second = _build_fasta_around(contig, pos, base)
-    attach_genome_fasta(genome, first, verify=False)
-    attach_genome_fasta(genome, second, verify=False)
-    assert getattr(genome, _VARCODE_FASTA_ATTR) is second
+    fasta1 = _build_fasta_around(contig, pos, base)
+    fasta2 = _build_fasta_around(contig, pos, base)
+    g1 = Genome(ensembl, fasta=fasta1, verify=False)
+    g2 = Genome(g1, fasta=fasta2, verify=False)
+    assert g2.fasta is fasta2
 
 
-def test_detach_via_none_removes_attribute(genome, cftr_position):
+def test_genome_with_integer_fasta_raises_typeerror(ensembl):
+    with pytest.raises(TypeError, match="pyfaidx-style protocol"):
+        Genome(ensembl, fasta=42, verify=False)
+
+
+def test_genome_with_list_fasta_raises_typeerror(ensembl):
+    with pytest.raises(TypeError, match="pyfaidx-style protocol"):
+        Genome(ensembl, fasta=[1, 2, 3], verify=False)
+
+
+def test_genome_repr_indicates_fasta_presence(ensembl, cftr_position):
     contig, pos, base = cftr_position
-    fasta = _build_fasta_around(contig, pos, base)
-    attach_genome_fasta(genome, fasta, verify=False)
-    assert hasattr(genome, _VARCODE_FASTA_ATTR)
-    attach_genome_fasta(genome, None)
-    assert not hasattr(genome, _VARCODE_FASTA_ATTR)
+    g_no = Genome(ensembl)
+    g_with = Genome(ensembl, fasta=_build_fasta_around(contig, pos, base),
+                    verify=False)
+    assert "no FASTA" in repr(g_no)
+    assert "FASTA attached" in repr(g_with)
 
 
-def test_detach_when_nothing_attached_is_no_op(genome):
-    # Should not raise.
-    attach_genome_fasta(genome, None)
-    assert not hasattr(genome, _VARCODE_FASTA_ATTR)
-
-
-def test_verify_emits_warning_on_mismatched_fasta(genome):
-    """A FASTA that disagrees with the transcript cDNA at probed
-    positions triggers the verify-on-attach warning. Catches GRCh37
-    attached to a GRCh38 release."""
-
+def test_verify_emits_warning_on_mismatched_fasta(ensembl):
     class _AlwaysWrongFasta:
         def __getitem__(self, contig):
             return _AlwaysWrongSlicer()
@@ -190,15 +183,14 @@ def test_verify_emits_warning_on_mismatched_fasta(genome):
 
     with warnings.catch_warnings(record=True) as captured:
         warnings.simplefilter("always")
-        attach_genome_fasta(genome, _AlwaysWrongFasta(), verify=True)
+        Genome(ensembl, fasta=_AlwaysWrongFasta(), verify=True)
 
     disagreement = [w for w in captured
                     if "disagree" in str(w.message).lower()]
     assert disagreement, [str(w.message) for w in captured]
 
 
-def test_verify_false_suppresses_check(genome):
-    """``verify=False`` skips the probe even when the FASTA would fail it."""
+def test_verify_false_suppresses_check(ensembl):
     class _AlwaysWrongFasta:
         def __getitem__(self, contig):
             return _AlwaysWrongSlicer()
@@ -210,70 +202,91 @@ def test_verify_false_suppresses_check(genome):
 
     with warnings.catch_warnings(record=True) as captured:
         warnings.simplefilter("always")
-        attach_genome_fasta(genome, _AlwaysWrongFasta(), verify=False)
+        Genome(ensembl, fasta=_AlwaysWrongFasta(), verify=False)
 
     assert not any("disagree" in str(w.message).lower() for w in captured)
 
 
 # --------------------------------------------------------------------
-# reference_base — Tier 2 (no FASTA)
+# __getattr__ delegation
 # --------------------------------------------------------------------
 
 
-def test_tier2_returns_transcript_base_on_plus_strand(genome, cftr_position):
+def test_genome_delegates_transcript_by_id(ensembl):
+    g = Genome(ensembl)
+    # Should pass through to pyensembl's transcript_by_id.
+    assert g.transcript_by_id(_CFTR_TRANSCRIPT_ID).id == _CFTR_TRANSCRIPT_ID
+
+
+def test_genome_delegates_transcripts_at_locus(ensembl, cftr_position):
+    g = Genome(ensembl)
+    contig, pos, _ = cftr_position
+    assert len(g.transcripts_at_locus(contig, pos, pos)) > 0
+
+
+# --------------------------------------------------------------------
+# Tiered lookup — Tier 2 only (no FASTA)
+# --------------------------------------------------------------------
+
+
+def test_tier2_returns_transcript_base_on_plus_strand(ensembl, cftr_position):
     contig, pos, expected = cftr_position
-    assert reference_base(genome, contig, pos) == expected
+    assert reference_base(ensembl, contig, pos) == expected
+    # Same answer via the wrapper.
+    assert Genome(ensembl).reference_base(contig, pos) == expected
 
 
-def test_tier2_returns_plus_strand_base_for_minus_strand_transcript(genome):
-    """For ``-`` strand transcripts the cDNA is reverse-complemented
-    from the + strand. The lookup must return the + strand base —
-    i.e. the complement of whatever the cDNA says at the corresponding
-    spliced offset."""
+def test_tier2_returns_plus_strand_base_for_minus_strand_transcript(ensembl):
     minus_t = next(
-        t for t in genome.transcripts()
+        t for t in ensembl.transcripts()
         if t.strand == '-' and t.exons and t.is_protein_coding)
     pos = minus_t.exons[0].start + 5
-    # Compute the expected base via the same spliced_offset path the
-    # implementation uses, then complement it (since cDNA is on the -
-    # strand for a - strand transcript).
     offset = minus_t.spliced_offset(pos)
     cdna_base = minus_t.sequence[offset].upper()
     expected = cdna_base.translate(str.maketrans("ACGT", "TGCA"))
-    assert reference_base(genome, minus_t.contig, pos) == expected
+    assert reference_base(ensembl, minus_t.contig, pos) == expected
 
 
-def test_tier2_returns_empty_for_intronic_position(genome):
-    t = genome.transcript_by_id(_CFTR_TRANSCRIPT_ID)
-    # 100 bp inside the first intron.
+def test_tier2_returns_empty_for_intronic_position(ensembl):
+    t = ensembl.transcript_by_id(_CFTR_TRANSCRIPT_ID)
     intron_pos = t.exons[0].end + 100
-    assert reference_base(genome, t.contig, intron_pos) == ""
+    assert reference_base(ensembl, t.contig, intron_pos) == ""
 
 
 # --------------------------------------------------------------------
-# reference_base — Tier 1 (FASTA attached)
+# Tiered lookup — Tier 1 (FASTA on varcode.Genome)
 # --------------------------------------------------------------------
 
 
-def test_tier1_returns_fasta_base_when_attached(genome, cftr_position):
+def test_tier1_returns_fasta_base_when_attached(ensembl, cftr_position):
     contig, pos, transcript_base = cftr_position
-    # Build a FASTA that AGREES with the transcript at this position
-    # so verify passes, but stuff 'X's everywhere else so we can tell
-    # Tier 1 is the source for nearby positions.
     fasta = _build_fasta_around(contig, pos, transcript_base, window=10)
-    attach_genome_fasta(genome, fasta, verify=False)
-    # The probe position should match (FASTA has the right base there).
-    assert reference_base(genome, contig, pos) == transcript_base
+    g = Genome(ensembl, fasta=fasta, verify=False)
+    assert g.reference_base(contig, pos) == transcript_base
 
 
-def test_tier1_falls_through_when_contig_missing(genome, cftr_position):
+def test_tier1_falls_through_when_contig_missing(ensembl, cftr_position):
     """A FASTA that doesn't carry the requested contig falls through
     to Tier 2 (transcript cDNA) — does not crash."""
     contig, pos, transcript_base = cftr_position
     empty_fasta = _DictBackedFasta({}, offset=1)
-    attach_genome_fasta(genome, empty_fasta, verify=False)
-    # Falls through to Tier 2; transcript-derived base survives.
-    assert reference_base(genome, contig, pos) == transcript_base
+    g = Genome(ensembl, fasta=empty_fasta, verify=False)
+    assert g.reference_base(contig, pos) == transcript_base
+
+
+def test_genome_sequence_method_mirrors_pyensembl_api(ensembl, cftr_position):
+    """``Genome.sequence(contig, start, end)`` mirrors the proposed
+    pyensembl API (openvax/pyensembl#337). Returns the + strand range
+    from the attached FASTA only — no Tier 2 fallback."""
+    contig, pos, transcript_base = cftr_position
+    fasta = _build_fasta_around(contig, pos, transcript_base, window=10)
+    g = Genome(ensembl, fasta=fasta, verify=False)
+    seq = g.sequence(contig, pos, pos)
+    assert seq == transcript_base
+    # No FASTA -> empty (does NOT fall back to Tier 2; that's what
+    # reference_base/range are for).
+    g_no = Genome(ensembl)
+    assert g_no.sequence(contig, pos, pos) == ""
 
 
 # --------------------------------------------------------------------
@@ -281,82 +294,49 @@ def test_tier1_falls_through_when_contig_missing(genome, cftr_position):
 # --------------------------------------------------------------------
 
 
-def test_tier2_range_uses_single_transcript_fast_path(genome):
-    t = genome.transcript_by_id(_CFTR_TRANSCRIPT_ID)
+def test_tier2_range_uses_single_transcript_fast_path(ensembl):
+    t = ensembl.transcript_by_id(_CFTR_TRANSCRIPT_ID)
     start = t.exons[0].start + 5
     end = start + 10
-    span = reference_range(genome, t.contig, start, end)
+    span = reference_range(ensembl, t.contig, start, end)
     assert len(span) == end - start + 1
-    # First and last base should match what reference_base gives us.
-    assert span[0] == reference_base(genome, t.contig, start)
-    assert span[-1] == reference_base(genome, t.contig, end)
+    assert span[0] == reference_base(ensembl, t.contig, start)
+    assert span[-1] == reference_base(ensembl, t.contig, end)
 
 
-def test_tier2_range_spanning_exon_boundary_returns_empty(genome):
-    """A range that crosses into intronic space has uncovered
-    positions; all-or-nothing makes the whole range return ``""``."""
-    t = genome.transcript_by_id(_CFTR_TRANSCRIPT_ID)
-    # Cross from the last base of exon 1 into the first intron.
+def test_tier2_range_spanning_exon_boundary_returns_empty(ensembl):
+    t = ensembl.transcript_by_id(_CFTR_TRANSCRIPT_ID)
     boundary = t.exons[0].end
-    span = reference_range(genome, t.contig, boundary - 2, boundary + 5)
+    span = reference_range(ensembl, t.contig, boundary - 2, boundary + 5)
     assert span == ""
 
 
-def test_tier1_range_spanning_exon_boundary_returns_full_sequence(genome):
-    """With a FASTA attached the same range returns full bases —
-    including the intronic stretch — because Tier 1 doesn't care
-    about exon coverage."""
-    t = genome.transcript_by_id(_CFTR_TRANSCRIPT_ID)
+def test_tier1_range_spanning_exon_boundary_returns_full_sequence(ensembl):
+    t = ensembl.transcript_by_id(_CFTR_TRANSCRIPT_ID)
     boundary = t.exons[0].end
     start, end = boundary - 2, boundary + 5
-    # Fill the window with arbitrary bases so the lookup succeeds.
     window_seq = 'ACGTACGTACGTACGTACGT'
-    fasta = _DictBackedFasta(
-        {t.contig: window_seq}, offset=start)
-    attach_genome_fasta(genome, fasta, verify=False)
-    span = reference_range(genome, t.contig, start, end)
+    fasta = _DictBackedFasta({t.contig: window_seq}, offset=start)
+    g = Genome(ensembl, fasta=fasta, verify=False)
+    span = g.reference_range(t.contig, start, end)
     assert len(span) == end - start + 1
     assert span == window_seq[:end - start + 1].upper()
 
 
-def test_reference_range_rejects_inverted_range(genome):
+def test_reference_range_rejects_inverted_range(ensembl):
     with pytest.raises(ValueError, match="end=.*< start="):
-        reference_range(genome, "1", 100, 50)
+        reference_range(ensembl, "1", 100, 50)
 
 
 # --------------------------------------------------------------------
-# cryptic_exons migration: silent-bail -> loud warning
+# load_vcf wiring
 # --------------------------------------------------------------------
 
 
-def test_attach_resets_cryptic_exons_warn_cache(genome, cftr_position):
-    """The ``cryptic_exons`` warn-once dedup keyed on ``id(genome)``
-    would otherwise persist across attach/detach cycles. Any explicit
-    attach (or detach) is user action — the next missing-FASTA
-    signal should be fresh, not suppressed.
-    """
-    from varcode import cryptic_exons
-    contig, pos, base = cftr_position
-
-    # Seed the cache as if a previous warning had fired.
-    cryptic_exons._MISSING_REFERENCE_WARNED.add(id(genome))
-    assert id(genome) in cryptic_exons._MISSING_REFERENCE_WARNED
-
-    # Attach -> cache should be cleared (fresh signal post-attach).
-    attach_genome_fasta(genome, _build_fasta_around(contig, pos, base),
-                        verify=False)
-    assert id(genome) not in cryptic_exons._MISSING_REFERENCE_WARNED
-
-    # Re-seed, then detach -> also cleared.
-    cryptic_exons._MISSING_REFERENCE_WARNED.add(id(genome))
-    attach_genome_fasta(genome, None)
-    assert id(genome) not in cryptic_exons._MISSING_REFERENCE_WARNED
-
-
-def test_load_vcf_attaches_genome_fasta(genome):
-    """``load_vcf(..., genome_fasta=...)`` attaches the FASTA to the
-    resolved genome before parsing — equivalent to a separate
-    ``attach_genome_fasta`` call but more ergonomic."""
+def test_load_vcf_wraps_in_varcode_genome(ensembl):
+    """``load_vcf(..., genome_fasta=...)`` wraps the resolved genome
+    in :class:`varcode.Genome`. The resulting collection's variants
+    carry the wrapper as ``genome``."""
     import os
     import tempfile
 
@@ -372,46 +352,52 @@ def test_load_vcf_attaches_genome_fasta(genome):
     with os.fdopen(fd, "w") as f:
         f.write(body)
     try:
-        # Use a known-good DictBackedFasta so verify=True doesn't warn.
-        # The probe lookup happens against real transcripts, so we
-        # need a FASTA that agrees at those positions. Easiest: use
-        # an empty FASTA (no contigs) which falls through verify
-        # silently (zero probed positions = no disagreement).
         empty_fasta = _DictBackedFasta({}, offset=1)
         vc = load_vcf(path, genome="GRCh38", genome_fasta=empty_fasta)
     finally:
         os.unlink(path)
-    # The resolved genome should have the FASTA attached.
-    assert hasattr(vc[0].genome, _VARCODE_FASTA_ATTR)
-    assert getattr(vc[0].genome, _VARCODE_FASTA_ATTR) is empty_fasta
+
+    assert isinstance(vc[0].genome, Genome)
+    assert vc[0].genome.fasta is empty_fasta
 
 
-def test_cryptic_exons_warns_when_no_reference_covers_breakpoint(genome):
-    """``enumerate_from_structural_variant`` previously bailed silently
-    when no genome FASTA was attached and the breakpoint fell outside
-    any transcript. Now it warns loudly."""
+# --------------------------------------------------------------------
+# cryptic_exons migration: silent-bail -> loud warning
+# --------------------------------------------------------------------
+
+
+def test_cryptic_exons_warns_once_per_genome():
+    """Cryptic-exon scoring on breakpoints outside any annotated
+    transcript and without a FASTA warns exactly once per genome.
+    Subsequent uncovered breakpoints on the same genome are silent."""
     from varcode import StructuralVariant
     from varcode.cryptic_exons import enumerate_from_structural_variant
 
-    # Intergenic-looking breakpoint between protein-coding genes on
-    # chr1 (gene density is high enough that "intergenic" requires
-    # care; chr1:1_000_000 is in a heterochromatic-ish region).
+    g = Genome(cached_release(81))
+    # Reset the per-instance flag so the warning is armed.
+    g._missing_reference_warned = False
+
     sv = StructuralVariant(
         contig="1", start=1_000_000, sv_type="BND",
         alt="N]2:1000000]", mate_contig="2",
         mate_start=1_000_000, mate_orientation="]]",
-        genome=genome,
+        genome=g,
     )
-    with warnings.catch_warnings(record=True) as captured:
-        warnings.simplefilter("always")
-        candidates = enumerate_from_structural_variant(sv, genome=genome)
 
-    msgs = [str(w.message) for w in captured]
-    # Either a no-reference warning fires (the migration's intent), or
-    # transcripts coincidentally cover this region — both branches are
-    # acceptable, but in the no-coverage case the message must be loud.
-    no_ref_warnings = [m for m in msgs if "no reference sequence" in m]
-    if not candidates:
-        # If we produced nothing, it's because the reference was absent
-        # — verify the warning fired.
-        assert no_ref_warnings, msgs
+    # First call — expect at most one warning (zero is also valid:
+    # transcripts may cover the position and Tier 2 returns content).
+    with warnings.catch_warnings(record=True) as first:
+        warnings.simplefilter("always")
+        enumerate_from_structural_variant(sv, genome=g)
+    first_no_ref = [w for w in first
+                    if "no reference sequence" in str(w.message)]
+    # Second call — even if first warned, second should NOT.
+    with warnings.catch_warnings(record=True) as second:
+        warnings.simplefilter("always")
+        enumerate_from_structural_variant(sv, genome=g)
+    second_no_ref = [w for w in second
+                     if "no reference sequence" in str(w.message)]
+    assert not second_no_ref, [str(w.message) for w in second]
+    # If the first call warned at all, the dedup flag should now be set.
+    if first_no_ref:
+        assert g._missing_reference_warned is True

--- a/tests/test_genome_sequence.py
+++ b/tests/test_genome_sequence.py
@@ -162,6 +162,25 @@ def test_genome_with_list_fasta_raises_typeerror(ensembl):
         Genome(ensembl, fasta=[1, 2, 3], verify=False)
 
 
+def test_genome_with_path_string_raises_importerror_when_pyfaidx_missing(
+        ensembl, monkeypatch):
+    """When the user passes a FASTA path string and pyfaidx isn't
+    installed, the error should point at the install command rather
+    than a confusing ``ModuleNotFoundError``."""
+    import builtins
+    real_import = builtins.__import__
+
+    def _no_pyfaidx(name, *args, **kwargs):
+        if name == "pyfaidx" or name.startswith("pyfaidx."):
+            raise ImportError("simulated missing pyfaidx")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_pyfaidx)
+
+    with pytest.raises(ImportError, match="pip install pyfaidx"):
+        Genome(ensembl, fasta="/nonexistent/path/to/GRCh38.fa", verify=False)
+
+
 def test_genome_without_release_raises(ensembl):
     """``Genome()`` with no release argument is an error — we don't
     silently construct a placeholder that fails later."""

--- a/tests/test_genome_sequence.py
+++ b/tests/test_genome_sequence.py
@@ -162,6 +162,48 @@ def test_genome_with_list_fasta_raises_typeerror(ensembl):
         Genome(ensembl, fasta=[1, 2, 3], verify=False)
 
 
+def test_genome_with_nonexistent_path_raises_filenotfound(ensembl, monkeypatch):
+    """A bad path is wrapped in a varcode-framed ``FileNotFoundError``
+    naming the path, instead of surfacing the bare pyfaidx traceback.
+
+    Injects a fake ``pyfaidx`` module whose ``Fasta`` constructor
+    raises ``FileNotFoundError``, so the test runs whether or not
+    pyfaidx is installed in the environment.
+    """
+    import sys
+    import types
+
+    fake_pyfaidx = types.ModuleType("pyfaidx")
+
+    class _RaisingFasta:
+        def __init__(self, path):
+            raise FileNotFoundError(
+                "[Errno 2] No such file or directory: %r" % path)
+
+    fake_pyfaidx.Fasta = _RaisingFasta
+    monkeypatch.setitem(sys.modules, "pyfaidx", fake_pyfaidx)
+
+    with pytest.raises(
+            FileNotFoundError, match="varcode.Genome.*could not open"):
+        Genome(ensembl, fasta="/definitely/not/a/real/path.fa", verify=False)
+
+
+def test_genome_dir_includes_delegated_attributes(ensembl):
+    """``dir(genome)`` should surface the wrapped pyensembl Genome's
+    attributes so IDE auto-completion can find them through the
+    wrapper."""
+    g = Genome(ensembl)
+    names = dir(g)
+    # Wrapper's own.
+    assert "fasta" in names
+    assert "sequence" in names
+    assert "reference_base" in names
+    # Delegated from pyensembl.
+    assert "transcripts_at_locus" in names
+    assert "transcript_by_id" in names
+    assert "reference_name" in names
+
+
 def test_genome_with_path_string_raises_importerror_when_pyfaidx_missing(
         ensembl, monkeypatch):
     """When the user passes a FASTA path string and pyfaidx isn't

--- a/tests/test_genome_sequence.py
+++ b/tests/test_genome_sequence.py
@@ -30,12 +30,12 @@ Covers:
   replaced by a per-genome warn-once.
 """
 
+import copy
 import warnings
 
 import pytest
 from pyensembl import cached_release
 
-import varcode
 from varcode import Genome
 from varcode.genome_sequence import reference_base, reference_range
 
@@ -132,15 +132,15 @@ def test_genome_from_pyensembl_object_passes_through(ensembl):
 
 
 def test_genome_rewrap_inherits_fasta(ensembl, cftr_position):
+    """Rewrapping a Genome without an explicit ``fasta=`` inherits the
+    inner Genome's FASTA. ``fasta=None`` is treated as "no override"
+    rather than "detach" — to drop the FASTA, construct a fresh
+    ``Genome(ensembl_release)`` directly."""
     contig, pos, base = cftr_position
     fasta = _build_fasta_around(contig, pos, base)
     g1 = Genome(ensembl, fasta=fasta, verify=False)
-    # Rewrapping without override inherits the fasta.
     g2 = Genome(g1)
     assert g2.fasta is fasta
-    # Explicit None overrides to detach.
-    # (Construction takes fasta=None as "no override" per the constructor
-    # signature; this is the documented behavior.)
 
 
 def test_genome_rewrap_overrides_fasta(ensembl, cftr_position):
@@ -160,6 +160,24 @@ def test_genome_with_integer_fasta_raises_typeerror(ensembl):
 def test_genome_with_list_fasta_raises_typeerror(ensembl):
     with pytest.raises(TypeError, match="pyfaidx-style protocol"):
         Genome(ensembl, fasta=[1, 2, 3], verify=False)
+
+
+def test_genome_without_release_raises(ensembl):
+    """``Genome()`` with no release argument is an error — we don't
+    silently construct a placeholder that fails later."""
+    with pytest.raises(ValueError, match="requires an ensembl_release"):
+        Genome()
+
+
+def test_genome_deepcopy_does_not_infinite_loop(ensembl):
+    """``__getattr__`` delegation must not recurse on Python's
+    copy/pickle dunders. The underscore guard in ``__getattr__`` is
+    what prevents this; regression here would hang the test."""
+    g = Genome(ensembl)
+    clone = copy.deepcopy(g)
+    assert clone is not g
+    assert clone._ensembl is g._ensembl  # shallow share of wrapped genome
+    assert clone.fasta is g.fasta
 
 
 def test_genome_repr_indicates_fasta_presence(ensembl, cftr_position):
@@ -225,18 +243,18 @@ def test_genome_delegates_transcripts_at_locus(ensembl, cftr_position):
 
 
 # --------------------------------------------------------------------
-# Tiered lookup — Tier 2 only (no FASTA)
+# Lookup via transcript cDNA only (no FASTA attached)
 # --------------------------------------------------------------------
 
 
-def test_tier2_returns_transcript_base_on_plus_strand(ensembl, cftr_position):
+def test_transcript_cdna_lookup_plus_strand(ensembl, cftr_position):
     contig, pos, expected = cftr_position
     assert reference_base(ensembl, contig, pos) == expected
     # Same answer via the wrapper.
     assert Genome(ensembl).reference_base(contig, pos) == expected
 
 
-def test_tier2_returns_plus_strand_base_for_minus_strand_transcript(ensembl):
+def test_transcript_cdna_lookup_minus_strand(ensembl):
     minus_t = next(
         t for t in ensembl.transcripts()
         if t.strand == '-' and t.exons and t.is_protein_coding)
@@ -247,44 +265,46 @@ def test_tier2_returns_plus_strand_base_for_minus_strand_transcript(ensembl):
     assert reference_base(ensembl, minus_t.contig, pos) == expected
 
 
-def test_tier2_returns_empty_for_intronic_position(ensembl):
+def test_transcript_cdna_returns_empty_for_intronic_position(ensembl):
     t = ensembl.transcript_by_id(_CFTR_TRANSCRIPT_ID)
     intron_pos = t.exons[0].end + 100
     assert reference_base(ensembl, t.contig, intron_pos) == ""
 
 
 # --------------------------------------------------------------------
-# Tiered lookup — Tier 1 (FASTA on varcode.Genome)
+# Lookup via attached chromosome FASTA
 # --------------------------------------------------------------------
 
 
-def test_tier1_returns_fasta_base_when_attached(ensembl, cftr_position):
+def test_chromosome_fasta_lookup_when_attached(ensembl, cftr_position):
     contig, pos, transcript_base = cftr_position
     fasta = _build_fasta_around(contig, pos, transcript_base, window=10)
     g = Genome(ensembl, fasta=fasta, verify=False)
     assert g.reference_base(contig, pos) == transcript_base
 
 
-def test_tier1_falls_through_when_contig_missing(ensembl, cftr_position):
+def test_chromosome_fasta_falls_through_to_cdna_when_contig_missing(
+        ensembl, cftr_position):
     """A FASTA that doesn't carry the requested contig falls through
-    to Tier 2 (transcript cDNA) — does not crash."""
+    to transcript cDNA — does not crash."""
     contig, pos, transcript_base = cftr_position
     empty_fasta = _DictBackedFasta({}, offset=1)
     g = Genome(ensembl, fasta=empty_fasta, verify=False)
     assert g.reference_base(contig, pos) == transcript_base
 
 
-def test_genome_sequence_method_mirrors_pyensembl_api(ensembl, cftr_position):
+def test_genome_sequence_method_is_fasta_only(ensembl, cftr_position):
     """``Genome.sequence(contig, start, end)`` mirrors the proposed
     pyensembl API (openvax/pyensembl#337). Returns the + strand range
-    from the attached FASTA only — no Tier 2 fallback."""
+    from the attached FASTA only — does NOT fall back to transcript
+    cDNA. Callers wanting the tiered lookup use ``reference_base`` /
+    ``reference_range`` instead."""
     contig, pos, transcript_base = cftr_position
     fasta = _build_fasta_around(contig, pos, transcript_base, window=10)
     g = Genome(ensembl, fasta=fasta, verify=False)
     seq = g.sequence(contig, pos, pos)
     assert seq == transcript_base
-    # No FASTA -> empty (does NOT fall back to Tier 2; that's what
-    # reference_base/range are for).
+    # No FASTA -> empty.
     g_no = Genome(ensembl)
     assert g_no.sequence(contig, pos, pos) == ""
 
@@ -294,7 +314,7 @@ def test_genome_sequence_method_mirrors_pyensembl_api(ensembl, cftr_position):
 # --------------------------------------------------------------------
 
 
-def test_tier2_range_uses_single_transcript_fast_path(ensembl):
+def test_cdna_range_uses_single_transcript_fast_path(ensembl):
     t = ensembl.transcript_by_id(_CFTR_TRANSCRIPT_ID)
     start = t.exons[0].start + 5
     end = start + 10
@@ -304,14 +324,14 @@ def test_tier2_range_uses_single_transcript_fast_path(ensembl):
     assert span[-1] == reference_base(ensembl, t.contig, end)
 
 
-def test_tier2_range_spanning_exon_boundary_returns_empty(ensembl):
+def test_cdna_range_spanning_exon_boundary_returns_empty(ensembl):
     t = ensembl.transcript_by_id(_CFTR_TRANSCRIPT_ID)
     boundary = t.exons[0].end
     span = reference_range(ensembl, t.contig, boundary - 2, boundary + 5)
     assert span == ""
 
 
-def test_tier1_range_spanning_exon_boundary_returns_full_sequence(ensembl):
+def test_fasta_range_spanning_exon_boundary_returns_full_sequence(ensembl):
     t = ensembl.transcript_by_id(_CFTR_TRANSCRIPT_ID)
     boundary = t.exons[0].end
     start, end = boundary - 2, boundary + 5

--- a/tests/test_genome_sequence.py
+++ b/tests/test_genome_sequence.py
@@ -1,0 +1,393 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for :mod:`varcode.genome_sequence` (#372).
+
+Covers the test matrix in the PR description:
+
+* ``attach_genome_fasta`` accepts paths, pyfaidx objects, and
+  duck-typed FASTA-shaped objects; rejects garbage; detaches via
+  ``None``; verifies content against transcript cDNA when asked.
+* ``reference_base`` and ``reference_range`` walk the three tiers
+  (FASTA -> transcript cDNA -> empty) including the Tier 2 range
+  fast path and the strand-aware base lookup.
+* ``cryptic_exons`` migration: silently-bailing flanking-region
+  scan replaced by loud warning when no reference covers the range.
+"""
+
+import warnings
+
+import pytest
+from pyensembl import cached_release
+
+import varcode
+from varcode.genome_sequence import (
+    _VARCODE_FASTA_ATTR,
+    attach_genome_fasta,
+    reference_base,
+    reference_range,
+)
+
+
+# --------------------------------------------------------------------
+# Minimal pyfaidx-shaped mock so tests don't need a real chromosome FASTA
+# --------------------------------------------------------------------
+
+
+class _DictBackedFasta:
+    """``{contig: sequence_string}`` adapter shaped like pyfaidx.Fasta.
+
+    ``offset`` is the 1-based genome position of the first character of
+    each contig's sequence (most test fixtures embed a small window
+    around a known locus rather than a full chromosome).
+    """
+    def __init__(self, contig_to_seq, *, offset=1):
+        self._d = dict(contig_to_seq)
+        self._offset = offset
+
+    def __getitem__(self, contig):
+        return _Slicer(self._d.get(contig, ""), self._offset)
+
+
+class _Slicer:
+    def __init__(self, seq, offset):
+        self.seq = seq
+        self._offset = offset
+
+    def __getitem__(self, s):
+        if isinstance(s, slice):
+            lo = max(0, (s.start or 0) - self._offset + 1)
+            hi = max(0, (s.stop or 0) - self._offset + 1)
+            return _Span(self.seq[lo:hi])
+        return _Span(self.seq[s - self._offset + 1])
+
+
+class _Span:
+    def __init__(self, seq):
+        self.seq = seq
+
+
+# --------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------
+
+
+_ENSEMBL_GRCh38 = cached_release(81)
+# CFTR (chr7, + strand) — well-known protein coding transcript.
+_CFTR_TRANSCRIPT_ID = "ENST00000003084"
+
+
+@pytest.fixture
+def genome():
+    """Fresh genome reference, with any prior FASTA attachment cleared.
+
+    ``cached_release`` returns a process-wide singleton so a test that
+    forgets to detach would leak the FASTA into other tests. The
+    teardown defends against that. Also clears the cryptic_exons
+    once-per-genome warn cache so the warning fixture is exercised
+    on every test that reaches it.
+    """
+    from varcode import cryptic_exons
+    g = cached_release(81)
+    if hasattr(g, _VARCODE_FASTA_ATTR):
+        delattr(g, _VARCODE_FASTA_ATTR)
+    cryptic_exons._MISSING_REFERENCE_WARNED.discard(id(g))
+    yield g
+    if hasattr(g, _VARCODE_FASTA_ATTR):
+        delattr(g, _VARCODE_FASTA_ATTR)
+    cryptic_exons._MISSING_REFERENCE_WARNED.discard(id(g))
+
+
+@pytest.fixture
+def cftr_position(genome):
+    """A (contig, position, expected_plus_strand_base) tuple inside
+    CFTR's first exon — known to be covered by Tier 2 (transcript cDNA)
+    and useful as an anchor for Tier 1 fixtures."""
+    t = genome.transcript_by_id(_CFTR_TRANSCRIPT_ID)
+    pos = t.exons[0].start + 5
+    expected = t.sequence[5].upper()
+    return (t.contig, pos, expected)
+
+
+def _build_fasta_around(contig, position, base, window=200):
+    """Build a tiny _DictBackedFasta with ``base`` at ``position`` and
+    'N' elsewhere within a +/-``window`` window."""
+    start_offset = position - window
+    seq = ['N'] * (2 * window + 1)
+    seq[position - start_offset] = base
+    return _DictBackedFasta({contig: ''.join(seq)}, offset=start_offset)
+
+
+# --------------------------------------------------------------------
+# attach_genome_fasta
+# --------------------------------------------------------------------
+
+
+def test_attach_with_dict_backed_object_sets_attribute(genome, cftr_position):
+    contig, pos, base = cftr_position
+    fasta = _build_fasta_around(contig, pos, base)
+    result = attach_genome_fasta(genome, fasta, verify=False)
+    assert result is genome  # returns the genome for chaining
+    assert getattr(genome, _VARCODE_FASTA_ATTR) is fasta
+
+
+def test_attach_with_integer_raises_typeerror(genome):
+    with pytest.raises(TypeError, match="pyfaidx-style protocol"):
+        attach_genome_fasta(genome, 42, verify=False)
+
+
+def test_attach_with_list_raises_typeerror(genome):
+    with pytest.raises(TypeError, match="pyfaidx-style protocol"):
+        attach_genome_fasta(genome, [1, 2, 3], verify=False)
+
+
+def test_reattach_overwrites_silently(genome, cftr_position):
+    contig, pos, base = cftr_position
+    first = _build_fasta_around(contig, pos, base)
+    second = _build_fasta_around(contig, pos, base)
+    attach_genome_fasta(genome, first, verify=False)
+    attach_genome_fasta(genome, second, verify=False)
+    assert getattr(genome, _VARCODE_FASTA_ATTR) is second
+
+
+def test_detach_via_none_removes_attribute(genome, cftr_position):
+    contig, pos, base = cftr_position
+    fasta = _build_fasta_around(contig, pos, base)
+    attach_genome_fasta(genome, fasta, verify=False)
+    assert hasattr(genome, _VARCODE_FASTA_ATTR)
+    attach_genome_fasta(genome, None)
+    assert not hasattr(genome, _VARCODE_FASTA_ATTR)
+
+
+def test_detach_when_nothing_attached_is_no_op(genome):
+    # Should not raise.
+    attach_genome_fasta(genome, None)
+    assert not hasattr(genome, _VARCODE_FASTA_ATTR)
+
+
+def test_verify_emits_warning_on_mismatched_fasta(genome):
+    """A FASTA that disagrees with the transcript cDNA at probed
+    positions triggers the verify-on-attach warning. Catches GRCh37
+    attached to a GRCh38 release."""
+
+    class _AlwaysWrongFasta:
+        def __getitem__(self, contig):
+            return _AlwaysWrongSlicer()
+
+    class _AlwaysWrongSlicer:
+        def __getitem__(self, s):
+            length = (s.stop - s.start) if isinstance(s, slice) else 1
+            return _Span('X' * length)
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        attach_genome_fasta(genome, _AlwaysWrongFasta(), verify=True)
+
+    disagreement = [w for w in captured
+                    if "disagree" in str(w.message).lower()]
+    assert disagreement, [str(w.message) for w in captured]
+
+
+def test_verify_false_suppresses_check(genome):
+    """``verify=False`` skips the probe even when the FASTA would fail it."""
+    class _AlwaysWrongFasta:
+        def __getitem__(self, contig):
+            return _AlwaysWrongSlicer()
+
+    class _AlwaysWrongSlicer:
+        def __getitem__(self, s):
+            length = (s.stop - s.start) if isinstance(s, slice) else 1
+            return _Span('X' * length)
+
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        attach_genome_fasta(genome, _AlwaysWrongFasta(), verify=False)
+
+    assert not any("disagree" in str(w.message).lower() for w in captured)
+
+
+# --------------------------------------------------------------------
+# reference_base — Tier 2 (no FASTA)
+# --------------------------------------------------------------------
+
+
+def test_tier2_returns_transcript_base_on_plus_strand(genome, cftr_position):
+    contig, pos, expected = cftr_position
+    assert reference_base(genome, contig, pos) == expected
+
+
+def test_tier2_returns_plus_strand_base_for_minus_strand_transcript(genome):
+    """For ``-`` strand transcripts the cDNA is reverse-complemented
+    from the + strand. The lookup must return the + strand base —
+    i.e. the complement of whatever the cDNA says at the corresponding
+    spliced offset."""
+    minus_t = next(
+        t for t in genome.transcripts()
+        if t.strand == '-' and t.exons and t.is_protein_coding)
+    pos = minus_t.exons[0].start + 5
+    # Compute the expected base via the same spliced_offset path the
+    # implementation uses, then complement it (since cDNA is on the -
+    # strand for a - strand transcript).
+    offset = minus_t.spliced_offset(pos)
+    cdna_base = minus_t.sequence[offset].upper()
+    expected = cdna_base.translate(str.maketrans("ACGT", "TGCA"))
+    assert reference_base(genome, minus_t.contig, pos) == expected
+
+
+def test_tier2_returns_empty_for_intronic_position(genome):
+    t = genome.transcript_by_id(_CFTR_TRANSCRIPT_ID)
+    # 100 bp inside the first intron.
+    intron_pos = t.exons[0].end + 100
+    assert reference_base(genome, t.contig, intron_pos) == ""
+
+
+# --------------------------------------------------------------------
+# reference_base — Tier 1 (FASTA attached)
+# --------------------------------------------------------------------
+
+
+def test_tier1_returns_fasta_base_when_attached(genome, cftr_position):
+    contig, pos, transcript_base = cftr_position
+    # Build a FASTA that AGREES with the transcript at this position
+    # so verify passes, but stuff 'X's everywhere else so we can tell
+    # Tier 1 is the source for nearby positions.
+    fasta = _build_fasta_around(contig, pos, transcript_base, window=10)
+    attach_genome_fasta(genome, fasta, verify=False)
+    # The probe position should match (FASTA has the right base there).
+    assert reference_base(genome, contig, pos) == transcript_base
+
+
+def test_tier1_falls_through_when_contig_missing(genome, cftr_position):
+    """A FASTA that doesn't carry the requested contig falls through
+    to Tier 2 (transcript cDNA) — does not crash."""
+    contig, pos, transcript_base = cftr_position
+    empty_fasta = _DictBackedFasta({}, offset=1)
+    attach_genome_fasta(genome, empty_fasta, verify=False)
+    # Falls through to Tier 2; transcript-derived base survives.
+    assert reference_base(genome, contig, pos) == transcript_base
+
+
+# --------------------------------------------------------------------
+# reference_range
+# --------------------------------------------------------------------
+
+
+def test_tier2_range_uses_single_transcript_fast_path(genome):
+    t = genome.transcript_by_id(_CFTR_TRANSCRIPT_ID)
+    start = t.exons[0].start + 5
+    end = start + 10
+    span = reference_range(genome, t.contig, start, end)
+    assert len(span) == end - start + 1
+    # First and last base should match what reference_base gives us.
+    assert span[0] == reference_base(genome, t.contig, start)
+    assert span[-1] == reference_base(genome, t.contig, end)
+
+
+def test_tier2_range_spanning_exon_boundary_returns_empty(genome):
+    """A range that crosses into intronic space has uncovered
+    positions; all-or-nothing makes the whole range return ``""``."""
+    t = genome.transcript_by_id(_CFTR_TRANSCRIPT_ID)
+    # Cross from the last base of exon 1 into the first intron.
+    boundary = t.exons[0].end
+    span = reference_range(genome, t.contig, boundary - 2, boundary + 5)
+    assert span == ""
+
+
+def test_tier1_range_spanning_exon_boundary_returns_full_sequence(genome):
+    """With a FASTA attached the same range returns full bases —
+    including the intronic stretch — because Tier 1 doesn't care
+    about exon coverage."""
+    t = genome.transcript_by_id(_CFTR_TRANSCRIPT_ID)
+    boundary = t.exons[0].end
+    start, end = boundary - 2, boundary + 5
+    # Fill the window with arbitrary bases so the lookup succeeds.
+    window_seq = 'ACGTACGTACGTACGTACGT'
+    fasta = _DictBackedFasta(
+        {t.contig: window_seq}, offset=start)
+    attach_genome_fasta(genome, fasta, verify=False)
+    span = reference_range(genome, t.contig, start, end)
+    assert len(span) == end - start + 1
+    assert span == window_seq[:end - start + 1].upper()
+
+
+def test_reference_range_rejects_inverted_range(genome):
+    with pytest.raises(ValueError, match="end=.*< start="):
+        reference_range(genome, "1", 100, 50)
+
+
+# --------------------------------------------------------------------
+# cryptic_exons migration: silent-bail -> loud warning
+# --------------------------------------------------------------------
+
+
+def test_load_vcf_attaches_genome_fasta(genome):
+    """``load_vcf(..., genome_fasta=...)`` attaches the FASTA to the
+    resolved genome before parsing — equivalent to a separate
+    ``attach_genome_fasta`` call but more ergonomic."""
+    import os
+    import tempfile
+
+    from varcode import load_vcf
+
+    body = (
+        "##fileformat=VCFv4.2\n"
+        "##reference=GRCh38\n"
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        "1\t1000\t.\tA\tT\t100\tPASS\t.\n"
+    )
+    fd, path = tempfile.mkstemp(suffix=".vcf")
+    with os.fdopen(fd, "w") as f:
+        f.write(body)
+    try:
+        # Use a known-good DictBackedFasta so verify=True doesn't warn.
+        # The probe lookup happens against real transcripts, so we
+        # need a FASTA that agrees at those positions. Easiest: use
+        # an empty FASTA (no contigs) which falls through verify
+        # silently (zero probed positions = no disagreement).
+        empty_fasta = _DictBackedFasta({}, offset=1)
+        vc = load_vcf(path, genome="GRCh38", genome_fasta=empty_fasta)
+    finally:
+        os.unlink(path)
+    # The resolved genome should have the FASTA attached.
+    assert hasattr(vc[0].genome, _VARCODE_FASTA_ATTR)
+    assert getattr(vc[0].genome, _VARCODE_FASTA_ATTR) is empty_fasta
+
+
+def test_cryptic_exons_warns_when_no_reference_covers_breakpoint(genome):
+    """``enumerate_from_structural_variant`` previously bailed silently
+    when no genome FASTA was attached and the breakpoint fell outside
+    any transcript. Now it warns loudly."""
+    from varcode import StructuralVariant
+    from varcode.cryptic_exons import enumerate_from_structural_variant
+
+    # Intergenic-looking breakpoint between protein-coding genes on
+    # chr1 (gene density is high enough that "intergenic" requires
+    # care; chr1:1_000_000 is in a heterochromatic-ish region).
+    sv = StructuralVariant(
+        contig="1", start=1_000_000, sv_type="BND",
+        alt="N]2:1000000]", mate_contig="2",
+        mate_start=1_000_000, mate_orientation="]]",
+        genome=genome,
+    )
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        candidates = enumerate_from_structural_variant(sv, genome=genome)
+
+    msgs = [str(w.message) for w in captured]
+    # Either a no-reference warning fires (the migration's intent), or
+    # transcripts coincidentally cover this region — both branches are
+    # acceptable, but in the no-coverage case the message must be loud.
+    no_ref_warnings = [m for m in msgs if "no reference sequence" in m]
+    if not candidates:
+        # If we produced nothing, it's because the reference was absent
+        # — verify the warning fired.
+        assert no_ref_warnings, msgs

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -25,6 +25,11 @@ from .annotators import (
     use_annotator,
 )
 from .errors import ReferenceMismatchError, SampleNotFoundError
+from .genome_sequence import (
+    attach_genome_fasta,
+    reference_base,
+    reference_range,
+)
 from .germline import (
     GenomeBuildMismatchError,
     GermlineContext,
@@ -169,6 +174,11 @@ __all__ = [
     "detect_loh",
     "enumerate_phase_hypotheses",
     "predict_germline_aware_effect",
+
+    # Genome FASTA attachment + raw reference lookup (openvax/varcode#372)
+    "attach_genome_fasta",
+    "reference_base",
+    "reference_range",
 
     # file loading
     "load_maf",

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -25,11 +25,8 @@ from .annotators import (
     use_annotator,
 )
 from .errors import ReferenceMismatchError, SampleNotFoundError
-from .genome_sequence import (
-    attach_genome_fasta,
-    reference_base,
-    reference_range,
-)
+from .genome import Genome
+from .genome_sequence import reference_base, reference_range
 from .germline import (
     GenomeBuildMismatchError,
     GermlineContext,
@@ -175,8 +172,8 @@ __all__ = [
     "enumerate_phase_hypotheses",
     "predict_germline_aware_effect",
 
-    # Genome FASTA attachment + raw reference lookup (openvax/varcode#372)
-    "attach_genome_fasta",
+    # Genome wrapper + tiered reference lookup (openvax/varcode#372)
+    "Genome",
     "reference_base",
     "reference_range",
 

--- a/varcode/cryptic_exons.py
+++ b/varcode/cryptic_exons.py
@@ -58,6 +58,7 @@ argument directly, grounding the candidates in actual molecules
 rather than inferred reference+breakpoint reconstructions.
 """
 
+import weakref as _weakref
 from typing import Callable, List, Optional, Tuple
 
 from .effects.effect_classes import CrypticExonCandidate
@@ -345,12 +346,13 @@ def enumerate_from_structural_variant(
     return candidates
 
 
-# Module-level dedup for raw pyensembl genomes that don't carry an
-# instance ``_missing_reference_warned`` flag (varcode.Genome does;
-# bare pyensembl.Genome doesn't). For the wrapped case, dedup lives
-# on the instance and is GC'd with it. For the bare case, this
-# process-wide set keyed on id(genome) is the next-best thing.
-_BARE_GENOME_MISSING_REFERENCE_WARNED = set()
+# Dedup for bare pyensembl genomes that don't carry an instance
+# ``_missing_reference_warned`` flag (varcode.Genome does; bare
+# pyensembl.Genome doesn't). WeakValueDictionary keyed on id(genome)
+# with the genome itself as the value: when the genome is GC'd the
+# entry self-clears, so we don't false-suppress a future warning for
+# a different genome that happens to land at the same id.
+_BARE_GENOME_WARN_LOG = _weakref.WeakValueDictionary()
 
 
 def _warn_missing_reference_once(genome):
@@ -362,8 +364,8 @@ def _warn_missing_reference_once(genome):
 
     Dedup state lives on the genome instance when possible
     (``varcode.Genome`` carries ``_missing_reference_warned``); for
-    bare pyensembl genomes we fall back to a module-level set keyed
-    on ``id(genome)``.
+    bare pyensembl genomes we fall back to a weakref-backed log so
+    GC'd genomes' ids can't false-suppress warnings on later objects.
     """
     import warnings
 
@@ -373,11 +375,16 @@ def _warn_missing_reference_once(genome):
             return
         genome._missing_reference_warned = True
     else:
-        # Bare pyensembl.Genome — fall back to module-level dedup.
+        # Bare pyensembl.Genome — weakref-keyed dedup.
         key = id(genome)
-        if key in _BARE_GENOME_MISSING_REFERENCE_WARNED:
+        if key in _BARE_GENOME_WARN_LOG:
             return
-        _BARE_GENOME_MISSING_REFERENCE_WARNED.add(key)
+        try:
+            _BARE_GENOME_WARN_LOG[key] = genome
+        except TypeError:
+            # Genome type can't be weakly referenced (rare). Emit the
+            # warning anyway — better to over-warn than miss a signal.
+            pass
 
     warnings.warn(
         "cryptic_exons: no reference sequence available for one or "

--- a/varcode/cryptic_exons.py
+++ b/varcode/cryptic_exons.py
@@ -319,18 +319,19 @@ def enumerate_from_structural_variant(
     if mate_contig is not None and mate_start is not None:
         breakpoints.append((mate_contig, mate_start))
 
+    from .genome_sequence import reference_range
+
     for contig, pos in breakpoints:
         if genome is None:
             continue
-        try:
-            ref_seq = genome.genome.sequence(
-                contig, pos - flank, pos + flank)
-        except Exception:
-            try:
-                ref_seq = genome.genome.contig_sequence(contig)[
-                    max(0, pos - flank):pos + flank]
-            except Exception:
-                continue
+        ref_seq = reference_range(genome, contig, pos - flank, pos + flank)
+        if not ref_seq:
+            # Warn once per process — firing per-breakpoint creates noise
+            # in pipelines that annotate many SVs without an attached
+            # FASTA. The user gets one actionable signal; subsequent
+            # uncovered breakpoints are silent.
+            _warn_missing_reference_once(genome)
+            continue
         candidates.extend(enumerate_candidates(
             contig=contig,
             sequence=ref_seq,
@@ -342,3 +343,30 @@ def enumerate_from_structural_variant(
         key=lambda c: (c.donor_score or 0) + (c.acceptor_score or 0),
         reverse=True)
     return candidates
+
+
+_MISSING_REFERENCE_WARNED = set()
+
+
+def _warn_missing_reference_once(genome):
+    """Emit the no-FASTA warning at most once per process per genome.
+
+    Cryptic-exon scoring runs implicitly during SV effect prediction;
+    a pipeline annotating many SVs without an attached FASTA would
+    otherwise get one warning per breakpoint. One actionable warning
+    is enough; the rest are noise.
+    """
+    import warnings
+    key = id(genome)
+    if key in _MISSING_REFERENCE_WARNED:
+        return
+    _MISSING_REFERENCE_WARNED.add(key)
+    warnings.warn(
+        "cryptic_exons: no reference sequence available for one or "
+        "more breakpoints (positions outside any annotated transcript, "
+        "and no chromosome FASTA attached to this genome). Attach a "
+        "FASTA with varcode.attach_genome_fasta(genome, fasta) to "
+        "enable cryptic-exon scoring outside annotated transcripts. "
+        "This warning fires once per genome per process; subsequent "
+        "uncovered breakpoints are silent.",
+        stacklevel=3)

--- a/varcode/cryptic_exons.py
+++ b/varcode/cryptic_exons.py
@@ -326,9 +326,9 @@ def enumerate_from_structural_variant(
             continue
         ref_seq = reference_range(genome, contig, pos - flank, pos + flank)
         if not ref_seq:
-            # Warn once per process — firing per-breakpoint creates noise
-            # in pipelines that annotate many SVs without an attached
-            # FASTA. The user gets one actionable signal; subsequent
+            # Warn once per genome — firing per-breakpoint creates noise
+            # in pipelines that annotate many SVs without a FASTA. The
+            # user gets one actionable signal per genome; subsequent
             # uncovered breakpoints are silent.
             _warn_missing_reference_once(genome)
             continue
@@ -345,28 +345,46 @@ def enumerate_from_structural_variant(
     return candidates
 
 
-_MISSING_REFERENCE_WARNED = set()
+# Module-level dedup for raw pyensembl genomes that don't carry an
+# instance ``_missing_reference_warned`` flag (varcode.Genome does;
+# bare pyensembl.Genome doesn't). For the wrapped case, dedup lives
+# on the instance and is GC'd with it. For the bare case, this
+# process-wide set keyed on id(genome) is the next-best thing.
+_BARE_GENOME_MISSING_REFERENCE_WARNED = set()
 
 
 def _warn_missing_reference_once(genome):
-    """Emit the no-FASTA warning at most once per process per genome.
+    """Emit the no-FASTA warning at most once per genome.
 
     Cryptic-exon scoring runs implicitly during SV effect prediction;
-    a pipeline annotating many SVs without an attached FASTA would
-    otherwise get one warning per breakpoint. One actionable warning
-    is enough; the rest are noise.
+    a pipeline annotating many SVs without a FASTA would otherwise get
+    one warning per breakpoint. One actionable warning is enough.
+
+    Dedup state lives on the genome instance when possible
+    (``varcode.Genome`` carries ``_missing_reference_warned``); for
+    bare pyensembl genomes we fall back to a module-level set keyed
+    on ``id(genome)``.
     """
     import warnings
-    key = id(genome)
-    if key in _MISSING_REFERENCE_WARNED:
-        return
-    _MISSING_REFERENCE_WARNED.add(key)
+
+    # Per-instance state (varcode.Genome) — preferred.
+    if hasattr(genome, "_missing_reference_warned"):
+        if genome._missing_reference_warned:
+            return
+        genome._missing_reference_warned = True
+    else:
+        # Bare pyensembl.Genome — fall back to module-level dedup.
+        key = id(genome)
+        if key in _BARE_GENOME_MISSING_REFERENCE_WARNED:
+            return
+        _BARE_GENOME_MISSING_REFERENCE_WARNED.add(key)
+
     warnings.warn(
         "cryptic_exons: no reference sequence available for one or "
         "more breakpoints (positions outside any annotated transcript, "
-        "and no chromosome FASTA attached to this genome). Attach a "
-        "FASTA with varcode.attach_genome_fasta(genome, fasta) to "
-        "enable cryptic-exon scoring outside annotated transcripts. "
-        "This warning fires once per genome per process; subsequent "
-        "uncovered breakpoints are silent.",
+        "and no chromosome FASTA attached to this genome). Construct "
+        "the genome with varcode.Genome(release, fasta=...) to enable "
+        "cryptic-exon scoring outside annotated transcripts. This "
+        "warning fires once per genome; subsequent uncovered "
+        "breakpoints are silent.",
         stacklevel=3)

--- a/varcode/cryptic_exons.py
+++ b/varcode/cryptic_exons.py
@@ -58,10 +58,12 @@ argument directly, grounding the candidates in actual molecules
 rather than inferred reference+breakpoint reconstructions.
 """
 
+import warnings
 import weakref as _weakref
 from typing import Callable, List, Optional, Tuple
 
 from .effects.effect_classes import CrypticExonCandidate
+from .genome_sequence import reference_range
 
 
 # --------------------------------------------------------------------
@@ -320,8 +322,6 @@ def enumerate_from_structural_variant(
     if mate_contig is not None and mate_start is not None:
         breakpoints.append((mate_contig, mate_start))
 
-    from .genome_sequence import reference_range
-
     for contig, pos in breakpoints:
         if genome is None:
             continue
@@ -367,8 +367,6 @@ def _warn_missing_reference_once(genome):
     bare pyensembl genomes we fall back to a weakref-backed log so
     GC'd genomes' ids can't false-suppress warnings on later objects.
     """
-    import warnings
-
     # Per-instance state (varcode.Genome) — preferred.
     if hasattr(genome, "_missing_reference_warned"):
         if genome._missing_reference_warned:

--- a/varcode/genome.py
+++ b/varcode/genome.py
@@ -1,0 +1,288 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Declarative wrapper for a pyensembl ``Genome`` + optional chromosome FASTA.
+
+varcode's reference is the pyensembl ``Genome`` object. By default it
+ships transcript and protein FASTAs but not the chromosome FASTA, so
+features needing raw genomic bases (intronic, intergenic, flanking)
+fall back to transcript-cDNA coverage only. :class:`Genome` is the
+construction-time composition point: pass a release identifier plus
+an optional ``fasta``, and downstream lookups see both tiers.
+
+Acts as a drop-in for ``pyensembl.Genome`` — every pyensembl attribute
+is accessible via :py:meth:`__getattr__` delegation, so existing code
+that calls ``genome.transcripts_at_locus(...)``,
+``genome.reference_name``, etc. works unchanged.
+
+This module is a stopgap until ``pyensembl.Genome`` natively supports
+the chromosome FASTA (tracked in openvax/pyensembl#337). Once that
+lands, this wrapper either becomes a one-line delegate or evaporates.
+Designed so the migration is straightforward — the API surface here
+(``Genome.sequence()``, ``Genome.fasta``, the construction-time
+composition pattern) is intentionally identical to the proposed
+pyensembl-native API.
+
+Tracked in openvax/varcode#372.
+"""
+
+import warnings
+
+
+class Genome:
+    """Pyensembl ``Genome`` + optional chromosome FASTA.
+
+    Parameters
+    ----------
+    ensembl_release : int, str, pyensembl.Genome, or Genome
+        Release identifier — passes through :func:`varcode.reference.infer_genome`,
+        so the same shapes accepted by ``load_vcf(genome=...)`` work here.
+        Passing another :class:`Genome` rewraps idempotently (inheriting
+        ``fasta`` unless overridden).
+    fasta : str, path-like, FASTA-shaped object, or None, optional
+        Optional chromosome FASTA:
+
+        * Path string — opened with pyfaidx (only required on this path).
+        * ``pyfaidx.Fasta`` — used as-is.
+        * Any object supporting ``fa[contig][start:end]`` and returning
+          a string or an object with ``.seq``.
+        * ``None`` — no chromosome-level access; features fall back to
+          transcript cDNA (Tier 2 only).
+    verify : bool, optional
+        When True (default) and ``fasta`` is provided, spot-check a few
+        exonic positions against pyensembl's transcript cDNA to catch
+        mislabeled FASTAs (e.g. GRCh37 attached to a GRCh38 release).
+        Iterates ``self.transcripts()`` which on a fresh process may
+        trigger lazy DB construction; pass ``verify=False`` to defer
+        that cost.
+
+    Examples
+    --------
+
+    >>> import varcode
+    >>> g = varcode.Genome(81, fasta="/path/to/GRCh38.fa")  # doctest: +SKIP
+    >>> vc = varcode.load_vcf("tumor.vcf", genome=g)        # doctest: +SKIP
+    >>> g.sequence("7", 117_480_000, 117_480_050)           # doctest: +SKIP
+    'AC...'
+
+    Notes
+    -----
+
+    Returned sequence is always uppercase. Soft-masked (lowercase)
+    repeat annotations from the FASTA are dropped — varcode treats all
+    bases uniformly. Callers that need the soft-masking signal should
+    read the FASTA directly.
+    """
+
+    def __init__(self, ensembl_release=None, *, fasta=None, verify=True):
+        # Late imports break a circular dep: reference.py imports
+        # pyensembl; we don't want this module imported during varcode
+        # package construction in unusual orders.
+        from .reference import infer_genome
+
+        fasta_was_provided = fasta is not None
+        if isinstance(ensembl_release, Genome):
+            # Idempotent rewrap. Inherits ._ensembl always; inherits
+            # .fasta unless the caller is providing a fresh one.
+            self._ensembl = ensembl_release._ensembl
+            if fasta_was_provided:
+                self.fasta = _resolve_fasta(fasta, self._ensembl)
+            else:
+                self.fasta = ensembl_release.fasta
+        elif ensembl_release is None:
+            # Tests / placeholder use — no genome to delegate to.
+            # Most consumers will fail downstream when they try to
+            # look up transcripts; intentional, no silent surprise.
+            self._ensembl = None
+            self.fasta = (_resolve_fasta(fasta, None)
+                          if fasta_was_provided else None)
+        else:
+            self._ensembl, _ = infer_genome(ensembl_release)
+            self.fasta = (_resolve_fasta(fasta, self._ensembl)
+                          if fasta_was_provided else None)
+
+        # Verify only when the caller freshly provided a FASTA.
+        # Inheriting a verified FASTA on rewrap doesn't need a re-check.
+        if (verify and fasta_was_provided
+                and self.fasta is not None
+                and self._ensembl is not None):
+            _verify_fasta_against_transcripts(self._ensembl, self.fasta)
+
+        # Per-instance warn-once for missing-reference signals from
+        # consumers (cryptic_exons, etc.). Bound to this Genome's
+        # lifetime — no module-level cache to invalidate.
+        self._missing_reference_warned = False
+
+    def __getattr__(self, name):
+        """Delegate everything else to the wrapped pyensembl Genome.
+
+        Called only when normal attribute lookup fails, so explicit
+        attributes (``_ensembl``, ``fasta``, ``_missing_reference_warned``)
+        still win. Underscore-prefixed names are not delegated to keep
+        Python internals (pickling, copying) from accidentally pulling
+        private state from the wrapped object.
+        """
+        if name.startswith("_"):
+            raise AttributeError(name)
+        ensembl = self.__dict__.get("_ensembl")
+        if ensembl is None:
+            raise AttributeError(
+                "varcode.Genome has no wrapped pyensembl Genome; "
+                "cannot resolve attribute %r" % name)
+        return getattr(ensembl, name)
+
+    def __repr__(self):
+        ref = getattr(self._ensembl, "reference_name", "?")
+        fasta_repr = "no FASTA" if self.fasta is None else "FASTA attached"
+        return "varcode.Genome(reference_name=%r, %s)" % (ref, fasta_repr)
+
+    # -- chromosome FASTA API (mirrors openvax/pyensembl#337) ----------
+
+    def sequence(self, contig, start, end):
+        """Chromosome FASTA sequence on the ``+`` strand.
+
+        1-based inclusive coordinates. Returns ``""`` when no FASTA is
+        attached or the contig / range isn't covered. Mirrors the
+        ``pyensembl.Genome.sequence()`` shape proposed upstream so the
+        eventual migration is mechanical.
+        """
+        if self.fasta is None:
+            return ""
+        from .genome_sequence import _tier1_range
+        return _tier1_range(self.fasta, contig, start, end)
+
+    # -- tiered lookup convenience -------------------------------------
+
+    def reference_base(self, contig, position):
+        """Tiered ``+`` strand base lookup (FASTA → transcript cDNA → ``""``).
+
+        Convenience method delegating to
+        :func:`varcode.genome_sequence.reference_base`.
+        """
+        from .genome_sequence import reference_base
+        return reference_base(self, contig, position)
+
+    def reference_range(self, contig, start, end):
+        """Tiered ``+`` strand range lookup. All-or-nothing — returns
+        ``""`` if any position in the range is uncovered by the chosen
+        tier."""
+        from .genome_sequence import reference_range
+        return reference_range(self, contig, start, end)
+
+
+# --------------------------------------------------------------------
+# Internal helpers (shared with varcode.genome_sequence). Centralized
+# here because Genome construction is the only public path that builds
+# them up.
+# --------------------------------------------------------------------
+
+
+def _resolve_fasta(arg, ensembl_genome):
+    """Validate and normalize a FASTA argument.
+
+    Path strings open via pyfaidx; objects are probed against a known
+    contig from the genome (``hasattr(arg, '__getitem__')`` alone is
+    too permissive — strings, lists, etc. all have it but don't honor
+    the slice protocol).
+    """
+    import os
+    if isinstance(arg, (str, bytes, os.PathLike)):
+        try:
+            import pyfaidx
+        except ImportError as e:
+            raise ImportError(
+                "varcode.Genome(fasta=<path>) needs pyfaidx. Install "
+                "with `pip install pyfaidx`, or pass a pre-opened FASTA "
+                "object that supports fa[contig][start:end]."
+            ) from e
+        return pyfaidx.Fasta(os.fspath(arg))
+
+    probe_contig = _probe_contig_for_validation(ensembl_genome)
+    if probe_contig is None:
+        # Can't validate (no genome, or genome reports no contigs).
+        # Accept on faith; the first real lookup will fail loudly if
+        # the object is malformed.
+        return arg
+    try:
+        slicer = arg[probe_contig]
+        _ = slicer[0:1]
+    except Exception as e:
+        raise TypeError(
+            "varcode.Genome: object of type %s does not honor the "
+            "pyfaidx-style protocol fa[contig][start:end] (probe "
+            "against contig %r failed: %s). Pass a path, a pyfaidx.Fasta, "
+            "or an object with the same indexing shape."
+            % (type(arg).__name__, probe_contig, e))
+    return arg
+
+
+def _probe_contig_for_validation(genome):
+    """Pick a contig name from the genome for probing a candidate FASTA.
+    Returns ``None`` if no genome was attached or it can't enumerate."""
+    if genome is None:
+        return None
+    for accessor in ("contigs", "all_contigs"):
+        getter = getattr(genome, accessor, None)
+        if callable(getter):
+            try:
+                contigs = list(getter())
+            except Exception:
+                contigs = []
+            if contigs:
+                return contigs[0]
+    return None
+
+
+def _verify_fasta_against_transcripts(ensembl_genome, fasta):
+    """Spot-check that the attached FASTA matches pyensembl's transcript
+    cDNA at a few exonic positions. Warns (does not raise) on mismatch
+    so users with intentionally-divergent setups can override with
+    ``verify=False``.
+    """
+    from .genome_sequence import _read_transcript_base, _tier1_range
+
+    try:
+        transcripts = list(ensembl_genome.transcripts())[:50]
+    except Exception:
+        return
+
+    checked = 0
+    mismatches = []
+    for t in transcripts:
+        if checked >= 3:
+            break
+        if not t.exons:
+            continue
+        try:
+            exon = t.exons[0]
+            position = exon.start + 1
+            tier2 = _read_transcript_base(t, position)
+            tier1 = _tier1_range(fasta, t.contig, position, position)
+        except Exception:
+            continue
+        if not tier1 or not tier2:
+            continue
+        checked += 1
+        if tier1 != tier2:
+            mismatches.append((t.contig, position, tier1, tier2))
+
+    if mismatches:
+        details = "; ".join(
+            "%s:%d FASTA=%r vs transcript=%r" % m for m in mismatches)
+        warnings.warn(
+            "varcode.Genome: FASTA contents disagree with pyensembl "
+            "transcript sequence at %d/%d probed positions (%s). "
+            "The attached FASTA may be for a different build than "
+            "the pyensembl release (e.g. GRCh37 vs GRCh38). Pass "
+            "verify=False to suppress this check."
+            % (len(mismatches), checked, details),
+            stacklevel=3)

--- a/varcode/genome.py
+++ b/varcode/genome.py
@@ -48,6 +48,7 @@ from .genome_sequence import (
     reference_base as _reference_base_lookup,
     reference_range as _reference_range_lookup,
 )
+from .reference import infer_genome
 
 
 class Genome:
@@ -91,6 +92,11 @@ class Genome:
           a string or an object with ``.seq``.
         * ``None`` — no chromosome-level access; features fall back to
           transcript cDNA.
+
+        varcode does not take ownership of the FASTA object — when the
+        caller passes a pre-opened ``pyfaidx.Fasta``, the caller is
+        responsible for its lifetime. Closing the FASTA after passing
+        it to ``Genome`` will cause subsequent lookups to fail.
     verify :
         When True (default) and ``fasta`` is provided, spot-check a few
         exonic positions against pyensembl's transcript cDNA to catch
@@ -115,6 +121,12 @@ class Genome:
     repeat annotations from the FASTA are dropped — varcode treats all
     bases uniformly. Callers that need the soft-masking signal should
     read the FASTA directly.
+
+    Equality and hashing fall back to ``object`` identity — two
+    ``Genome`` instances wrapping the same pyensembl release compare
+    unequal. This is intentional: a wrapper with an attached FASTA
+    and one without are different objects in any sense that matters
+    for varcode features, even if they share the same ``reference_name``.
     """
 
     def __init__(
@@ -123,11 +135,6 @@ class Genome:
             *,
             fasta: Optional[Any] = None,
             verify: bool = True):
-        # Late import: reference.py imports pyensembl at the module top;
-        # importing it eagerly here would entrench the cycle that
-        # pyensembl already creates with varcode's top-level package.
-        from .reference import infer_genome
-
         fasta_was_provided = fasta is not None
         if isinstance(ensembl_release, Genome):
             # Idempotent rewrap. Inherits ._ensembl always; inherits
@@ -183,8 +190,7 @@ class Genome:
     def __repr__(self) -> str:
         ref = getattr(self._ensembl, "reference_name", "?")
         fasta_repr = "no FASTA" if self.fasta is None else "FASTA attached"
-        return "varcode.Genome(reference_name=%r, %s, id=%#x)" % (
-            ref, fasta_repr, id(self))
+        return "varcode.Genome(reference_name=%r, %s)" % (ref, fasta_repr)
 
     # -- chromosome FASTA API (mirrors openvax/pyensembl#337) ----------
 

--- a/varcode/genome.py
+++ b/varcode/genome.py
@@ -192,6 +192,16 @@ class Genome:
         fasta_repr = "no FASTA" if self.fasta is None else "FASTA attached"
         return "varcode.Genome(reference_name=%r, %s)" % (ref, fasta_repr)
 
+    def __dir__(self):
+        """Include attributes of the wrapped pyensembl Genome so
+        ``dir(genome)`` and IDE auto-completion surface the full
+        delegated API, not just the wrapper's own attributes."""
+        own = set(super().__dir__())
+        ensembl = self.__dict__.get("_ensembl")
+        if ensembl is not None:
+            own.update(dir(ensembl))
+        return sorted(own)
+
     # -- chromosome FASTA API (mirrors openvax/pyensembl#337) ----------
 
     def sequence(self, contig: str, start: int, end: int) -> str:
@@ -250,7 +260,20 @@ def _resolve_fasta(arg: Any, ensembl_genome: Any) -> Any:
                 "with `pip install pyfaidx`, or pass a pre-opened FASTA "
                 "object that supports fa[contig][start:end]."
             ) from e
-        return pyfaidx.Fasta(os.fspath(arg))
+        path_str = os.fspath(arg)
+        try:
+            return pyfaidx.Fasta(path_str)
+        except (FileNotFoundError, OSError) as e:
+            # Frame the path error as a varcode problem so users see
+            # "the FASTA you passed to Genome" rather than a bare
+            # pyfaidx traceback that they have to translate back.
+            raise FileNotFoundError(
+                "varcode.Genome(fasta=%r): could not open FASTA at this "
+                "path (%s: %s). Check the path and that the file is "
+                "readable; pyfaidx needs the FASTA and a matching .fai "
+                "index alongside it (the index is created automatically "
+                "on first open if writable)."
+                % (path_str, type(e).__name__, e)) from e
 
     probe_contig = _probe_contig_for_validation(ensembl_genome)
     if probe_contig is None:

--- a/varcode/genome.py
+++ b/varcode/genome.py
@@ -17,7 +17,7 @@ ships transcript and protein FASTAs but not the chromosome FASTA, so
 features needing raw genomic bases (intronic, intergenic, flanking)
 fall back to transcript-cDNA coverage only. :class:`Genome` is the
 construction-time composition point: pass a release identifier plus
-an optional ``fasta``, and downstream lookups see both tiers.
+an optional ``fasta``, and downstream lookups see both sources.
 
 Acts as a drop-in for ``pyensembl.Genome`` — every pyensembl attribute
 is accessible via :py:meth:`__getattr__` delegation, so existing code
@@ -35,20 +35,54 @@ pyensembl-native API.
 Tracked in openvax/varcode#372.
 """
 
+import os
 import warnings
+from typing import Any, Optional
+
+# Module-level imports of the lookup helpers. Functions in this file
+# call into them on hot paths; per-call imports would add measurable
+# overhead in tight loops (e.g. left-alignment shifts in #369).
+from .genome_sequence import (
+    _fasta_range,
+    _read_transcript_base,
+    reference_base as _reference_base_lookup,
+    reference_range as _reference_range_lookup,
+)
 
 
 class Genome:
     """Pyensembl ``Genome`` + optional chromosome FASTA.
 
+    Two source layers under one object:
+
+    * ``self.fasta`` — optional chromosome FASTA. When attached,
+      :meth:`sequence` reads from it directly; :meth:`reference_base`
+      and :meth:`reference_range` prefer it before falling back to
+      transcript cDNA.
+    * Wrapped pyensembl ``Genome`` — transcript annotations + cDNA.
+      Always present; provides the fallback for exonic positions
+      when no FASTA is attached.
+
+    The two methods have intentionally different fall-through semantics:
+
+    * :meth:`sequence` — chromosome FASTA *only*. Returns ``""`` when
+      no FASTA is attached. Mirrors the proposed
+      ``pyensembl.Genome.sequence()`` shape from
+      openvax/pyensembl#337 so the eventual upstream migration is
+      mechanical.
+    * :meth:`reference_base` / :meth:`reference_range` — tiered.
+      FASTA first when attached; otherwise transcript cDNA. Use these
+      when you want "whatever varcode can tell you" about a position.
+
     Parameters
     ----------
-    ensembl_release : int, str, pyensembl.Genome, or Genome
+    ensembl_release :
         Release identifier — passes through :func:`varcode.reference.infer_genome`,
-        so the same shapes accepted by ``load_vcf(genome=...)`` work here.
+        so the same shapes accepted by ``load_vcf(genome=...)`` work here
+        (int, reference-name string, ``pyensembl.Genome``).
         Passing another :class:`Genome` rewraps idempotently (inheriting
         ``fasta`` unless overridden).
-    fasta : str, path-like, FASTA-shaped object, or None, optional
+    fasta :
         Optional chromosome FASTA:
 
         * Path string — opened with pyfaidx (only required on this path).
@@ -56,8 +90,8 @@ class Genome:
         * Any object supporting ``fa[contig][start:end]`` and returning
           a string or an object with ``.seq``.
         * ``None`` — no chromosome-level access; features fall back to
-          transcript cDNA (Tier 2 only).
-    verify : bool, optional
+          transcript cDNA.
+    verify :
         When True (default) and ``fasta`` is provided, spot-check a few
         exonic positions against pyensembl's transcript cDNA to catch
         mislabeled FASTAs (e.g. GRCh37 attached to a GRCh38 release).
@@ -83,10 +117,15 @@ class Genome:
     read the FASTA directly.
     """
 
-    def __init__(self, ensembl_release=None, *, fasta=None, verify=True):
-        # Late imports break a circular dep: reference.py imports
-        # pyensembl; we don't want this module imported during varcode
-        # package construction in unusual orders.
+    def __init__(
+            self,
+            ensembl_release: Any = None,
+            *,
+            fasta: Optional[Any] = None,
+            verify: bool = True):
+        # Late import: reference.py imports pyensembl at the module top;
+        # importing it eagerly here would entrench the cycle that
+        # pyensembl already creates with varcode's top-level package.
         from .reference import infer_genome
 
         fasta_was_provided = fasta is not None
@@ -98,14 +137,12 @@ class Genome:
                 self.fasta = _resolve_fasta(fasta, self._ensembl)
             else:
                 self.fasta = ensembl_release.fasta
-        elif ensembl_release is None:
-            # Tests / placeholder use — no genome to delegate to.
-            # Most consumers will fail downstream when they try to
-            # look up transcripts; intentional, no silent surprise.
-            self._ensembl = None
-            self.fasta = (_resolve_fasta(fasta, None)
-                          if fasta_was_provided else None)
         else:
+            if ensembl_release is None:
+                raise ValueError(
+                    "varcode.Genome requires an ensembl_release argument "
+                    "(int release number, reference-name string, or a "
+                    "pyensembl.Genome / varcode.Genome instance).")
             self._ensembl, _ = infer_genome(ensembl_release)
             self.fasta = (_resolve_fasta(fasta, self._ensembl)
                           if fasta_was_provided else None)
@@ -127,9 +164,12 @@ class Genome:
 
         Called only when normal attribute lookup fails, so explicit
         attributes (``_ensembl``, ``fasta``, ``_missing_reference_warned``)
-        still win. Underscore-prefixed names are not delegated to keep
-        Python internals (pickling, copying) from accidentally pulling
-        private state from the wrapped object.
+        still win. Underscore-prefixed names are not delegated — this
+        prevents infinite recursion when Python's copy / pickle
+        machinery probes for ``__deepcopy__`` / ``__reduce__`` /
+        ``__getstate__`` etc., and keeps the wrapper's private state
+        from accidentally pulling private state from the wrapped
+        object.
         """
         if name.startswith("_"):
             raise AttributeError(name)
@@ -140,53 +180,54 @@ class Genome:
                 "cannot resolve attribute %r" % name)
         return getattr(ensembl, name)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         ref = getattr(self._ensembl, "reference_name", "?")
         fasta_repr = "no FASTA" if self.fasta is None else "FASTA attached"
-        return "varcode.Genome(reference_name=%r, %s)" % (ref, fasta_repr)
+        return "varcode.Genome(reference_name=%r, %s, id=%#x)" % (
+            ref, fasta_repr, id(self))
 
     # -- chromosome FASTA API (mirrors openvax/pyensembl#337) ----------
 
-    def sequence(self, contig, start, end):
+    def sequence(self, contig: str, start: int, end: int) -> str:
         """Chromosome FASTA sequence on the ``+`` strand.
 
         1-based inclusive coordinates. Returns ``""`` when no FASTA is
-        attached or the contig / range isn't covered. Mirrors the
-        ``pyensembl.Genome.sequence()`` shape proposed upstream so the
-        eventual migration is mechanical.
+        attached or the contig / range isn't covered.
+
+        FASTA-only — does **not** fall back to transcript cDNA. Use
+        :meth:`reference_base` / :meth:`reference_range` for the
+        tiered lookup. The split is deliberate: this method mirrors
+        the proposed ``pyensembl.Genome.sequence()`` API so callers
+        who want raw chromosome bases (and the upstream migration
+        path) can use it unambiguously.
         """
         if self.fasta is None:
             return ""
-        from .genome_sequence import _tier1_range
-        return _tier1_range(self.fasta, contig, start, end)
+        return _fasta_range(self.fasta, contig, start, end)
 
     # -- tiered lookup convenience -------------------------------------
 
-    def reference_base(self, contig, position):
+    def reference_base(self, contig: str, position: int) -> str:
         """Tiered ``+`` strand base lookup (FASTA → transcript cDNA → ``""``).
 
         Convenience method delegating to
         :func:`varcode.genome_sequence.reference_base`.
         """
-        from .genome_sequence import reference_base
-        return reference_base(self, contig, position)
+        return _reference_base_lookup(self, contig, position)
 
-    def reference_range(self, contig, start, end):
+    def reference_range(self, contig: str, start: int, end: int) -> str:
         """Tiered ``+`` strand range lookup. All-or-nothing — returns
         ``""`` if any position in the range is uncovered by the chosen
-        tier."""
-        from .genome_sequence import reference_range
-        return reference_range(self, contig, start, end)
+        source."""
+        return _reference_range_lookup(self, contig, start, end)
 
 
 # --------------------------------------------------------------------
-# Internal helpers (shared with varcode.genome_sequence). Centralized
-# here because Genome construction is the only public path that builds
-# them up.
+# Internal helpers
 # --------------------------------------------------------------------
 
 
-def _resolve_fasta(arg, ensembl_genome):
+def _resolve_fasta(arg: Any, ensembl_genome: Any) -> Any:
     """Validate and normalize a FASTA argument.
 
     Path strings open via pyfaidx; objects are probed against a known
@@ -194,7 +235,6 @@ def _resolve_fasta(arg, ensembl_genome):
     too permissive — strings, lists, etc. all have it but don't honor
     the slice protocol).
     """
-    import os
     if isinstance(arg, (str, bytes, os.PathLike)):
         try:
             import pyfaidx
@@ -208,9 +248,8 @@ def _resolve_fasta(arg, ensembl_genome):
 
     probe_contig = _probe_contig_for_validation(ensembl_genome)
     if probe_contig is None:
-        # Can't validate (no genome, or genome reports no contigs).
-        # Accept on faith; the first real lookup will fail loudly if
-        # the object is malformed.
+        # Can't validate (genome reports no contigs). Accept on faith;
+        # the first real lookup will fail loudly if the object is malformed.
         return arg
     try:
         slicer = arg[probe_contig]
@@ -225,9 +264,9 @@ def _resolve_fasta(arg, ensembl_genome):
     return arg
 
 
-def _probe_contig_for_validation(genome):
+def _probe_contig_for_validation(genome: Any) -> Optional[str]:
     """Pick a contig name from the genome for probing a candidate FASTA.
-    Returns ``None`` if no genome was attached or it can't enumerate."""
+    Returns ``None`` if the genome can't enumerate."""
     if genome is None:
         return None
     for accessor in ("contigs", "all_contigs"):
@@ -242,14 +281,12 @@ def _probe_contig_for_validation(genome):
     return None
 
 
-def _verify_fasta_against_transcripts(ensembl_genome, fasta):
+def _verify_fasta_against_transcripts(ensembl_genome: Any, fasta: Any) -> None:
     """Spot-check that the attached FASTA matches pyensembl's transcript
     cDNA at a few exonic positions. Warns (does not raise) on mismatch
     so users with intentionally-divergent setups can override with
     ``verify=False``.
     """
-    from .genome_sequence import _read_transcript_base, _tier1_range
-
     try:
         transcripts = list(ensembl_genome.transcripts())[:50]
     except Exception:
@@ -265,15 +302,15 @@ def _verify_fasta_against_transcripts(ensembl_genome, fasta):
         try:
             exon = t.exons[0]
             position = exon.start + 1
-            tier2 = _read_transcript_base(t, position)
-            tier1 = _tier1_range(fasta, t.contig, position, position)
+            transcript_base = _read_transcript_base(t, position)
+            fasta_base = _fasta_range(fasta, t.contig, position, position)
         except Exception:
             continue
-        if not tier1 or not tier2:
+        if not fasta_base or not transcript_base:
             continue
         checked += 1
-        if tier1 != tier2:
-            mismatches.append((t.contig, position, tier1, tier2))
+        if fasta_base != transcript_base:
+            mismatches.append((t.contig, position, fasta_base, transcript_base))
 
     if mismatches:
         details = "; ".join(

--- a/varcode/genome_sequence.py
+++ b/varcode/genome_sequence.py
@@ -1,0 +1,102 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reference sequence lookup against a pyensembl :class:`Genome`.
+
+varcode's reference is the pyensembl ``Genome`` object the user passes
+through ``genome=``. By default that genome ships transcript and
+protein FASTAs but not the chromosome FASTA — so any feature that
+needs raw bases at arbitrary genomic positions (intronic, intergenic,
+flanking) has to go through this module's tiered lookup:
+
+1. **Tier 1** — if the genome has an attached chromosome FASTA via
+   :func:`attach_genome_fasta`, read from it.
+2. **Tier 2** — fall back to pyensembl transcript cDNA via
+   ``transcript.spliced_offset()`` for any transcript covering the
+   position. Reverse-complements for ``-`` strand transcripts so the
+   result is always on the ``+`` strand.
+3. **Tier 3** — return ``""``. The caller decides whether empty is an
+   error or just "no shift possible / no candidates / etc."
+
+Internal API: feature code calls :func:`reference_base` or
+:func:`reference_range`. User-facing API: :func:`attach_genome_fasta`.
+
+Tracked in openvax/varcode#372.
+"""
+
+_VARCODE_FASTA_ATTR = "_varcode_fasta"
+
+
+def attach_genome_fasta(genome, fasta_or_path):
+    """Attach a chromosome FASTA to a pyensembl ``Genome`` so varcode
+    can read raw reference bases at arbitrary positions.
+
+    The default ``pyensembl install`` ships transcript and protein
+    FASTAs only. Features that need intronic, intergenic, or flanking
+    bases (left-alignment, cryptic-exon scoring, sequence-aware
+    splice prediction) require this attachment.
+
+    Parameters
+    ----------
+    genome : pyensembl.Genome
+        The genome to extend. Mutated in place — the FASTA is stored
+        on a varcode-specific underscore attribute.
+    fasta_or_path : str, path-like, or FASTA object
+        One of:
+
+        * A path string (``"/path/to/GRCh38.fa"``) — opened with
+          pyfaidx internally.
+        * A ``pyfaidx.Fasta`` instance — used as-is.
+        * Any object supporting ``fa[contig][start:end].seq`` —
+          tests, custom storage, mmap'd files, etc.
+
+    Examples
+    --------
+
+    >>> import varcode
+    >>> import pyfaidx
+    >>> from pyensembl import EnsemblRelease
+    >>> g = EnsemblRelease(81)
+    >>> varcode.attach_genome_fasta(g, "/path/to/GRCh38.fa")  # doctest: +SKIP
+    >>> vc = varcode.load_vcf("tumor.vcf", genome=g)          # doctest: +SKIP
+    """
+    raise NotImplementedError(
+        "varcode.attach_genome_fasta — implementation in progress, "
+        "tracked in openvax/varcode#372")
+
+
+def reference_base(genome, contig, position):
+    """Return the ``+`` strand reference base at ``(contig, position)``.
+
+    1-based inclusive coordinates matching pyensembl. Returns ``""``
+    when no tier of the lookup covers this position.
+
+    See module docstring for the tiered fallback rules.
+    """
+    raise NotImplementedError(
+        "varcode.genome_sequence.reference_base — implementation in "
+        "progress, tracked in openvax/varcode#372")
+
+
+def reference_range(genome, contig, start, end):
+    """Return the ``+`` strand reference sequence over ``[start, end]``.
+
+    1-based inclusive coordinates. Returns ``""`` if *any* position in
+    the range is not covered by the current tier — the lookup is
+    all-or-nothing, so callers see a partial range only when they ask
+    for one explicitly.
+
+    See module docstring for the tiered fallback rules.
+    """
+    raise NotImplementedError(
+        "varcode.genome_sequence.reference_range — implementation in "
+        "progress, tracked in openvax/varcode#372")

--- a/varcode/genome_sequence.py
+++ b/varcode/genome_sequence.py
@@ -93,7 +93,10 @@ def attach_genome_fasta(genome, fasta_or_path, *, verify=True):
         exonic position varcode already knows (via Tier 2) and warn if
         the bases disagree. Catches mislabeled FASTAs (GRCh37 attached
         to a GRCh38 release). Set False to skip if you have an
-        intentionally-divergent setup.
+        intentionally-divergent setup, or if attaching very early in a
+        fresh process where iterating ``genome.transcripts()`` would
+        force lazy construction of pyensembl's transcript DB before
+        the first effect-prediction call would have done so anyway.
 
     Returns
     -------
@@ -120,15 +123,29 @@ def attach_genome_fasta(genome, fasta_or_path, *, verify=True):
         # Detach.
         if hasattr(genome, _VARCODE_FASTA_ATTR):
             delattr(genome, _VARCODE_FASTA_ATTR)
+        _clear_attach_dedup_state(genome)
         return genome
 
     fasta = _resolve_fasta(fasta_or_path, genome=genome)
     setattr(genome, _VARCODE_FASTA_ATTR, fasta)
+    _clear_attach_dedup_state(genome)
 
     if verify:
         _verify_fasta_against_transcripts(genome, fasta)
 
     return genome
+
+
+def _clear_attach_dedup_state(genome):
+    """Reset warn-once caches that other modules keyed against this
+    genome. Any explicit attach or detach is user action — the next
+    "no reference available" warning should be a fresh signal, not
+    suppressed because we warned earlier in the same process.
+    """
+    # Lazy import: cryptic_exons imports from this module (for
+    # reference_range), so eager imports would cycle.
+    from . import cryptic_exons
+    cryptic_exons._MISSING_REFERENCE_WARNED.discard(id(genome))
 
 
 def reference_base(genome, contig, position):
@@ -353,21 +370,53 @@ def _tier2_base(genome, contig, position):
     return answer
 
 
-def _read_transcript_base(transcript, position):
-    """Return the + strand base at ``position`` from one transcript's
-    spliced cDNA, or ``""`` if the position isn't on any exon of this
-    transcript."""
+def _plus_strand_slice(transcript, start, end):
+    """Return the + strand bases over ``[start, end]`` from one
+    transcript's spliced cDNA, or ``""`` if the requested range isn't
+    fully on this transcript's exons.
+
+    1-based inclusive coordinates.
+
+    Strand handling lives here so callers don't have to reason about
+    it. For ``+`` strand transcripts the slice maps directly. For
+    ``-`` strand transcripts the cDNA is in transcript orientation
+    (the reverse-complement of the ``+`` strand), so the slice needs
+    to be complemented and then reversed to come back in
+    ``+`` strand 5'→3' order.
+
+    Returns ``""`` rather than raising for any non-coverage condition
+    (intronic position, position past the end of the transcript,
+    range that spans an exon boundary, etc.) — callers loop over
+    multiple transcripts and need a uniform "this one didn't work"
+    signal.
+    """
     try:
-        offset = transcript.spliced_offset(position)
+        start_offset = transcript.spliced_offset(start)
+        end_offset = transcript.spliced_offset(end)
     except (ValueError, KeyError):
         return ""
     seq = transcript.sequence
-    if seq is None or offset >= len(seq):
+    if seq is None:
         return ""
-    base = seq[offset].upper()
+    lo, hi = sorted((start_offset, end_offset))
+    if hi >= len(seq):
+        return ""
+    slice_seq = seq[lo:hi + 1].upper()
+    if len(slice_seq) != end - start + 1:
+        # Guard against pyensembl returning a truncated sequence for a
+        # malformed annotation — shouldn't happen, but if it does,
+        # silently signal "no coverage from this transcript."
+        return ""
     if transcript.strand == "-":
-        base = base.translate(_COMPLEMENT)
-    return base
+        slice_seq = slice_seq.translate(_COMPLEMENT)[::-1]
+    return slice_seq
+
+
+def _read_transcript_base(transcript, position):
+    """Return the + strand base at ``position`` from one transcript,
+    or ``""`` if the position isn't on any exon of this transcript.
+    Single-position specialization of :func:`_plus_strand_slice`."""
+    return _plus_strand_slice(transcript, position, position)
 
 
 def _tier2_range_via_single_transcript(genome, contig, start, end):
@@ -380,25 +429,8 @@ def _tier2_range_via_single_transcript(genome, contig, start, end):
         transcripts = genome.transcripts_at_locus(contig, start, end)
     except Exception:
         return None
-
     for t in transcripts:
-        try:
-            start_offset = t.spliced_offset(start)
-            end_offset = t.spliced_offset(end)
-        except (ValueError, KeyError):
-            continue
-        seq = t.sequence
-        if seq is None:
-            continue
-        lo, hi = sorted((start_offset, end_offset))
-        if hi >= len(seq):
-            continue
-        slice_seq = seq[lo:hi + 1].upper()
-        if len(slice_seq) != end - start + 1:
-            # Shouldn't happen for a well-formed transcript, but guard
-            # against pyensembl returning a truncated sequence.
-            continue
-        if t.strand == "-":
-            slice_seq = slice_seq.translate(_COMPLEMENT)[::-1]
-        return slice_seq
+        span = _plus_strand_slice(t, start, end)
+        if span:
+            return span
     return None

--- a/varcode/genome_sequence.py
+++ b/varcode/genome_sequence.py
@@ -10,16 +10,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Reference sequence lookup against a pyensembl :class:`Genome`.
+"""Tiered reference sequence lookup against a pyensembl ``Genome`` or
+:class:`varcode.Genome`.
 
-varcode's reference is the pyensembl ``Genome`` object the user passes
-through ``genome=``. By default that genome ships transcript and
-protein FASTAs but not the chromosome FASTA — so any feature that
-needs raw bases at arbitrary genomic positions (intronic, intergenic,
-flanking) has to go through this module's tiered lookup:
+The genome object is the reference. varcode's :class:`Genome` wrapper
+adds an optional chromosome FASTA (the ``.fasta`` attribute);
+``pyensembl.Genome`` has only transcript and protein FASTAs. Both
+work here — the dispatch reads ``getattr(genome, 'fasta', None)``
+and falls through tiers:
 
-1. **Tier 1** — if the genome has an attached chromosome FASTA via
-   :func:`attach_genome_fasta`, read from it.
+1. **Tier 1** — if the genome has a ``.fasta`` attached, read from it.
 2. **Tier 2** — fall back to pyensembl transcript cDNA via
    ``transcript.spliced_offset()`` for any transcript covering the
    position. Reverse-complements for ``-`` strand transcripts so the
@@ -28,124 +28,22 @@ flanking) has to go through this module's tiered lookup:
    error or just "no shift possible / no candidates / etc."
 
 Internal API: feature code calls :func:`reference_base` or
-:func:`reference_range`. User-facing API: :func:`attach_genome_fasta`.
+:func:`reference_range`. User-facing API: :class:`varcode.Genome`'s
+methods (or its construction-time ``fasta=`` kwarg) and the same
+module-level functions for ad-hoc use.
 
-Tracked in openvax/varcode#372.
-
-Notes
------
-
-* Returned sequence is always uppercase. Soft-masked (lowercase) repeat
-  annotations from the FASTA are normalized away — varcode treats all
-  bases uniformly. Callers that need the soft-masking signal should
-  read the FASTA directly.
-* :func:`attach_genome_fasta` mutates the genome object in place.
-  Because pyensembl typically returns cached singletons
-  (``cached_release(N)`` is shared across the process), the attachment
-  is visible to every caller holding that genome reference. This is
-  usually what you want; if you need a FASTA-less view, construct a
-  separate :class:`pyensembl.Genome` instance for it.
+Tracked in openvax/varcode#372. Upstream pyensembl support for the
+chromosome FASTA itself is tracked in openvax/pyensembl#337.
 """
 
 import warnings
 
-_VARCODE_FASTA_ATTR = "_varcode_fasta"
 _COMPLEMENT = str.maketrans("ACGTNacgtn", "TGCANTGCAN")
 
 
 # --------------------------------------------------------------------
-# Public API
+# Public lookup helpers
 # --------------------------------------------------------------------
-
-
-def attach_genome_fasta(genome, fasta_or_path, *, verify=True):
-    """Attach a chromosome FASTA to a pyensembl ``Genome`` so varcode
-    can read raw reference bases at arbitrary positions.
-
-    The default ``pyensembl install`` ships transcript and protein
-    FASTAs only. Features that need intronic, intergenic, or flanking
-    bases (left-alignment, cryptic-exon scoring, sequence-aware
-    splice prediction) require this attachment.
-
-    Mutates ``genome`` in place. Returns it for use as a pseudo-
-    constructor:
-
-    >>> g = varcode.attach_genome_fasta(EnsemblRelease(81), fasta)  # doctest: +SKIP
-
-    Parameters
-    ----------
-    genome : pyensembl.Genome
-        The genome to extend. **Mutated in place** — see module docstring
-        re: pyensembl's cached singletons.
-    fasta_or_path : str, path-like, FASTA-shaped object, or None
-        One of:
-
-        * A path string (``"/path/to/GRCh38.fa"``) — opened with
-          pyfaidx internally. pyfaidx becomes a runtime dependency
-          *only* on this path.
-        * A ``pyfaidx.Fasta`` instance — used as-is.
-        * Any object supporting ``fa[contig][start:end]`` and
-          returning either a string or an object with ``.seq``.
-          Validated by a probe call (see notes).
-        * ``None`` — detach. Removes any previously attached FASTA.
-    verify : bool, optional
-        When True (default), spot-check the attached FASTA against an
-        exonic position varcode already knows (via Tier 2) and warn if
-        the bases disagree. Catches mislabeled FASTAs (GRCh37 attached
-        to a GRCh38 release). Set False to skip if you have an
-        intentionally-divergent setup, or if attaching very early in a
-        fresh process where iterating ``genome.transcripts()`` would
-        force lazy construction of pyensembl's transcript DB before
-        the first effect-prediction call would have done so anyway.
-
-    Returns
-    -------
-    pyensembl.Genome
-        The same ``genome`` object, for chaining.
-
-    Raises
-    ------
-    TypeError
-        If ``fasta_or_path`` is not a path, ``None``, or a FASTA-shaped
-        object that responds to a probe lookup.
-
-    Notes
-    -----
-
-    The "FASTA-shaped object" check is a probe, not a class check:
-    we attempt ``fasta[contig][0:1]`` against a contig the genome
-    reports. This rejects strings, lists, and bare dicts (which all
-    have ``__getitem__`` but don't honor the slice protocol pyfaidx
-    uses) and accepts pyfaidx, the in-tree ``_DictBackedFasta`` test
-    helper, and any custom mmap/S3-backed storage with the same shape.
-    """
-    if fasta_or_path is None:
-        # Detach.
-        if hasattr(genome, _VARCODE_FASTA_ATTR):
-            delattr(genome, _VARCODE_FASTA_ATTR)
-        _clear_attach_dedup_state(genome)
-        return genome
-
-    fasta = _resolve_fasta(fasta_or_path, genome=genome)
-    setattr(genome, _VARCODE_FASTA_ATTR, fasta)
-    _clear_attach_dedup_state(genome)
-
-    if verify:
-        _verify_fasta_against_transcripts(genome, fasta)
-
-    return genome
-
-
-def _clear_attach_dedup_state(genome):
-    """Reset warn-once caches that other modules keyed against this
-    genome. Any explicit attach or detach is user action — the next
-    "no reference available" warning should be a fresh signal, not
-    suppressed because we warned earlier in the same process.
-    """
-    # Lazy import: cryptic_exons imports from this module (for
-    # reference_range), so eager imports would cycle.
-    from . import cryptic_exons
-    cryptic_exons._MISSING_REFERENCE_WARNED.discard(id(genome))
 
 
 def reference_base(genome, contig, position):
@@ -154,9 +52,13 @@ def reference_base(genome, contig, position):
     1-based inclusive coordinates matching pyensembl. Returns ``""``
     when no tier of the lookup covers this position.
 
+    Works on any genome shape — :class:`varcode.Genome` (Tier 1
+    available via ``.fasta``), bare ``pyensembl.Genome`` (Tier 2
+    only), or anything duck-typed for ``transcripts_at_locus``.
+
     See module docstring for the tiered fallback rules.
     """
-    fasta = getattr(genome, _VARCODE_FASTA_ATTR, None)
+    fasta = getattr(genome, "fasta", None)
     if fasta is not None:
         tier1 = _tier1_range(fasta, contig, position, position)
         if tier1:
@@ -174,9 +76,8 @@ def reference_range(genome, contig, start, end):
     :func:`reference_base`.)
 
     Tier 2 first tries a single-transcript range lookup (cheap: one
-    locus query, one slice into ``transcript.sequence``). Falls back
-    to per-position scanning only when no single transcript spans the
-    whole range.
+    locus query, one slice). Falls back to per-position scanning only
+    when no single transcript spans the whole range.
 
     See module docstring for the tiered fallback rules.
     """
@@ -185,20 +86,16 @@ def reference_range(genome, contig, start, end):
             "reference_range: end=%d < start=%d on %r"
             % (end, start, contig))
 
-    fasta = getattr(genome, _VARCODE_FASTA_ATTR, None)
+    fasta = getattr(genome, "fasta", None)
     if fasta is not None:
         tier1 = _tier1_range(fasta, contig, start, end)
         if tier1 and len(tier1) == end - start + 1:
             return tier1
-        # Tier 1 returned partial or empty — fall through to Tier 2.
 
-    # Tier 2 fast path: a single transcript that fully covers the range.
     span = _tier2_range_via_single_transcript(genome, contig, start, end)
     if span is not None:
         return span
 
-    # Tier 2 slow path: walk each position. If any is uncovered,
-    # all-or-nothing returns empty.
     bases = []
     for pos in range(start, end + 1):
         base = _tier2_base(genome, contig, pos)
@@ -209,113 +106,8 @@ def reference_range(genome, contig, start, end):
 
 
 # --------------------------------------------------------------------
-# Internal helpers
+# Tier implementations (also consumed by varcode.Genome construction)
 # --------------------------------------------------------------------
-
-
-def _resolve_fasta(arg, genome):
-    """Validate and normalize a FASTA argument.
-
-    Path strings open via pyfaidx; objects are probed against a known
-    contig from the genome (we don't trust ``hasattr`` alone — strings
-    and dicts have ``__getitem__`` but don't honor the slice protocol).
-    """
-    import os
-    if isinstance(arg, (str, bytes, os.PathLike)):
-        try:
-            import pyfaidx
-        except ImportError as e:
-            raise ImportError(
-                "attach_genome_fasta needs pyfaidx to open a FASTA "
-                "path. Install with `pip install pyfaidx`, or pass a "
-                "pre-opened FASTA object that supports "
-                "fa[contig][start:end]."
-            ) from e
-        return pyfaidx.Fasta(os.fspath(arg))
-
-    # Probe duck-typed object: it must support fa[contig][slice].
-    probe_contig = _probe_contig_for_validation(genome)
-    if probe_contig is None:
-        # We can't validate — genome reports no contigs. Accept the
-        # object on faith; if it's wrong, the first real lookup fails.
-        return arg
-    try:
-        slicer = arg[probe_contig]
-        _ = slicer[0:1]
-    except Exception as e:
-        raise TypeError(
-            "attach_genome_fasta: object of type %s does not honor "
-            "the pyfaidx-style protocol fa[contig][start:end] "
-            "(probe against contig %r failed: %s). Pass a path, a "
-            "pyfaidx.Fasta, or an object with the same indexing shape."
-            % (type(arg).__name__, probe_contig, e))
-    return arg
-
-
-def _probe_contig_for_validation(genome):
-    """Pick a contig name from the genome for probing a candidate FASTA.
-    Returns ``None`` if the genome can't supply one."""
-    for accessor in ("contigs", "all_contigs"):
-        getter = getattr(genome, accessor, None)
-        if callable(getter):
-            try:
-                contigs = list(getter())
-            except Exception:
-                contigs = []
-            if contigs:
-                return contigs[0]
-    return None
-
-
-def _verify_fasta_against_transcripts(genome, fasta):
-    """Spot-check that the attached FASTA matches what pyensembl says
-    about a few exonic positions. Warns (does not raise) on mismatch
-    so users can override with ``verify=False`` if they know what
-    they're doing.
-
-    Picks up to three transcripts and reads their first CDS-start base
-    from both Tier 1 (FASTA) and Tier 2 (transcript cDNA). Mismatches
-    almost always mean the FASTA is for a different build than the
-    pyensembl release.
-    """
-    try:
-        # Reuse the genome's transcript iteration; bail quietly if
-        # pyensembl can't enumerate (no DB built yet, etc.).
-        transcripts = list(genome.transcripts())[:50]
-    except Exception:
-        return
-
-    checked = 0
-    mismatches = []
-    for t in transcripts:
-        if checked >= 3:
-            break
-        if not t.exons:
-            continue
-        try:
-            exon = t.exons[0]
-            position = exon.start + 1   # 1-based; safely inside the exon
-            tier2 = _tier2_base(genome, t.contig, position)
-            tier1 = _tier1_range(fasta, t.contig, position, position)
-        except Exception:
-            continue
-        if not tier1 or not tier2:
-            continue
-        checked += 1
-        if tier1 != tier2:
-            mismatches.append((t.contig, position, tier1, tier2))
-
-    if mismatches:
-        details = "; ".join(
-            "%s:%d FASTA=%r vs transcript=%r" % m for m in mismatches)
-        warnings.warn(
-            "attach_genome_fasta: FASTA contents disagree with "
-            "pyensembl transcript sequence at %d/%d probed positions "
-            "(%s). The attached FASTA may be for a different build "
-            "than the pyensembl release (e.g. GRCh37 vs GRCh38). "
-            "Pass verify=False to suppress this check."
-            % (len(mismatches), checked, details),
-            stacklevel=3)
 
 
 def _tier1_range(fasta, contig, start, end):
@@ -330,8 +122,6 @@ def _tier1_range(fasta, contig, start, end):
         span = slicer[start - 1:end]   # 1-based inclusive -> 0-based half-open
     except (IndexError, ValueError, Exception):
         return ""
-    # pyfaidx returns a Sequence with .seq; bare-string adapters return
-    # a string directly.
     raw = getattr(span, "seq", None)
     if raw is None:
         raw = span if isinstance(span, str) else str(span)
@@ -339,13 +129,11 @@ def _tier1_range(fasta, contig, start, end):
 
 
 def _tier2_base(genome, contig, position):
-    """Pyensembl-transcript fallback for a single + strand base.
+    """Pyensembl-transcript fallback for a single ``+`` strand base.
 
     Returns ``""`` when no transcript covers ``position``. When
     multiple transcripts cover it and disagree on the base, logs a
-    debug-level warning and returns the first one's answer (callers
-    that care about disagreement can intercept the warning).
-    """
+    warning and returns the first answer."""
     try:
         transcripts = genome.transcripts_at_locus(contig, position, position)
     except Exception:
@@ -371,24 +159,21 @@ def _tier2_base(genome, contig, position):
 
 
 def _plus_strand_slice(transcript, start, end):
-    """Return the + strand bases over ``[start, end]`` from one
+    """Return the ``+`` strand bases over ``[start, end]`` from one
     transcript's spliced cDNA, or ``""`` if the requested range isn't
-    fully on this transcript's exons.
-
-    1-based inclusive coordinates.
+    fully on this transcript's exons. 1-based inclusive.
 
     Strand handling lives here so callers don't have to reason about
     it. For ``+`` strand transcripts the slice maps directly. For
     ``-`` strand transcripts the cDNA is in transcript orientation
-    (the reverse-complement of the ``+`` strand), so the slice needs
-    to be complemented and then reversed to come back in
-    ``+`` strand 5'→3' order.
+    (the reverse-complement of the ``+`` strand), so the slice is
+    complemented and then reversed to come back in ``+`` strand
+    5'→3' order.
 
     Returns ``""`` rather than raising for any non-coverage condition
-    (intronic position, position past the end of the transcript,
-    range that spans an exon boundary, etc.) — callers loop over
-    multiple transcripts and need a uniform "this one didn't work"
-    signal.
+    (intronic, past the end of the transcript, range that spans an
+    exon boundary, etc.) — callers loop over multiple transcripts and
+    need a uniform "this one didn't work" signal.
     """
     try:
         start_offset = transcript.spliced_offset(start)
@@ -403,9 +188,6 @@ def _plus_strand_slice(transcript, start, end):
         return ""
     slice_seq = seq[lo:hi + 1].upper()
     if len(slice_seq) != end - start + 1:
-        # Guard against pyensembl returning a truncated sequence for a
-        # malformed annotation — shouldn't happen, but if it does,
-        # silently signal "no coverage from this transcript."
         return ""
     if transcript.strand == "-":
         slice_seq = slice_seq.translate(_COMPLEMENT)[::-1]
@@ -413,17 +195,15 @@ def _plus_strand_slice(transcript, start, end):
 
 
 def _read_transcript_base(transcript, position):
-    """Return the + strand base at ``position`` from one transcript,
-    or ``""`` if the position isn't on any exon of this transcript.
-    Single-position specialization of :func:`_plus_strand_slice`."""
+    """Single-position specialization of :func:`_plus_strand_slice`."""
     return _plus_strand_slice(transcript, position, position)
 
 
 def _tier2_range_via_single_transcript(genome, contig, start, end):
     """Try to satisfy a Tier 2 range from one transcript that fully
-    covers ``[start, end]``. Returns the + strand sequence on success,
-    or ``None`` if no single transcript spans the range (caller falls
-    back to per-position).
+    covers ``[start, end]``. Returns the ``+`` strand sequence on
+    success, or ``None`` if no single transcript spans the range
+    (caller falls back to per-position).
     """
     try:
         transcripts = genome.transcripts_at_locus(contig, start, end)

--- a/varcode/genome_sequence.py
+++ b/varcode/genome_sequence.py
@@ -39,8 +39,10 @@ Tracked in openvax/varcode#372. Upstream pyensembl support for the
 chromosome FASTA itself is tracked in openvax/pyensembl#337.
 """
 
-import warnings
+import logging
 from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
 
 _COMPLEMENT = str.maketrans("ACGTNacgtn", "TGCANTGCAN")
 
@@ -144,8 +146,14 @@ def _base_from_genome_transcripts(
     first ``+`` strand base any of them yields.
 
     Returns ``""`` when no transcript covers ``position``. When
-    multiple transcripts cover it and disagree on the base, warns
-    once per ``(contig, position)`` and returns the first answer."""
+    multiple transcripts cover the same position they should agree
+    on the ``+`` strand base; a disagreement implies annotation skew,
+    an alt-locus position, or a pyensembl bug. We silently take the
+    first answer and log the disagreement at debug level — the case
+    is rare and not actionable for most users; debug logging keeps
+    the diagnostic available without flooding warnings or carrying
+    module-level dedup state.
+    """
     try:
         transcripts = genome.transcripts_at_locus(contig, position, position)
     except Exception:
@@ -157,7 +165,10 @@ def _base_from_genome_transcripts(
         if not base:
             continue
         if answer and base != answer:
-            _warn_transcript_disagreement(contig, position, answer, base)
+            logger.debug(
+                "transcripts overlapping %s:%d disagree on the + strand "
+                "base (%r vs %r); using the first answer",
+                contig, position, answer, base)
             break
         if not answer:
             answer = base
@@ -221,35 +232,3 @@ def _range_from_single_transcript(
         if span:
             return span
     return None
-
-
-# --------------------------------------------------------------------
-# Internal: transcript-disagreement warn-once
-# --------------------------------------------------------------------
-
-
-_DISAGREEMENT_WARNED = set()
-
-
-def _warn_transcript_disagreement(contig, position, first_base, other_base):
-    """Warn once per ``(contig, position)`` when transcripts overlapping
-    a single position disagree on the ``+`` strand base.
-
-    Range scans cross many positions; without dedup, an
-    annotation-skew region would emit a separate warning for every
-    base. The dedup is process-wide because the underlying transcript
-    annotations are too — re-warning across calls would still produce
-    duplicate signals for the same biological discrepancy.
-    """
-    key = (contig, position)
-    if key in _DISAGREEMENT_WARNED:
-        return
-    _DISAGREEMENT_WARNED.add(key)
-    warnings.warn(
-        "reference_base: transcripts overlapping %s:%d disagree on "
-        "the + strand base (%r vs %r). Returning the first answer; "
-        "the discrepancy may indicate annotation skew or an "
-        "alt-locus position. This warning fires at most once per "
-        "(contig, position)."
-        % (contig, position, first_base, other_base),
-        stacklevel=4)

--- a/varcode/genome_sequence.py
+++ b/varcode/genome_sequence.py
@@ -31,12 +31,34 @@ Internal API: feature code calls :func:`reference_base` or
 :func:`reference_range`. User-facing API: :func:`attach_genome_fasta`.
 
 Tracked in openvax/varcode#372.
+
+Notes
+-----
+
+* Returned sequence is always uppercase. Soft-masked (lowercase) repeat
+  annotations from the FASTA are normalized away — varcode treats all
+  bases uniformly. Callers that need the soft-masking signal should
+  read the FASTA directly.
+* :func:`attach_genome_fasta` mutates the genome object in place.
+  Because pyensembl typically returns cached singletons
+  (``cached_release(N)`` is shared across the process), the attachment
+  is visible to every caller holding that genome reference. This is
+  usually what you want; if you need a FASTA-less view, construct a
+  separate :class:`pyensembl.Genome` instance for it.
 """
 
+import warnings
+
 _VARCODE_FASTA_ATTR = "_varcode_fasta"
+_COMPLEMENT = str.maketrans("ACGTNacgtn", "TGCANTGCAN")
 
 
-def attach_genome_fasta(genome, fasta_or_path):
+# --------------------------------------------------------------------
+# Public API
+# --------------------------------------------------------------------
+
+
+def attach_genome_fasta(genome, fasta_or_path, *, verify=True):
     """Attach a chromosome FASTA to a pyensembl ``Genome`` so varcode
     can read raw reference bases at arbitrary positions.
 
@@ -45,33 +67,68 @@ def attach_genome_fasta(genome, fasta_or_path):
     bases (left-alignment, cryptic-exon scoring, sequence-aware
     splice prediction) require this attachment.
 
+    Mutates ``genome`` in place. Returns it for use as a pseudo-
+    constructor:
+
+    >>> g = varcode.attach_genome_fasta(EnsemblRelease(81), fasta)  # doctest: +SKIP
+
     Parameters
     ----------
     genome : pyensembl.Genome
-        The genome to extend. Mutated in place — the FASTA is stored
-        on a varcode-specific underscore attribute.
-    fasta_or_path : str, path-like, or FASTA object
+        The genome to extend. **Mutated in place** — see module docstring
+        re: pyensembl's cached singletons.
+    fasta_or_path : str, path-like, FASTA-shaped object, or None
         One of:
 
         * A path string (``"/path/to/GRCh38.fa"``) — opened with
-          pyfaidx internally.
+          pyfaidx internally. pyfaidx becomes a runtime dependency
+          *only* on this path.
         * A ``pyfaidx.Fasta`` instance — used as-is.
-        * Any object supporting ``fa[contig][start:end].seq`` —
-          tests, custom storage, mmap'd files, etc.
+        * Any object supporting ``fa[contig][start:end]`` and
+          returning either a string or an object with ``.seq``.
+          Validated by a probe call (see notes).
+        * ``None`` — detach. Removes any previously attached FASTA.
+    verify : bool, optional
+        When True (default), spot-check the attached FASTA against an
+        exonic position varcode already knows (via Tier 2) and warn if
+        the bases disagree. Catches mislabeled FASTAs (GRCh37 attached
+        to a GRCh38 release). Set False to skip if you have an
+        intentionally-divergent setup.
 
-    Examples
-    --------
+    Returns
+    -------
+    pyensembl.Genome
+        The same ``genome`` object, for chaining.
 
-    >>> import varcode
-    >>> import pyfaidx
-    >>> from pyensembl import EnsemblRelease
-    >>> g = EnsemblRelease(81)
-    >>> varcode.attach_genome_fasta(g, "/path/to/GRCh38.fa")  # doctest: +SKIP
-    >>> vc = varcode.load_vcf("tumor.vcf", genome=g)          # doctest: +SKIP
+    Raises
+    ------
+    TypeError
+        If ``fasta_or_path`` is not a path, ``None``, or a FASTA-shaped
+        object that responds to a probe lookup.
+
+    Notes
+    -----
+
+    The "FASTA-shaped object" check is a probe, not a class check:
+    we attempt ``fasta[contig][0:1]`` against a contig the genome
+    reports. This rejects strings, lists, and bare dicts (which all
+    have ``__getitem__`` but don't honor the slice protocol pyfaidx
+    uses) and accepts pyfaidx, the in-tree ``_DictBackedFasta`` test
+    helper, and any custom mmap/S3-backed storage with the same shape.
     """
-    raise NotImplementedError(
-        "varcode.attach_genome_fasta — implementation in progress, "
-        "tracked in openvax/varcode#372")
+    if fasta_or_path is None:
+        # Detach.
+        if hasattr(genome, _VARCODE_FASTA_ATTR):
+            delattr(genome, _VARCODE_FASTA_ATTR)
+        return genome
+
+    fasta = _resolve_fasta(fasta_or_path, genome=genome)
+    setattr(genome, _VARCODE_FASTA_ATTR, fasta)
+
+    if verify:
+        _verify_fasta_against_transcripts(genome, fasta)
+
+    return genome
 
 
 def reference_base(genome, contig, position):
@@ -82,21 +139,266 @@ def reference_base(genome, contig, position):
 
     See module docstring for the tiered fallback rules.
     """
-    raise NotImplementedError(
-        "varcode.genome_sequence.reference_base — implementation in "
-        "progress, tracked in openvax/varcode#372")
+    fasta = getattr(genome, _VARCODE_FASTA_ATTR, None)
+    if fasta is not None:
+        tier1 = _tier1_range(fasta, contig, position, position)
+        if tier1:
+            return tier1
+    return _tier2_base(genome, contig, position)
 
 
 def reference_range(genome, contig, start, end):
     """Return the ``+`` strand reference sequence over ``[start, end]``.
 
-    1-based inclusive coordinates. Returns ``""`` if *any* position in
-    the range is not covered by the current tier — the lookup is
+    1-based inclusive coordinates. Returns ``""`` if **any** position
+    in the range is not covered by the current tier — the lookup is
     all-or-nothing, so callers see a partial range only when they ask
-    for one explicitly.
+    for one explicitly. (For best-effort partial answers, iterate
+    :func:`reference_base`.)
+
+    Tier 2 first tries a single-transcript range lookup (cheap: one
+    locus query, one slice into ``transcript.sequence``). Falls back
+    to per-position scanning only when no single transcript spans the
+    whole range.
 
     See module docstring for the tiered fallback rules.
     """
-    raise NotImplementedError(
-        "varcode.genome_sequence.reference_range — implementation in "
-        "progress, tracked in openvax/varcode#372")
+    if end < start:
+        raise ValueError(
+            "reference_range: end=%d < start=%d on %r"
+            % (end, start, contig))
+
+    fasta = getattr(genome, _VARCODE_FASTA_ATTR, None)
+    if fasta is not None:
+        tier1 = _tier1_range(fasta, contig, start, end)
+        if tier1 and len(tier1) == end - start + 1:
+            return tier1
+        # Tier 1 returned partial or empty — fall through to Tier 2.
+
+    # Tier 2 fast path: a single transcript that fully covers the range.
+    span = _tier2_range_via_single_transcript(genome, contig, start, end)
+    if span is not None:
+        return span
+
+    # Tier 2 slow path: walk each position. If any is uncovered,
+    # all-or-nothing returns empty.
+    bases = []
+    for pos in range(start, end + 1):
+        base = _tier2_base(genome, contig, pos)
+        if not base:
+            return ""
+        bases.append(base)
+    return "".join(bases)
+
+
+# --------------------------------------------------------------------
+# Internal helpers
+# --------------------------------------------------------------------
+
+
+def _resolve_fasta(arg, genome):
+    """Validate and normalize a FASTA argument.
+
+    Path strings open via pyfaidx; objects are probed against a known
+    contig from the genome (we don't trust ``hasattr`` alone — strings
+    and dicts have ``__getitem__`` but don't honor the slice protocol).
+    """
+    import os
+    if isinstance(arg, (str, bytes, os.PathLike)):
+        try:
+            import pyfaidx
+        except ImportError as e:
+            raise ImportError(
+                "attach_genome_fasta needs pyfaidx to open a FASTA "
+                "path. Install with `pip install pyfaidx`, or pass a "
+                "pre-opened FASTA object that supports "
+                "fa[contig][start:end]."
+            ) from e
+        return pyfaidx.Fasta(os.fspath(arg))
+
+    # Probe duck-typed object: it must support fa[contig][slice].
+    probe_contig = _probe_contig_for_validation(genome)
+    if probe_contig is None:
+        # We can't validate — genome reports no contigs. Accept the
+        # object on faith; if it's wrong, the first real lookup fails.
+        return arg
+    try:
+        slicer = arg[probe_contig]
+        _ = slicer[0:1]
+    except Exception as e:
+        raise TypeError(
+            "attach_genome_fasta: object of type %s does not honor "
+            "the pyfaidx-style protocol fa[contig][start:end] "
+            "(probe against contig %r failed: %s). Pass a path, a "
+            "pyfaidx.Fasta, or an object with the same indexing shape."
+            % (type(arg).__name__, probe_contig, e))
+    return arg
+
+
+def _probe_contig_for_validation(genome):
+    """Pick a contig name from the genome for probing a candidate FASTA.
+    Returns ``None`` if the genome can't supply one."""
+    for accessor in ("contigs", "all_contigs"):
+        getter = getattr(genome, accessor, None)
+        if callable(getter):
+            try:
+                contigs = list(getter())
+            except Exception:
+                contigs = []
+            if contigs:
+                return contigs[0]
+    return None
+
+
+def _verify_fasta_against_transcripts(genome, fasta):
+    """Spot-check that the attached FASTA matches what pyensembl says
+    about a few exonic positions. Warns (does not raise) on mismatch
+    so users can override with ``verify=False`` if they know what
+    they're doing.
+
+    Picks up to three transcripts and reads their first CDS-start base
+    from both Tier 1 (FASTA) and Tier 2 (transcript cDNA). Mismatches
+    almost always mean the FASTA is for a different build than the
+    pyensembl release.
+    """
+    try:
+        # Reuse the genome's transcript iteration; bail quietly if
+        # pyensembl can't enumerate (no DB built yet, etc.).
+        transcripts = list(genome.transcripts())[:50]
+    except Exception:
+        return
+
+    checked = 0
+    mismatches = []
+    for t in transcripts:
+        if checked >= 3:
+            break
+        if not t.exons:
+            continue
+        try:
+            exon = t.exons[0]
+            position = exon.start + 1   # 1-based; safely inside the exon
+            tier2 = _tier2_base(genome, t.contig, position)
+            tier1 = _tier1_range(fasta, t.contig, position, position)
+        except Exception:
+            continue
+        if not tier1 or not tier2:
+            continue
+        checked += 1
+        if tier1 != tier2:
+            mismatches.append((t.contig, position, tier1, tier2))
+
+    if mismatches:
+        details = "; ".join(
+            "%s:%d FASTA=%r vs transcript=%r" % m for m in mismatches)
+        warnings.warn(
+            "attach_genome_fasta: FASTA contents disagree with "
+            "pyensembl transcript sequence at %d/%d probed positions "
+            "(%s). The attached FASTA may be for a different build "
+            "than the pyensembl release (e.g. GRCh37 vs GRCh38). "
+            "Pass verify=False to suppress this check."
+            % (len(mismatches), checked, details),
+            stacklevel=3)
+
+
+def _tier1_range(fasta, contig, start, end):
+    """Single-range FASTA lookup. Returns ``""`` for missing contigs,
+    out-of-range slices, or any pyfaidx/adapter error. Bases come back
+    uppercase (soft-masking dropped — see module docstring)."""
+    try:
+        slicer = fasta[contig]
+    except (KeyError, ValueError, Exception):
+        return ""
+    try:
+        span = slicer[start - 1:end]   # 1-based inclusive -> 0-based half-open
+    except (IndexError, ValueError, Exception):
+        return ""
+    # pyfaidx returns a Sequence with .seq; bare-string adapters return
+    # a string directly.
+    raw = getattr(span, "seq", None)
+    if raw is None:
+        raw = span if isinstance(span, str) else str(span)
+    return raw.upper()
+
+
+def _tier2_base(genome, contig, position):
+    """Pyensembl-transcript fallback for a single + strand base.
+
+    Returns ``""`` when no transcript covers ``position``. When
+    multiple transcripts cover it and disagree on the base, logs a
+    debug-level warning and returns the first one's answer (callers
+    that care about disagreement can intercept the warning).
+    """
+    try:
+        transcripts = genome.transcripts_at_locus(contig, position, position)
+    except Exception:
+        return ""
+
+    answer = ""
+    for t in transcripts:
+        base = _read_transcript_base(t, position)
+        if not base:
+            continue
+        if answer and base != answer:
+            warnings.warn(
+                "reference_base: transcripts overlapping %s:%d "
+                "disagree on the + strand base (%r vs %r). Returning "
+                "the first answer; the discrepancy may indicate "
+                "annotation skew or an alt-locus position."
+                % (contig, position, answer, base),
+                stacklevel=4)
+            break
+        if not answer:
+            answer = base
+    return answer
+
+
+def _read_transcript_base(transcript, position):
+    """Return the + strand base at ``position`` from one transcript's
+    spliced cDNA, or ``""`` if the position isn't on any exon of this
+    transcript."""
+    try:
+        offset = transcript.spliced_offset(position)
+    except (ValueError, KeyError):
+        return ""
+    seq = transcript.sequence
+    if seq is None or offset >= len(seq):
+        return ""
+    base = seq[offset].upper()
+    if transcript.strand == "-":
+        base = base.translate(_COMPLEMENT)
+    return base
+
+
+def _tier2_range_via_single_transcript(genome, contig, start, end):
+    """Try to satisfy a Tier 2 range from one transcript that fully
+    covers ``[start, end]``. Returns the + strand sequence on success,
+    or ``None`` if no single transcript spans the range (caller falls
+    back to per-position).
+    """
+    try:
+        transcripts = genome.transcripts_at_locus(contig, start, end)
+    except Exception:
+        return None
+
+    for t in transcripts:
+        try:
+            start_offset = t.spliced_offset(start)
+            end_offset = t.spliced_offset(end)
+        except (ValueError, KeyError):
+            continue
+        seq = t.sequence
+        if seq is None:
+            continue
+        lo, hi = sorted((start_offset, end_offset))
+        if hi >= len(seq):
+            continue
+        slice_seq = seq[lo:hi + 1].upper()
+        if len(slice_seq) != end - start + 1:
+            # Shouldn't happen for a well-formed transcript, but guard
+            # against pyensembl returning a truncated sequence.
+            continue
+        if t.strand == "-":
+            slice_seq = slice_seq.translate(_COMPLEMENT)[::-1]
+        return slice_seq
+    return None

--- a/varcode/genome_sequence.py
+++ b/varcode/genome_sequence.py
@@ -86,6 +86,17 @@ def reference_range(genome: Any, contig: str, start: int, end: int) -> str:
     (cheap: one locus query, one slice). Falls back to per-position
     scanning only when no single transcript spans the whole range.
 
+    Complexity:
+
+    * Chromosome FASTA hit: one slice. O(end - start).
+    * Single-transcript span: one locus query, one slice. O(1) in
+      transcript lookups.
+    * Per-position fallback: one locus query per position, but
+      all-or-nothing makes the loop bail at the first uncovered
+      position. Worst case is O(covered prefix length), not the full
+      range — a range that's mostly intronic produces one transcript
+      query, not N.
+
     See module docstring for the full fallback order.
     """
     if end < start:

--- a/varcode/genome_sequence.py
+++ b/varcode/genome_sequence.py
@@ -10,22 +10,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tiered reference sequence lookup against a pyensembl ``Genome`` or
+"""Reference sequence lookup against a pyensembl ``Genome`` or
 :class:`varcode.Genome`.
 
-The genome object is the reference. varcode's :class:`Genome` wrapper
-adds an optional chromosome FASTA (the ``.fasta`` attribute);
-``pyensembl.Genome`` has only transcript and protein FASTAs. Both
-work here — the dispatch reads ``getattr(genome, 'fasta', None)``
-and falls through tiers:
+varcode has two possible sources of reference bases at a genomic
+position, and falls back between them in this order:
 
-1. **Tier 1** — if the genome has a ``.fasta`` attached, read from it.
-2. **Tier 2** — fall back to pyensembl transcript cDNA via
-   ``transcript.spliced_offset()`` for any transcript covering the
-   position. Reverse-complements for ``-`` strand transcripts so the
-   result is always on the ``+`` strand.
-3. **Tier 3** — return ``""``. The caller decides whether empty is an
-   error or just "no shift possible / no candidates / etc."
+1. **Chromosome FASTA** (when attached) — read directly from the
+   FASTA file via the ``.fasta`` attribute on :class:`varcode.Genome`.
+   Covers every base on every contig the FASTA contains. Pass a
+   FASTA when constructing the genome to enable this source.
+2. **Transcript cDNA** — fall back to pyensembl's transcript
+   sequences via ``transcript.spliced_offset()`` for any transcript
+   covering the position. Reverse-complements for ``-`` strand
+   transcripts so the result is always on the ``+`` strand. Covers
+   every exonic base of every transcript varcode loaded (which is
+   always available — pyensembl ships transcript FASTAs by default).
+3. *Nothing covers it.* Return ``""`` — the caller decides whether
+   empty is an error or just "no shift possible / no candidates /
+   etc."
 
 Internal API: feature code calls :func:`reference_base` or
 :func:`reference_range`. User-facing API: :class:`varcode.Genome`'s
@@ -37,6 +40,7 @@ chromosome FASTA itself is tracked in openvax/pyensembl#337.
 """
 
 import warnings
+from typing import Any, Optional
 
 _COMPLEMENT = str.maketrans("ACGTNacgtn", "TGCANTGCAN")
 
@@ -46,40 +50,41 @@ _COMPLEMENT = str.maketrans("ACGTNacgtn", "TGCANTGCAN")
 # --------------------------------------------------------------------
 
 
-def reference_base(genome, contig, position):
+def reference_base(genome: Any, contig: str, position: int) -> str:
     """Return the ``+`` strand reference base at ``(contig, position)``.
 
     1-based inclusive coordinates matching pyensembl. Returns ``""``
-    when no tier of the lookup covers this position.
+    when no source covers this position.
 
-    Works on any genome shape — :class:`varcode.Genome` (Tier 1
-    available via ``.fasta``), bare ``pyensembl.Genome`` (Tier 2
-    only), or anything duck-typed for ``transcripts_at_locus``.
+    Works on any genome shape — :class:`varcode.Genome` (chromosome
+    FASTA available via ``.fasta``), bare ``pyensembl.Genome``
+    (transcript cDNA only), or anything duck-typed for
+    ``transcripts_at_locus``.
 
-    See module docstring for the tiered fallback rules.
+    See module docstring for the full fallback order.
     """
     fasta = getattr(genome, "fasta", None)
     if fasta is not None:
-        tier1 = _tier1_range(fasta, contig, position, position)
-        if tier1:
-            return tier1
-    return _tier2_base(genome, contig, position)
+        from_fasta = _fasta_range(fasta, contig, position, position)
+        if from_fasta:
+            return from_fasta
+    return _base_from_genome_transcripts(genome, contig, position)
 
 
-def reference_range(genome, contig, start, end):
+def reference_range(genome: Any, contig: str, start: int, end: int) -> str:
     """Return the ``+`` strand reference sequence over ``[start, end]``.
 
     1-based inclusive coordinates. Returns ``""`` if **any** position
-    in the range is not covered by the current tier — the lookup is
+    in the range is not covered by the chosen source — the lookup is
     all-or-nothing, so callers see a partial range only when they ask
     for one explicitly. (For best-effort partial answers, iterate
     :func:`reference_base`.)
 
-    Tier 2 first tries a single-transcript range lookup (cheap: one
-    locus query, one slice). Falls back to per-position scanning only
-    when no single transcript spans the whole range.
+    Transcript-cDNA path first tries a single-transcript range lookup
+    (cheap: one locus query, one slice). Falls back to per-position
+    scanning only when no single transcript spans the whole range.
 
-    See module docstring for the tiered fallback rules.
+    See module docstring for the full fallback order.
     """
     if end < start:
         raise ValueError(
@@ -88,17 +93,17 @@ def reference_range(genome, contig, start, end):
 
     fasta = getattr(genome, "fasta", None)
     if fasta is not None:
-        tier1 = _tier1_range(fasta, contig, start, end)
-        if tier1 and len(tier1) == end - start + 1:
-            return tier1
+        from_fasta = _fasta_range(fasta, contig, start, end)
+        if from_fasta and len(from_fasta) == end - start + 1:
+            return from_fasta
 
-    span = _tier2_range_via_single_transcript(genome, contig, start, end)
+    span = _range_from_single_transcript(genome, contig, start, end)
     if span is not None:
         return span
 
     bases = []
     for pos in range(start, end + 1):
-        base = _tier2_base(genome, contig, pos)
+        base = _base_from_genome_transcripts(genome, contig, pos)
         if not base:
             return ""
         bases.append(base)
@@ -106,21 +111,26 @@ def reference_range(genome, contig, start, end):
 
 
 # --------------------------------------------------------------------
-# Tier implementations (also consumed by varcode.Genome construction)
+# Source readers (also consumed by varcode.Genome construction)
 # --------------------------------------------------------------------
 
 
-def _tier1_range(fasta, contig, start, end):
-    """Single-range FASTA lookup. Returns ``""`` for missing contigs,
-    out-of-range slices, or any pyfaidx/adapter error. Bases come back
-    uppercase (soft-masking dropped — see module docstring)."""
+def _fasta_range(fasta: Any, contig: str, start: int, end: int) -> str:
+    """Read a range from an attached chromosome FASTA.
+
+    Returns ``""`` for missing contigs, out-of-range slices, or any
+    pyfaidx/adapter error. Bases come back uppercase (soft-masking
+    dropped — see module docstring)."""
     try:
         slicer = fasta[contig]
-    except (KeyError, ValueError, Exception):
+    except Exception:
+        # Defensive: pyfaidx raises KeyError for missing contigs but
+        # custom adapters may raise other types. Treat any failure
+        # to resolve the contig as "not covered."
         return ""
     try:
         span = slicer[start - 1:end]   # 1-based inclusive -> 0-based half-open
-    except (IndexError, ValueError, Exception):
+    except Exception:
         return ""
     raw = getattr(span, "seq", None)
     if raw is None:
@@ -128,12 +138,14 @@ def _tier1_range(fasta, contig, start, end):
     return raw.upper()
 
 
-def _tier2_base(genome, contig, position):
-    """Pyensembl-transcript fallback for a single ``+`` strand base.
+def _base_from_genome_transcripts(
+        genome: Any, contig: str, position: int) -> str:
+    """Walk the genome's transcripts at ``position`` and return the
+    first ``+`` strand base any of them yields.
 
     Returns ``""`` when no transcript covers ``position``. When
-    multiple transcripts cover it and disagree on the base, logs a
-    warning and returns the first answer."""
+    multiple transcripts cover it and disagree on the base, warns
+    once per ``(contig, position)`` and returns the first answer."""
     try:
         transcripts = genome.transcripts_at_locus(contig, position, position)
     except Exception:
@@ -145,20 +157,14 @@ def _tier2_base(genome, contig, position):
         if not base:
             continue
         if answer and base != answer:
-            warnings.warn(
-                "reference_base: transcripts overlapping %s:%d "
-                "disagree on the + strand base (%r vs %r). Returning "
-                "the first answer; the discrepancy may indicate "
-                "annotation skew or an alt-locus position."
-                % (contig, position, answer, base),
-                stacklevel=4)
+            _warn_transcript_disagreement(contig, position, answer, base)
             break
         if not answer:
             answer = base
     return answer
 
 
-def _plus_strand_slice(transcript, start, end):
+def _plus_strand_slice(transcript: Any, start: int, end: int) -> str:
     """Return the ``+`` strand bases over ``[start, end]`` from one
     transcript's spliced cDNA, or ``""`` if the requested range isn't
     fully on this transcript's exons. 1-based inclusive.
@@ -194,13 +200,14 @@ def _plus_strand_slice(transcript, start, end):
     return slice_seq
 
 
-def _read_transcript_base(transcript, position):
+def _read_transcript_base(transcript: Any, position: int) -> str:
     """Single-position specialization of :func:`_plus_strand_slice`."""
     return _plus_strand_slice(transcript, position, position)
 
 
-def _tier2_range_via_single_transcript(genome, contig, start, end):
-    """Try to satisfy a Tier 2 range from one transcript that fully
+def _range_from_single_transcript(
+        genome: Any, contig: str, start: int, end: int) -> Optional[str]:
+    """Try to satisfy a range read from one transcript that fully
     covers ``[start, end]``. Returns the ``+`` strand sequence on
     success, or ``None`` if no single transcript spans the range
     (caller falls back to per-position).
@@ -214,3 +221,35 @@ def _tier2_range_via_single_transcript(genome, contig, start, end):
         if span:
             return span
     return None
+
+
+# --------------------------------------------------------------------
+# Internal: transcript-disagreement warn-once
+# --------------------------------------------------------------------
+
+
+_DISAGREEMENT_WARNED = set()
+
+
+def _warn_transcript_disagreement(contig, position, first_base, other_base):
+    """Warn once per ``(contig, position)`` when transcripts overlapping
+    a single position disagree on the ``+`` strand base.
+
+    Range scans cross many positions; without dedup, an
+    annotation-skew region would emit a separate warning for every
+    base. The dedup is process-wide because the underlying transcript
+    annotations are too — re-warning across calls would still produce
+    duplicate signals for the same biological discrepancy.
+    """
+    key = (contig, position)
+    if key in _DISAGREEMENT_WARNED:
+        return
+    _DISAGREEMENT_WARNED.add(key)
+    warnings.warn(
+        "reference_base: transcripts overlapping %s:%d disagree on "
+        "the + strand base (%r vs %r). Returning the first answer; "
+        "the discrepancy may indicate annotation skew or an "
+        "alt-locus position. This warning fires at most once per "
+        "(contig, position)."
+        % (contig, position, first_base, other_base),
+        stacklevel=4)

--- a/varcode/reference.py
+++ b/varcode/reference.py
@@ -338,7 +338,7 @@ def infer_genome(genome_object_string_or_int):
             and hasattr(genome_object_string_or_int, "fasta")):
         genome = genome_object_string_or_int
     elif isinstance(genome_object_string_or_int, Genome):
-        genome =  genome_object_string_or_int
+        genome = genome_object_string_or_int
     elif is_integer(genome_object_string_or_int):
         genome = cached_ensembl_release(genome_object_string_or_int)
     elif is_string(genome_object_string_or_int):

--- a/varcode/reference.py
+++ b/varcode/reference.py
@@ -330,7 +330,14 @@ def infer_genome(genome_object_string_or_int):
     was returned as a substitute.
     """
     converted_ucsc_to_ensembl = False
-    if isinstance(genome_object_string_or_int, Genome):
+    # varcode.Genome wraps a pyensembl Genome with optional FASTA.
+    # Recognize it via duck-typing (has ``transcripts_at_locus`` and a
+    # ``fasta`` attribute) so we don't have to import it here and
+    # introduce a cycle.
+    if (hasattr(genome_object_string_or_int, "transcripts_at_locus")
+            and hasattr(genome_object_string_or_int, "fasta")):
+        genome = genome_object_string_or_int
+    elif isinstance(genome_object_string_or_int, Genome):
         genome =  genome_object_string_or_int
     elif is_integer(genome_object_string_or_int):
         genome = cached_ensembl_release(genome_object_string_or_int)

--- a/varcode/vcf.py
+++ b/varcode/vcf.py
@@ -65,7 +65,8 @@ def load_vcf(
         distinct=True,
         normalize_contig_names=True,
         convert_ucsc_contig_names=True,
-        parse_structural_variants=False):
+        parse_structural_variants=False,
+        genome_fasta=None):
     """
     Load reference name and Variant objects from the given VCF filename.
 
@@ -122,6 +123,16 @@ def load_vcf(
         Convert chromosome names from hg19 (e.g. "chr1") to equivalent names
         for GRCh37 (e.g. "1"). By default this is set to True. If None, it
         also evaluates to True if the genome of the VCF is a UCSC reference.
+
+    genome_fasta : str, path-like, or FASTA object, optional
+        Optionally attach a chromosome FASTA to the resolved genome
+        before parsing. Shorthand for
+        ``varcode.attach_genome_fasta(genome, genome_fasta)``; see
+        that function for the accepted types and the rationale.
+        Without this, features that need raw genomic bases
+        (cryptic-exon scoring, indel left-alignment, sequence-aware
+        splice prediction) fall back to transcript-cDNA coverage
+        only.
     """
 
     require_string(path, "Path or URL to VCF")
@@ -152,6 +163,7 @@ def load_vcf(
                 only_passing=only_passing,
                 allow_extended_nucleotides=allow_extended_nucleotides,
                 include_info=include_info,
+                genome_fasta=genome_fasta,
                 chunk_size=chunk_size,
                 max_variants=max_variants,
                 sort_key=sort_key,
@@ -191,6 +203,11 @@ def load_vcf(
 
     if convert_ucsc_contig_names is None:
         convert_ucsc_contig_names = genome_was_ucsc
+
+    if genome_fasta is not None:
+        # Late import: only paid by callers that opt in to FASTA attachment.
+        from .genome_sequence import attach_genome_fasta
+        attach_genome_fasta(genome, genome_fasta)
 
     df_iterator = read_vcf_into_dataframe(
         path,

--- a/varcode/vcf.py
+++ b/varcode/vcf.py
@@ -169,7 +169,8 @@ def load_vcf(
                 sort_key=sort_key,
                 distinct=distinct,
                 normalize_contig_names=normalize_contig_names,
-                convert_ucsc_contig_names=convert_ucsc_contig_names)
+                convert_ucsc_contig_names=convert_ucsc_contig_names,
+                parse_structural_variants=parse_structural_variants)
         finally:
             logger.info("Removing temporary file: %s", filename)
             os.unlink(filename)

--- a/varcode/vcf.py
+++ b/varcode/vcf.py
@@ -126,13 +126,13 @@ def load_vcf(
 
     genome_fasta : str, path-like, or FASTA object, optional
         Optionally attach a chromosome FASTA to the resolved genome
-        before parsing. Shorthand for
-        ``varcode.attach_genome_fasta(genome, genome_fasta)``; see
-        that function for the accepted types and the rationale.
-        Without this, features that need raw genomic bases
-        (cryptic-exon scoring, indel left-alignment, sequence-aware
-        splice prediction) fall back to transcript-cDNA coverage
-        only.
+        before parsing. Equivalent to wrapping with
+        ``varcode.Genome(genome, fasta=genome_fasta)`` and passing the
+        wrapper; see :class:`varcode.Genome` for the accepted types
+        and verification behavior. Without this, features that need
+        raw genomic bases (cryptic-exon scoring, indel
+        left-alignment, sequence-aware splice prediction) fall back
+        to transcript-cDNA coverage only.
     """
 
     require_string(path, "Path or URL to VCF")
@@ -205,9 +205,11 @@ def load_vcf(
         convert_ucsc_contig_names = genome_was_ucsc
 
     if genome_fasta is not None:
-        # Late import: only paid by callers that opt in to FASTA attachment.
-        from .genome_sequence import attach_genome_fasta
-        attach_genome_fasta(genome, genome_fasta)
+        # Wrap the resolved genome in varcode.Genome so the FASTA is
+        # part of the genome object rather than a side-channel
+        # attachment. Late import keeps the cost on callers who opt in.
+        from .genome import Genome as VarcodeGenome
+        genome = VarcodeGenome(genome, fasta=genome_fasta)
 
     df_iterator = read_vcf_into_dataframe(
         path,


### PR DESCRIPTION
Foundational PR for #372. Unblocks #369 (`left_align_indels`), fixes the silently-degraded `cryptic_exons` lookup, and prepares the ground for #297 (ML splice signals) and the splice-outcome protein computation originally scoped in #296 (now closed as superseded by this).

The commit here is **scaffold only** — `varcode/genome_sequence.py` with `attach_genome_fasta` / `reference_base` / `reference_range` signatures and full module docstring spelling out the tiered-lookup contract. Bodies raise `NotImplementedError`. Implementation lands in follow-up commits on this branch.

---

## Table of contents

1. [Problem & framing](#1-problem--framing)
2. [API surface](#2-api-surface)
3. [Tiered lookup](#3-tiered-lookup)
4. [`attach_genome_fasta` semantics](#4-attach_genome_fasta-semantics)
5. [Internal helpers consumed by features](#5-internal-helpers-consumed-by-features)
6. [`cryptic_exons` migration](#6-cryptic_exons-migration)
7. [Test matrix](#7-test-matrix)
8. [Open design questions](#8-open-design-questions)
9. [Plan to merge](#9-plan-to-merge)
10. [Test plan](#10-test-plan)

---

## 1. Problem & framing

varcode's reference is the pyensembl `Genome` object passed via `genome=`. The default ``pyensembl install --release N`` ships transcript and protein FASTAs but **not** the chromosome FASTA, so any feature wanting raw bases at arbitrary genomic positions (intronic, intergenic, flanking) hits a wall.

`varcode/cryptic_exons.py:326` already tries `genome.genome.sequence(...)` for flanking-region scoring, but the call lives inside a bare `try/except` that swallows everything. On a standard install, that path *never works*. The feature is silently degraded — nobody knows because the silence is indistinguishable from "no candidates found."

**Framing decision**: don't invent a `Reference` abstraction parallel to `Genome`. The genome IS varcode's reference. We extend it.

The mental model becomes: "the genome answers reference questions. By default it covers exonic positions only. Attach a FASTA and it covers everywhere."

## 2. API surface

One user-facing helper, one optional `load_vcf` kwarg, no new top-level types.

```python
import varcode
import pyfaidx
from pyensembl import EnsemblRelease

# Pattern 1: attach to an existing genome.
g = EnsemblRelease(81)
varcode.attach_genome_fasta(g, "/path/to/GRCh38.fa")
# or:
varcode.attach_genome_fasta(g, pyfaidx.Fasta("/path/..."))

vc = varcode.load_vcf("tumor.vcf", genome=g, parse_structural_variants=True)

# Pattern 2: load_vcf shortcut.
vc = varcode.load_vcf("tumor.vcf",
                      genome="GRCh38",
                      genome_fasta="/path/to/GRCh38.fa")
```

That's the entire public surface for this PR. Three module-level exports:

* `varcode.attach_genome_fasta(genome, fasta_or_path)`
* `varcode.reference_base(genome, contig, position)` — internal helper, exposed for downstream consumers (left_align_indels, cryptic_exons callers)
* `varcode.reference_range(genome, contig, start, end)` — same

## 3. Tiered lookup

Both `reference_base` and `reference_range` walk three tiers in order:

| Tier | Source | Coverage | Available when |
|---|---|---|---|
| 1 | Attached chromosome FASTA (`genome._varcode_fasta`) | Every base on every contig | User called `attach_genome_fasta` |
| 2 | pyensembl transcript cDNA via `transcript.spliced_offset()` | Every exonic base of every transcript varcode loaded | Always (pyensembl default) |
| 3 | — | None | Return `""` |

Tier 2 means: **exonic positions answer correctly with no FASTA at all**. Default users get a meaningful upgrade without ever touching a FASTA file:

* `cryptic_exons` starts working for exonic-adjacent breakpoints.
* `left_align_indels` can shift indels fully inside one exon.
* Splice outcome stubs (INTRON_RETENTION, etc.) can compute coding effects for in-exon disruptions.

Tier 1 unlocks: intronic indels, deep intergenic SV breakpoints, ML splice-site flanking, cross-exon shift bounds.

### Tier 2 implementation detail (strand handling)

For each position:

1. Walk `genome.transcripts_at_locus(contig, position, position)`.
2. For each transcript, compute `offset = transcript.spliced_offset(position)`.
3. Read `transcript.sequence[offset]`.
4. For `-` strand transcripts, `transcript.sequence` is the *transcript-orientation* cDNA (reverse-complemented from the + strand). Apply the complement to return the + strand base.

```python
_COMPLEMENT = str.maketrans("ACGTN", "TGCAN")

def _tier2_base(genome, contig, position):
    for t in genome.transcripts_at_locus(contig, position, position):
        try:
            offset = t.spliced_offset(position)
        except (ValueError, KeyError):
            continue
        seq = t.sequence
        if seq is None or offset >= len(seq):
            continue
        base = seq[offset].upper()
        return base.translate(_COMPLEMENT) if t.strand == "-" else base
    return ""
```

### Tier 1 implementation detail

```python
def _tier1_range(fasta, contig, start, end):
    try:
        slicer = fasta[contig]
    except (KeyError, ValueError):
        return ""
    try:
        span = slicer[start - 1:end]   # 1-based inclusive -> 0-based half-open
        return str(getattr(span, "seq", span)).upper()
    except (IndexError, ValueError):
        return ""
```

The `getattr(span, "seq", span)` accommodates both pyfaidx (which returns a `Sequence` object exposing `.seq`) and bare-string FASTAs (the tests' `DictBackedFasta`).

### Range semantics

`reference_range` is **all-or-nothing**: if any position in `[start, end]` is uncovered by the chosen tier, returns `""`. This prevents partial-sequence bugs where the consumer thinks they got a complete range but silently lost intronic interior bases. Callers that want best-effort partial answers can iterate `reference_base` themselves.

## 4. `attach_genome_fasta` semantics

```python
def attach_genome_fasta(genome, fasta_or_path):
    """Attach a chromosome FASTA to the genome for full-sequence access."""
    fasta = _resolve_fasta(fasta_or_path)
    setattr(genome, _VARCODE_FASTA_ATTR, fasta)
    return genome

def _resolve_fasta(arg):
    if isinstance(arg, (str, bytes, os.PathLike)):
        import pyfaidx  # local import: only required when path is given
        return pyfaidx.Fasta(str(arg))
    if hasattr(arg, "__getitem__"):
        return arg
    raise TypeError(
        "attach_genome_fasta accepts a path, a pyfaidx.Fasta, or any "
        "object supporting fasta[contig][start:end]; got %r" % type(arg))
```

Behavior:

* Path string → `pyfaidx.Fasta(path)`. pyfaidx becomes a soft dependency (import-on-use). Users who pass pre-loaded objects don't need it.
* `pyfaidx.Fasta` instance → used as-is.
* Anything with `__getitem__` returning sliceable sequences → duck-typed, used as-is.
* Anything else → `TypeError` with a useful message.
* Re-attach overwrites the previous attachment silently. (Idempotent re-attach with the same FASTA is a no-op; replacing one FASTA with a different one is rare and benign.)

The attachment stores on `genome._varcode_fasta`. The leading underscore + `_varcode_` prefix prevents collisions with pyensembl's own attributes; the convention scales to other varcode-specific genome extensions if we ever need them.

## 5. Internal helpers consumed by features

Features that need raw bases call the helpers — they never touch `genome._varcode_fasta` directly. This keeps the tiered fallback in one place and lets us evolve the storage convention without rippling through consumers.

```python
# In varcode.cryptic_exons:
from .genome_sequence import reference_range
ref_seq = reference_range(genome, contig, pos - flank, pos + flank)
if not ref_seq:
    warn(...)
    continue

# In future varcode.transforms.left_align_indels:
from .genome_sequence import reference_range
prev = reference_range(variant.genome, variant.contig, start - 1, start - 1)
if not prev:
    break  # bounded by exon boundary (Tier 2) or chromosome start (Tier 1)
```

The helpers are exported from the top-level package because the user might reasonably want to call them ad-hoc:

```python
import varcode
seq = varcode.reference_range(genome, "1", 1_000_000, 1_000_100)
```

## 6. `cryptic_exons` migration

The current code in `varcode/cryptic_exons.py:323-333`:

```python
for contig, pos in breakpoints:
    if genome is None:
        continue
    try:
        ref_seq = genome.genome.sequence(
            contig, pos - flank, pos + flank)
    except Exception:
        try:
            ref_seq = genome.genome.contig_sequence(contig)[
                max(0, pos - flank):pos + flank]
        except Exception:
            continue
    candidates.extend(...)
```

Becomes:

```python
from .genome_sequence import reference_range

for contig, pos in breakpoints:
    if genome is None:
        continue
    ref_seq = reference_range(genome, contig, pos - flank, pos + flank)
    if not ref_seq:
        warnings.warn(
            "cryptic_exons: no reference sequence available at "
            "%s:%d-%d (non-exonic and no chromosome FASTA attached). "
            "Attach with varcode.attach_genome_fasta(genome, fasta) "
            "to enable cryptic-exon scoring outside annotated "
            "transcripts." % (contig, pos - flank, pos + flank),
            stacklevel=2)
        continue
    candidates.extend(...)
```

Loud signal replaces silent bail. The migration removes two layers of `try/except` and one fallback path; both were workarounds for the same missing infrastructure.

## 7. Test matrix

New file `tests/test_genome_sequence.py`. No real FASTA dependency — tests use a minimal mock matching pyfaidx's slice surface:

```python
class _DictBackedFasta:
    def __init__(self, sequences): self._d = sequences
    def __getitem__(self, contig):
        return _Slicer(self._d.get(contig, ""))
class _Slicer:
    def __init__(self, seq): self.seq = seq
    def __getitem__(self, s): return _Span(self.seq[s])
class _Span:
    def __init__(self, seq): self.seq = seq
```

Test cases:

| # | Case | Expectation |
|---|---|---|
| 1 | `attach_genome_fasta` with a `_DictBackedFasta` object | attribute set; subsequent lookups use it |
| 2 | `attach_genome_fasta` with an integer | `TypeError` with useful message |
| 3 | `attach_genome_fasta` re-attach overwrites | second attach wins |
| 4 | `reference_base` Tier 1 (FASTA attached, position covered) | returns FASTA base, uppercase |
| 5 | `reference_base` Tier 1 (FASTA attached, contig missing) | returns `""` (no exception leaks) |
| 6 | `reference_base` Tier 2 (no FASTA, exonic + strand transcript) | returns + strand base from transcript cDNA |
| 7 | `reference_base` Tier 2 (no FASTA, exonic - strand transcript) | returns + strand base (reverse-complemented from cDNA) |
| 8 | `reference_base` Tier 3 (no FASTA, intronic position) | returns `""` |
| 9 | `reference_range` Tier 1 multi-position | returns concatenated bases |
| 10 | `reference_range` Tier 2 spanning exon boundary (no FASTA) | returns `""` (any intronic position fails the whole range) |
| 11 | `reference_range` Tier 1 (FASTA), spanning exon boundary | returns full sequence including the intronic stretch |
| 12 | `cryptic_exons` with `_DictBackedFasta` covering the breakpoint region | candidates produced |
| 13 | `cryptic_exons` without FASTA, breakpoint in intergenic space | warning emitted, no candidates |
| 14 | `cryptic_exons` without FASTA, breakpoint within an exon | Tier 2 covers, candidates produced |
| 15 | `load_vcf(..., genome_fasta="/path")` | `_varcode_fasta` attribute set on the resolved genome before parsing |
| 16 | Path-string attachment when pyfaidx is not installed | `ImportError` surfaced with a useful "pip install pyfaidx" message |

## 8. Open design questions

Three points for reviewer input:

1. **pyfaidx as a hard dependency vs import-on-use.** Today's `pyproject.toml` does not list pyfaidx. I lean import-on-use — users who pre-construct a `pyfaidx.Fasta` (or use the dict adapter, or bring custom storage) never need varcode to know about pyfaidx. The cost is a slightly less helpful error when someone passes a path without pyfaidx installed. Acceptable, IMO.
2. **Should `reference_range` be all-or-nothing, or return partial sequences with `None`/`""` for uncovered positions?** I lean all-or-nothing (rationale in §3): partial answers create silent correctness bugs. If a caller wants per-position fallback they can iterate `reference_base`.
3. **Spot-check FASTA contents at attachment time.** Compare a sentinel position's FASTA base to a known truth (e.g. first transcript's first exon's first base via Tier 2) to catch mislabeled FASTAs (GRCh37 attached to a GRCh38 pyensembl release). Cheap (one Tier-2 lookup, one Tier-1 lookup), high value (catches a class of subtle bugs). I'd add it but separately track an opt-out kwarg in case someone has an intentionally-divergent setup. Reviewer: include in this PR or punt?

## 9. Plan to merge

Five commits on this branch, each independently reviewable:

| # | Commit | LOC est. |
|---|---|---|
| 1 | **Scaffold** — module skeleton, signatures, contract docstring, top-level exports. (done; this commit, ~120 LOC) |  |
| 2 | `attach_genome_fasta` body + `_resolve_fasta` + module-level constants | ~80 |
| 3 | `reference_base` / `reference_range` with Tier 1 + Tier 2 + Tier 3 fallback | ~120 |
| 4 | `cryptic_exons` migration from silent-bail to loud (per §6) | ~40 |
| 5 | `load_vcf(..., genome_fasta=...)` convenience kwarg | ~30 |
| 6 | Test matrix (16 cases per §7) | ~350 |

Lift draft → ready when commits 2–6 land and CI is green.

## 10. Test plan

- [ ] `pytest tests/test_genome_sequence.py` — 16 cases pass.
- [ ] `pytest tests/test_cryptic_exons*.py` — migration doesn't break existing tests; loud warning fires in the no-FASTA-no-exon case.
- [ ] `pytest tests/` — full suite green across 3.9 / 3.10 / 3.11.
- [ ] Manual: attach a real FASTA, run `cryptic_exons` on a known fusion VCF, verify candidates emerge from intronic flanking regions.

---

## Out of scope (deferred)

- **Compressed FASTA support** — inherits whatever pyfaidx supports (.fa, .fa.gz with bgzip). No varcode-side work.
- **Lazy attachment** (attach via path, defer opening until first lookup) — minor optimization; users who care can pass a pre-constructed `pyfaidx.Fasta`.
- **Spot-check on attach** — see open design question #3.