### PR TITLE
varcode.transforms.left_align_indels (#369, planning + scaffold)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -175,6 +175,10 @@ Auto-generated from in-source docstrings via
 
 ::: varcode.transforms.pair_breakends
 
+### `varcode.transforms.left_align_indels`
+
+::: varcode.transforms.left_align_indels
+
 ## File loading
 
 ### `varcode.load_vcf`

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -128,6 +128,74 @@ If you want both directions in the same effect collection without
 running `pair_breakends`, just don't run it — the parser already
 emits both halves.
 
+## `left_align_indels`
+
+Shifts indels to their canonical leftmost equivalent position.
+**Preserves cardinality** (1:1, value may change).
+
+Two pipelines that exchange variants need a canonical representation
+per indel. `CTT→T` at position 10 inside a `CT`-repeat means the
+same biological event as `CT→_` at position 8 — but tools that
+compare variants by `(contig, start, ref, alt)` see those
+representations as distinct. Left-alignment normalizes to the
+leftmost equivalent position.
+
+### Usage
+
+```python
+from varcode import load_vcf, Genome
+from varcode.transforms import left_align_indels
+
+# Default (transcript-cDNA coverage only) — exonic indels normalize,
+# intronic/intergenic pass through unchanged.
+vc = load_vcf("tumor.vcf", genome="GRCh38")
+vc = left_align_indels(vc)
+
+# Full coverage — every indel normalizes.
+g = Genome(81, fasta="/path/to/GRCh38.fa")
+vc = load_vcf("tumor.vcf", genome=g)
+vc = left_align_indels(vc)
+```
+
+No `reference` parameter — `left_align_indels` reads bases via the
+genome the variants already carry (see
+[varcode.Genome](api.md#varcodegenome)). Coverage depends on which
+genome shape was passed.
+
+### Behavior
+
+| Variant kind | Outcome |
+|---|---|
+| Pure SNV / MNV / complex (`ATG→GCC`) | Pass-through, `source_variants=()` |
+| Already-canonical indel (no equivalent leftward position) | Pass-through, `source_variants=()` |
+| Indel inside an exon, no FASTA | Shifts via transcript cDNA |
+| Indel in homopolymer / STR repeat | Shifts to leftmost equivalent position |
+| Indel in intron / intergenic, no FASTA | Pass-through (no reference coverage) |
+| Indel in intron / intergenic, FASTA attached | Shifts via FASTA |
+| Indel that starts exonic but would shift past the exon boundary, no FASTA | **Partial shift** — moves left until the boundary, sets `info["left_align_partial"] = True` |
+| Indel at chromosome start | Shift bounded by `start > 1` |
+
+### Metadata
+
+Shifted variants carry:
+
+- `source_variants = (original,)` — the pre-shift variant.
+- Source-path metadata re-keyed under the shifted variant; the
+  original key is removed.
+- `info["original_start"]` — the pre-shift start position, for
+  round-trip diagnostics.
+- `info["left_align_partial"] = True` — set only when the shift was
+  bounded by reference coverage (not by the reference disagreeing).
+  Tells downstream tools that a chromosome FASTA might have shifted
+  the variant further.
+
+### Idempotence
+
+Running `left_align_indels` twice produces the same result on the
+second call — every variant is already at its canonical leftmost
+position after the first call. Composes cleanly with `pair_breakends`
+in either order; SVs and BNDs are not indels and pass through.
+
 ## Roadmap
 
 Transforms planned for future PRs. Each lands as its own ticket; all
@@ -136,8 +204,7 @@ follow the contract above.
 | Transform | Cardinality | Brief |
 |---|---|---|
 | `combine_cis_snvs(vc, phase_resolver)` | reduces | Adjacent in-codon SNVs sharing a phase set merge into MNVs. |
-| `left_align_indels(vc, reference)` | preserves | Canonical-position indel normalization. |
-| `split_multiallelic(vc)` | increases | One variant per ALT for multi-ALT rows (today's implicit parse-time behavior, as an explicit transform). |
-| `decompose_mnvs(vc)` | increases | Inverse of `combine_cis_snvs`. Useful for cross-tool comparison. |
 
-See the [API reference](api.md) for `varcode.transforms.pair_breakends`.
+See the [API reference](api.md) for
+`varcode.transforms.pair_breakends` and
+`varcode.transforms.left_align_indels`.

--- a/tests/test_transforms_left_align.py
+++ b/tests/test_transforms_left_align.py
@@ -159,21 +159,16 @@ def test_deletion_in_homopolymer_shifts_to_leftmost():
 
 
 def test_insertion_in_homopolymer_shifts_to_leftmost():
-    """Reference AAAAA at pos 5-9, with non-A flanking. Insert 'A'
-    after pos 9 should shift to insertion at pos 5 (the leftmost
-    anchor where the inserted A is equivalent)."""
+    """Reference: pos 4='T', pos 5..9='A', pos 10='T'. An 'A'
+    insertion after pos 9 walks through the A-run and stops at the
+    'T' boundary — final anchor is at pos 4 (the last position where
+    ``reference[check_pos]`` was still 'A')."""
     g = _genome_with_fasta({"1": "T" + "A" * 5 + "T"}, offset=4)
-    # offset=4 means: pos 4='T', pos 5..9='A', pos 10='T'.
     v = Variant("1", 9, "A", "AA", genome=g)  # insert A after pos 9
     out = left_align_indels(VariantCollection([v]))
     o = out[0]
     assert o.ref == "" and o.alt == "A"
-    assert o.start == 4  # algorithm stops when reference[5]='A' but
-    # check at iter 6 is at reference[4]='T'; T != A; stop. Wait, let me
-    # trace: start=9, check reference[9]='A' (since pos 9 = seq[5] = 'A'),
-    # match, shift to start=8. check reference[8]='A', shift. ... shift
-    # to start=5. check reference[5]='A', shift to start=4. check
-    # reference[4]='T', T != A, stop. So final start=4. ✓
+    assert o.start == 4
 
 
 def test_str_repeat_deletion_shifts_to_first_unit():
@@ -193,23 +188,19 @@ def test_str_repeat_deletion_shifts_to_first_unit():
 
 
 def test_bounded_at_chromosome_start():
-    """Shift bounded by start > 1 — even in an infinite homopolymer,
-    the algorithm stops at pos 1."""
-    # Reference A at pos 1 only, then arbitrary.
-    g = _genome_with_fasta({"1": "A" + "T" * 100}, offset=1)
+    """Shift bounded by ``start > 1`` — even in a homopolymer that
+    runs to the chromosome start, the algorithm stops at pos 1
+    without underflowing."""
+    # Reference: 2-A homopolymer at the chromosome start, then T's.
+    # ``Variant("1", 1, "AA", "A", g)`` normalizes to ref='A', alt='',
+    # start=2 — delete the second A. Shift left would go to start=1.
+    g = _genome_with_fasta({"1": "AA" + "T" * 100}, offset=1)
     v = Variant("1", 1, "AA", "A", genome=g)
-    # Hmm — this normalizes to ref='A',alt='',start=2 (delete the second
-    # base which is T per our reference). That's not a valid call for
-    # left-alignment because there's no run.
-    # Use a 2-A homopolymer at start instead.
-    g2 = _genome_with_fasta({"1": "AA" + "T" * 100}, offset=1)
-    v2 = Variant("1", 1, "AA", "A", genome=g2)
-    # ref='A',alt='',start=2. Try to shift to 1.
-    out = left_align_indels(VariantCollection([v2]))
+    assert (v.ref, v.alt, v.start) == ("A", "", 2)
+    out = left_align_indels(VariantCollection([v]))
     o = out[0]
-    # Shifted from start=2 to start=1; can't go further (start > 1 false).
     assert o.start == 1
-    assert o.source_variants == (v2,)
+    assert o.source_variants == (v,)
 
 
 def test_multi_base_insertion_in_homopolymer():
@@ -368,6 +359,74 @@ def test_composes_with_pair_breakends():
 # --------------------------------------------------------------------
 
 
+def test_exonic_indel_on_minus_strand_transcript_uses_plus_strand_bases():
+    """Tier-2 coverage for an exonic indel on a ``-`` strand
+    transcript: the algorithm must read ``+`` strand bases (via the
+    transcript-cDNA reverse-complement helper) so the shift decision
+    matches what a FASTA would give.
+
+    Picks a real ``-`` strand protein-coding transcript from
+    pyensembl, finds a homopolymer run inside its first exon by
+    inspecting the spliced cDNA, and synthesizes a deletion in that
+    run. After ``left_align_indels``, the deletion should shift to
+    the leftmost position in the run.
+    """
+    g = cached_release(81)
+    # Find a - strand transcript with a coding sequence that contains
+    # a run of identical + strand bases at least 3 long, fully within
+    # the first exon.
+    target = None
+    for t in g.transcripts():
+        if t.strand != "-" or not t.is_protein_coding or not t.exons:
+            continue
+        exon = t.exons[0]
+        if exon.end - exon.start < 10:
+            continue
+        # Read the + strand sequence of the first exon via the
+        # transcript-cDNA helper used by reference_range.
+        from varcode.genome_sequence import _plus_strand_slice
+        plus_seq = _plus_strand_slice(t, exon.start, exon.end)
+        if not plus_seq:
+            continue
+        # Scan for a homopolymer run of length >= 3 with a non-matching
+        # base on the left flank (so the shift terminates inside the
+        # exon, not at the exon boundary — which would make this a
+        # partial-shift test, not a clean natural-stop test).
+        for i in range(1, len(plus_seq) - 3):
+            base = plus_seq[i]
+            if (plus_seq[i - 1] != base
+                    and plus_seq[i + 1] == base
+                    and plus_seq[i + 2] == base):
+                target = (t, exon, i, base, plus_seq)
+                break
+        if target is not None:
+            break
+
+    if target is None:
+        pytest.skip("could not find a suitable - strand transcript run")
+
+    t, exon, run_start_idx_in_exon, base, plus_seq = target
+    # Genomic position of the first base of the run on the + strand.
+    run_start_pos = exon.start + run_start_idx_in_exon
+    # Construct a deletion of the SECOND base of the run (so a one-step
+    # shift is possible and produces a different start).
+    del_pos = run_start_pos + 1
+    # VCF-anchored form: REF = anchor + del_base, ALT = anchor.
+    anchor = plus_seq[run_start_idx_in_exon - 1 + 1]  # base at del_pos - 1 on + strand
+    # Actually use a clearer construction: pre-normalized.
+    v = Variant(t.contig, del_pos, base, "", genome=g,
+                allow_extended_nucleotides=True)
+    # Sanity: post-normalization is a deletion with start == del_pos.
+    assert v.is_deletion and v.start == del_pos
+
+    out = left_align_indels(VariantCollection([v]))
+    o = out[0]
+    # Should have shifted left by exactly 1 (run starts at
+    # run_start_pos, del_pos is one in).
+    assert o.start == run_start_pos
+    assert o.source_variants == (v,)
+
+
 def test_intronic_indel_without_fasta_passes_through():
     """An indel in an intron without a FASTA has no reference
     coverage (Tier 2 returns empty); the algorithm exits immediately
@@ -384,6 +443,43 @@ def test_intronic_indel_without_fasta_passes_through():
     # No shift — variant passes through.
     assert out[0] is v
     assert out[0].source_variants == ()
+
+
+def test_partial_shift_flag_NOT_set_when_natural_stop():
+    """Negative test for the partial-shift flag: when the algorithm
+    stops because the reference *disagrees* (not because coverage ran
+    out), ``info["left_align_partial"]`` must NOT be set. The flag's
+    whole purpose is to distinguish "stopped at canonical position"
+    from "stopped at a coverage boundary."
+    """
+    # Reference: AAAA at pos 5-8 then C at pos 9. Deletion 'A' at pos
+    # 8 (so original start=9, ref='A', alt=''). Shifts left through
+    # the A-run and stops naturally when reference[4] is 'C' (not 'A')
+    # — wait, we need a setup where the run hits a different base.
+    #
+    # Layout: pos 5='C', pos 6..9='A', pos 10='T'. Deletion at
+    # original start=10 (varcode normalizes 'AA'->'A' at pos 9 to
+    # ref='A', alt='', start=10) shifts left through positions
+    # 10,9,8,7 (all checks succeed against the A-run), then check at
+    # pos 5 finds 'C' — natural stop, not coverage stop.
+    g = _genome_with_fasta(
+        {"1": "C" + "A" * 4 + "T" * 50}, offset=5)
+    v = Variant("1", 9, "AA", "A", genome=g)
+    assert (v.ref, v.alt, v.start) == ("A", "", 10)
+    metadata = {"synth": {v: {"id": "v1", "info": {}}}}
+    vc = VariantCollection(
+        variants=[v],
+        sources={"synth"},
+        source_to_metadata_dict=metadata)
+    out = left_align_indels(vc)
+    shifted = out[0]
+    # Shifted from start=10 to start=6 (leftmost A); reference[5]='C'
+    # disagrees -> natural stop.
+    assert shifted.start == 6
+    info = out.source_to_metadata_dict["synth"][shifted]["info"]
+    assert info["original_start"] == 10
+    # The key assertion: natural stop, so the partial flag is NOT set.
+    assert "left_align_partial" not in info
 
 
 def test_partial_shift_flag_set_when_coverage_runs_out():

--- a/tests/test_transforms_left_align.py
+++ b/tests/test_transforms_left_align.py
@@ -1,0 +1,409 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for :func:`varcode.transforms.left_align_indels` (#369).
+
+Covers the test matrix from PR #374:
+
+* Pass-throughs — SNVs, MNVs, complex variants, already-canonical
+  indels.
+* Real shifts — homopolymer deletions/insertions, STR repeats,
+  multi-base payloads.
+* Bounded shifts — chromosome start, exon boundary (partial-shift
+  flag), uncovered intronic positions.
+* Metadata + provenance — source_variants population, original_start
+  in info dict, source-path metadata re-keyed under shifted variants.
+* Composition — idempotence, mixed VC with SNVs + indels + paired
+  BNDs, empty VC.
+"""
+
+import pytest
+from pyensembl import cached_release
+
+from varcode import Genome, Variant, VariantCollection
+from varcode.transforms import left_align_indels
+
+
+# --------------------------------------------------------------------
+# Test helpers — DictBackedFasta adapter (same shape as
+# tests/test_genome_sequence.py).
+# --------------------------------------------------------------------
+
+
+class _DictBackedFasta:
+    """``{contig: sequence_string}`` adapter shaped like pyfaidx.Fasta.
+
+    ``offset`` is the 1-based genome position of the first character
+    of each contig's sequence."""
+    def __init__(self, contig_to_seq, *, offset=1):
+        self._d = dict(contig_to_seq)
+        self._offset = offset
+
+    def __getitem__(self, contig):
+        return _Slicer(self._d.get(contig, ""), self._offset)
+
+
+class _Slicer:
+    def __init__(self, seq, offset):
+        self.seq = seq
+        self._offset = offset
+
+    def __getitem__(self, s):
+        lo = max(0, (s.start or 0) - self._offset + 1)
+        hi = max(0, (s.stop or 0) - self._offset + 1)
+        return _Span(self.seq[lo:hi])
+
+
+class _Span:
+    def __init__(self, seq):
+        self.seq = seq
+
+
+def _genome_with_fasta(contig_to_seq, offset=1):
+    """Build a :class:`varcode.Genome` wrapping pyensembl release 81
+    with an attached :class:`_DictBackedFasta`. verify=False because
+    the test fixtures don't agree with pyensembl transcript bases."""
+    return Genome(
+        cached_release(81),
+        fasta=_DictBackedFasta(contig_to_seq, offset=offset),
+        verify=False)
+
+
+# --------------------------------------------------------------------
+# Pass-throughs
+# --------------------------------------------------------------------
+
+
+def test_snv_passes_through():
+    g = _genome_with_fasta({"1": "A" * 100}, offset=1)
+    v = Variant("1", 50, "A", "T", genome=g)
+    vc = VariantCollection([v])
+    out = left_align_indels(vc)
+    assert out[0] is v
+    assert out[0].source_variants == ()
+
+
+def test_mnv_passes_through():
+    g = _genome_with_fasta({"1": "A" * 100}, offset=1)
+    v = Variant("1", 50, "AT", "GC", genome=g)
+    vc = VariantCollection([v])
+    out = left_align_indels(vc)
+    assert out[0] is v
+    assert out[0].source_variants == ()
+
+
+def test_complex_variant_passes_through():
+    """Length-mismatched AND content-different (``ATG->GCC``) — not a
+    clean indel. Pass through unchanged."""
+    g = _genome_with_fasta({"1": "A" * 100}, offset=1)
+    v = Variant("1", 50, "ATG", "GCC", genome=g)
+    vc = VariantCollection([v])
+    out = left_align_indels(vc)
+    assert out[0] is v
+
+
+def test_canonical_deletion_passes_through():
+    """Already-canonical deletion in a non-repeat region — no shift."""
+    # Reference at pos 49 = 'C', pos 50 = 'T', pos 51 = 'G'. Deleting T
+    # at pos 50 has no equivalent position because pos 49 != T.
+    # ``Variant("1", 50, "CT", "C", g)`` normalizes to ref='T',
+    # alt='', start=51 (varcode's deletion-start points at the
+    # deleted T). Reference layout: C at pos 50 + T at pos 51 +
+    # G at pos 52..onward. The algorithm checks reference[50]='C'
+    # vs payload[-1]='T'; mismatch -> no shift.
+    g = _genome_with_fasta({"1": "C" * 50 + "T" + "G" * 49}, offset=1)
+    v = Variant("1", 50, "CT", "C", genome=g)
+    assert (v.ref, v.alt, v.start) == ("T", "", 51)
+    vc = VariantCollection([v])
+    out = left_align_indels(vc)
+    assert out[0] is v
+    assert out[0].source_variants == ()
+
+
+def test_canonical_insertion_passes_through():
+    """Already-canonical insertion in a non-repeat region — no shift."""
+    g = _genome_with_fasta({"1": "C" * 49 + "T" + "G" * 50}, offset=1)
+    v = Variant("1", 50, "T", "TA", genome=g)  # insert A after pos 50
+    vc = VariantCollection([v])
+    out = left_align_indels(vc)
+    assert out[0] is v
+
+
+# --------------------------------------------------------------------
+# Real shifts
+# --------------------------------------------------------------------
+
+
+def test_deletion_in_homopolymer_shifts_to_leftmost():
+    """Reference AAAAAAAAAA at pos 1-10. Delete 'A' at pos 10 (varcode
+    normalizes 'AA'->'A' at pos 9 to ref='A',alt='',start=10).
+    Should shift to the leftmost equivalent: start=1."""
+    g = _genome_with_fasta({"1": "A" * 10}, offset=1)
+    v = Variant("1", 9, "AA", "A", genome=g)
+    assert v.start == 10  # post-normalization
+
+    out = left_align_indels(VariantCollection([v]))
+    o = out[0]
+    assert o.ref == "A" and o.alt == ""
+    assert o.start == 1
+    assert o.source_variants == (v,)
+
+
+def test_insertion_in_homopolymer_shifts_to_leftmost():
+    """Reference AAAAA at pos 5-9, with non-A flanking. Insert 'A'
+    after pos 9 should shift to insertion at pos 5 (the leftmost
+    anchor where the inserted A is equivalent)."""
+    g = _genome_with_fasta({"1": "T" + "A" * 5 + "T"}, offset=4)
+    # offset=4 means: pos 4='T', pos 5..9='A', pos 10='T'.
+    v = Variant("1", 9, "A", "AA", genome=g)  # insert A after pos 9
+    out = left_align_indels(VariantCollection([v]))
+    o = out[0]
+    assert o.ref == "" and o.alt == "A"
+    assert o.start == 4  # algorithm stops when reference[5]='A' but
+    # check at iter 6 is at reference[4]='T'; T != A; stop. Wait, let me
+    # trace: start=9, check reference[9]='A' (since pos 9 = seq[5] = 'A'),
+    # match, shift to start=8. check reference[8]='A', shift. ... shift
+    # to start=5. check reference[5]='A', shift to start=4. check
+    # reference[4]='T', T != A, stop. So final start=4. ✓
+
+
+def test_str_repeat_deletion_shifts_to_first_unit():
+    """Reference: ATATATATAT (5 AT repeats) at pos 1-10. Delete 'AT'
+    at pos 9-10 should shift to delete 'AT' at pos 1-2."""
+    g = _genome_with_fasta({"1": "AT" * 5}, offset=1)
+    v = Variant("1", 8, "TAT", "T", genome=g)
+    # CT- repeat deletion. Varcode normalizes 'TAT'->'T' (anchor T)
+    # so ref='AT' alt='' start=9.
+    assert (v.ref, v.alt, v.start) == ("AT", "", 9)
+
+    out = left_align_indels(VariantCollection([v]))
+    o = out[0]
+    assert o.ref == "AT" and o.alt == ""
+    assert o.start == 1  # leftmost AT in the repeat
+    assert o.source_variants == (v,)
+
+
+def test_bounded_at_chromosome_start():
+    """Shift bounded by start > 1 — even in an infinite homopolymer,
+    the algorithm stops at pos 1."""
+    # Reference A at pos 1 only, then arbitrary.
+    g = _genome_with_fasta({"1": "A" + "T" * 100}, offset=1)
+    v = Variant("1", 1, "AA", "A", genome=g)
+    # Hmm — this normalizes to ref='A',alt='',start=2 (delete the second
+    # base which is T per our reference). That's not a valid call for
+    # left-alignment because there's no run.
+    # Use a 2-A homopolymer at start instead.
+    g2 = _genome_with_fasta({"1": "AA" + "T" * 100}, offset=1)
+    v2 = Variant("1", 1, "AA", "A", genome=g2)
+    # ref='A',alt='',start=2. Try to shift to 1.
+    out = left_align_indels(VariantCollection([v2]))
+    o = out[0]
+    # Shifted from start=2 to start=1; can't go further (start > 1 false).
+    assert o.start == 1
+    assert o.source_variants == (v2,)
+
+
+def test_multi_base_insertion_in_homopolymer():
+    """Multi-base payload shift: insert 'AAA' in a long A-run."""
+    g = _genome_with_fasta({"1": "T" + "A" * 20 + "T"}, offset=1)
+    # pos 1='T', pos 2..21='A', pos 22='T'.
+    v = Variant("1", 21, "A", "AAAA", genome=g)
+    # Normalized: ref='',alt='AAA',start=21.
+    out = left_align_indels(VariantCollection([v]))
+    o = out[0]
+    assert o.ref == "" and o.alt == "AAA"
+    # Shift continues as long as reference matches payload[-1]='A'.
+    # Stops when reference at check_pos is not 'A'. Reference[1]='T'.
+    # So shift continues through positions 21..2 (all A), stops at
+    # check_pos=1 (T != A). Final start = 1 (varcode insertion anchor).
+    assert o.start == 1
+    assert o.source_variants == (v,)
+
+
+# --------------------------------------------------------------------
+# Idempotence, mixed VC, empty VC
+# --------------------------------------------------------------------
+
+
+def test_idempotent_on_canonical_input():
+    """Running left_align_indels twice produces the same VC the
+    second time — the first call leaves variants at canonical
+    positions, so the second call finds nothing to shift."""
+    g = _genome_with_fasta({"1": "A" * 10 + "T" * 5}, offset=1)
+    v = Variant("1", 9, "AA", "A", genome=g)
+    once = left_align_indels(VariantCollection([v]))
+    twice = left_align_indels(once)
+    assert once[0].start == twice[0].start
+    assert once[0].ref == twice[0].ref
+    assert once[0].alt == twice[0].alt
+    # The second call had nothing to shift, so it returns the input
+    # collection unchanged.
+    assert twice is once
+
+
+def test_mixed_vc_only_indels_shift():
+    g = _genome_with_fasta({"1": "A" * 20 + "T" * 80}, offset=1)
+    snv = Variant("1", 50, "T", "G", genome=g)
+    indel = Variant("1", 19, "AA", "A", genome=g)
+    mnv = Variant("1", 60, "TT", "GG", genome=g)
+    vc = VariantCollection([snv, indel, mnv])
+    out = left_align_indels(vc)
+    # Same length; SNV and MNV pass through; indel shifts.
+    assert len(out) == 3
+    snv_out = [v for v in out if v.is_snv][0]
+    indel_out = [v for v in out if v.is_indel][0]
+    assert snv_out is snv
+    assert indel_out.source_variants == (indel,)
+    assert indel_out.start == 1
+
+
+def test_empty_vc_passes_through():
+    g = _genome_with_fasta({"1": "A" * 10}, offset=1)
+    # Skip the genome here — empty VC doesn't need one.
+    vc = VariantCollection([])
+    out = left_align_indels(vc)
+    assert len(out) == 0
+
+
+# --------------------------------------------------------------------
+# Metadata + provenance
+# --------------------------------------------------------------------
+
+
+def test_original_start_recorded_in_metadata_info():
+    """The original (pre-shift) start position is recorded in the
+    shifted variant's metadata info dict for round-trip and
+    debugging."""
+    g = _genome_with_fasta({"1": "A" * 10}, offset=1)
+    v = Variant("1", 9, "AA", "A", genome=g)
+    metadata = {"synth": {v: {"id": "v1", "info": {"AC": 1}}}}
+    vc = VariantCollection(
+        variants=[v],
+        sources={"synth"},
+        source_to_metadata_dict=metadata)
+    out = left_align_indels(vc)
+    shifted = out[0]
+    assert shifted is not v
+    meta = out.source_to_metadata_dict["synth"][shifted]
+    assert meta["info"]["original_start"] == 10  # pre-shift start
+    assert meta["info"]["AC"] == 1  # other info fields preserved
+    # The original variant is no longer keyed in the metadata dict.
+    assert v not in out.source_to_metadata_dict["synth"]
+
+
+def test_unshifted_variant_metadata_passes_through_by_reference():
+    """Variants that don't shift keep their original metadata entry
+    by reference — no allocation, no info-dict copy."""
+    g = _genome_with_fasta({"1": "ACGT" * 25}, offset=1)
+    v = Variant("1", 50, "A", "T", genome=g)  # SNV; no shift possible
+    original_info = {"AC": 1}
+    metadata = {"synth": {v: {"id": "v1", "info": original_info}}}
+    vc = VariantCollection(
+        variants=[v],
+        sources={"synth"},
+        source_to_metadata_dict=metadata)
+    out = left_align_indels(vc)
+    assert out[0] is v
+    # Same metadata entry (no shifting happened, so no copy needed).
+    assert out.source_to_metadata_dict["synth"][v] is metadata["synth"][v]
+
+
+# --------------------------------------------------------------------
+# Composition with pair_breakends
+# --------------------------------------------------------------------
+
+
+def test_composes_with_pair_breakends():
+    """Mixed VC containing SNVs, indels, and a paired BND. After
+    left_align_indels + pair_breakends: indel shifts, BNDs collapse
+    into one combined SV, SNV unchanged."""
+    from varcode.transforms import pair_breakends
+    from varcode import load_vcf
+    import tempfile
+
+    body = (
+        "##fileformat=VCFv4.2\n"
+        "##reference=GRCh38\n"
+        "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"t\">\n"
+        "##INFO=<ID=MATEID,Number=1,Type=String,Description=\"m\">\n"
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+        "1\t1000\tsnv\tA\tT\t100\tPASS\t.\n"
+        "1\t1100\tindel\tAA\tA\t100\tPASS\t.\n"
+        "19\t15250000\tbnd1\tG\tG]15:34350000]\t100\tPASS\tMATEID=bnd2\n"
+        "15\t34350000\tbnd2\tA\tA[19:15250000[\t100\tPASS\tMATEID=bnd1\n"
+    )
+    with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".vcf", delete=False) as f:
+        f.write(body)
+        path = f.name
+
+    # Use a real pyensembl genome (no FASTA) — left_align will fall
+    # through to transcript cDNA. The chr1 indel won't shift (Tier 2
+    # only covers exonic positions, and pos 1100 is intergenic), but
+    # the test still verifies composition works.
+    vc = load_vcf(path, genome="GRCh38", parse_structural_variants=True)
+    assert len(vc) == 4
+
+    vc = left_align_indels(vc)
+    vc = pair_breakends(vc)
+
+    # 1 SNV + 1 indel (unshifted, intergenic with no FASTA) + 1 combined BND.
+    assert len(vc) == 3
+    bnds = [v for v in vc if getattr(v, "sv_type", None) == "BND"]
+    assert len(bnds) == 1
+    assert len(bnds[0].source_variants) == 2
+
+
+# --------------------------------------------------------------------
+# Tier 2 coverage — exonic indels shift, intronic ones don't
+# --------------------------------------------------------------------
+
+
+def test_intronic_indel_without_fasta_passes_through():
+    """An indel in an intron without a FASTA has no reference
+    coverage (Tier 2 returns empty); the algorithm exits immediately
+    and the variant passes through unchanged."""
+    # Use real pyensembl genome. CFTR (chr7, + strand) — pick an
+    # intronic position.
+    from pyensembl import cached_release
+    g = cached_release(81)
+    t = g.transcript_by_id("ENST00000003084")
+    intron_pos = t.exons[0].end + 100  # 100bp into the first intron
+    v = Variant("7", intron_pos, "AA", "A", genome=g)
+    vc = VariantCollection([v])
+    out = left_align_indels(vc)
+    # No shift — variant passes through.
+    assert out[0] is v
+    assert out[0].source_variants == ()
+
+
+def test_partial_shift_flag_set_when_coverage_runs_out():
+    """When the algorithm shifts at least once but stops because the
+    reference returns empty (Tier 2 exon boundary, or off-end-of-FASTA),
+    info['left_align_partial'] = True flags the result."""
+    # Reference covers only positions 5-10 (all A); positions <5 are
+    # uncovered. A deletion in the run can shift from pos 10 down to
+    # pos 5, then stops at the coverage boundary.
+    g = _genome_with_fasta({"1": "A" * 6}, offset=5)
+    v = Variant("1", 9, "AA", "A", genome=g)
+    # Normalized: ref='A', alt='', start=10.
+    metadata = {"synth": {v: {"id": "v1", "info": {}}}}
+    vc = VariantCollection(
+        variants=[v],
+        sources={"synth"},
+        source_to_metadata_dict=metadata)
+    out = left_align_indels(vc)
+    shifted = out[0]
+    assert shifted.start == 5  # shifted to coverage boundary
+    info = out.source_to_metadata_dict["synth"][shifted]["info"]
+    assert info.get("left_align_partial") is True
+    assert info["original_start"] == 10

--- a/varcode/transforms/__init__.py
+++ b/varcode/transforms/__init__.py
@@ -34,13 +34,13 @@ Shipped transforms:
 
 * :func:`pair_breakends` — merges MATEID-paired BND rows into a
   single combined ``StructuralVariant``. (reduces)
+* :func:`left_align_indels` — shifts indels to their canonical
+  leftmost equivalent position. (preserves)
 
 Planned (separate PRs):
 
 * ``combine_cis_snvs`` — combine adjacent in-codon SNVs into MNVs
   given phase. (reduces)
-* ``left_align_indels`` — canonical-position indel normalization.
-  (preserves)
 * ``split_multiallelic`` — split a multi-ALT row into one variant
   per ALT, making today's implicit parse-time behavior explicit.
   (increases)
@@ -51,10 +51,11 @@ Planned (separate PRs):
 import warnings
 
 from ..structural_variant import StructuralVariant
+from ..variant import Variant
 from ..variant_collection import VariantCollection
 
 
-__all__ = ["pair_breakends"]
+__all__ = ["pair_breakends", "left_align_indels"]
 
 
 def _is_breakend(variant):
@@ -530,3 +531,84 @@ def pair_breakends(vc):
         sources=vc.sources,
         source_to_metadata_dict=out_metadata,
     )
+
+
+# ====================================================================
+# left_align_indels
+# ====================================================================
+
+
+def left_align_indels(vc):
+    """Shift indels to their canonical leftmost equivalent position. (preserves)
+
+    Indels in homopolymer or short-tandem-repeat regions can be
+    represented at any of several equivalent positions — ``CTT->T``
+    inside a ``CT``-repeat means the same biological event as
+    ``CT->_`` two positions to the left. Tools that compare variants
+    by ``(contig, start, ref, alt)`` see those representations as
+    distinct calls. Left-alignment normalizes to a single canonical
+    representation per indel: the leftmost equivalent position.
+
+    The algorithm is the standard variant-normalization left-shift
+    used by ``bcftools norm`` and GATK ``LeftAlignAndTrimVariants``,
+    applied as an opt-in ``VariantCollection -> VariantCollection``
+    transform rather than baked into VCF load.
+
+    Reference sequence is read via the genome the variants carry —
+    no explicit ``reference`` parameter. Coverage tiers (see
+    :mod:`varcode.genome_sequence`):
+
+    * **Chromosome FASTA attached** (via :class:`varcode.Genome`'s
+      ``fasta`` slot): indels everywhere shift to canonical
+      positions, including in introns and intergenic regions.
+    * **No FASTA** (default pyensembl install): indels fully within
+      an exon shift via the transcript cDNA fallback. Intronic and
+      intergenic indels pass through unchanged. Indels that *start*
+      exonic but would shift across an exon boundary stop at the
+      boundary and carry ``info["left_align_partial"] = True``.
+
+    Parameters
+    ----------
+    vc : VariantCollection
+        Input collection. May contain a mix of SNVs, MNVs, indels,
+        complex variants, and SVs — only pure indels (length-different
+        REF/ALT with one side empty after suffix trimming) are
+        considered for shifting. Everything else passes through.
+
+    Returns
+    -------
+    VariantCollection
+        A new collection with indels at their canonical leftmost
+        positions. Variants that shifted carry
+        ``source_variants=(original,)``; everything else passes through
+        with ``source_variants=()``.
+
+    Behavior
+    --------
+
+    * **Cardinality**: preserves (1:1, position/payload may change).
+    * **Provenance**: shifted variants carry
+      ``source_variants=(original,)``; unchanged variants stay with
+      ``source_variants=()``.
+    * **Metadata**: per-source-path metadata is re-keyed under the
+      shifted variant; the original entry is no longer in the output
+      collection's metadata dict. ``info["original_start"]`` is added
+      so round-trip / debugging can recover the input position.
+    * **Idempotence**: a variant already at canonical position passes
+      through unchanged on every subsequent call.
+    * **Multi-base indels** (e.g. ``CCAGTC->C`` for a 5bp deletion in
+      a ``CAGTC``-repeat) shift the same way as single-base indels;
+      the shift uses the indel's payload as the unit.
+    * **Complex variants** (length-mismatched and content-mismatched,
+      e.g. ``ATG->GCC``) are not shifted — left-alignment isn't
+      well-defined for them. Pass-through.
+
+    Examples
+    --------
+
+    >>> from varcode.transforms import left_align_indels
+    >>> normalized = left_align_indels(vc)  # doctest: +SKIP
+    """
+    raise NotImplementedError(
+        "varcode.transforms.left_align_indels — implementation in "
+        "progress, tracked in openvax/varcode#369")

--- a/varcode/transforms/__init__.py
+++ b/varcode/transforms/__init__.py
@@ -41,11 +41,6 @@ Planned (separate PRs):
 
 * ``combine_cis_snvs`` — combine adjacent in-codon SNVs into MNVs
   given phase. (reduces)
-* ``split_multiallelic`` — split a multi-ALT row into one variant
-  per ALT, making today's implicit parse-time behavior explicit.
-  (increases)
-* ``decompose_mnvs`` — inverse of ``combine_cis_snvs``: split MNVs
-  into constituent SNVs for cross-tool comparison. (increases)
 """
 
 import warnings
@@ -609,6 +604,125 @@ def left_align_indels(vc):
     >>> from varcode.transforms import left_align_indels
     >>> normalized = left_align_indels(vc)  # doctest: +SKIP
     """
-    raise NotImplementedError(
-        "varcode.transforms.left_align_indels — implementation in "
-        "progress, tracked in openvax/varcode#369")
+    from ..genome_sequence import reference_range
+
+    replacement = {}        # original variant -> shifted variant
+    bounded_by_coverage = set()  # shifted variants whose shift hit a
+                                 # reference-coverage boundary (Tier 2 stop)
+
+    for variant in vc:
+        if not variant.is_indel:
+            continue
+        shifted, partial = _left_align_one(variant, reference_range)
+        if shifted is variant:
+            continue
+        replacement[variant] = shifted
+        if partial:
+            bounded_by_coverage.add(id(shifted))
+
+    if not replacement:
+        return vc
+
+    out_variants = [replacement.get(v, v) for v in vc]
+
+    out_metadata = {}
+    for path, by_variant in vc.source_to_metadata_dict.items():
+        out_by_variant = {}
+        for variant, meta in by_variant.items():
+            shifted = replacement.get(variant)
+            if shifted is None:
+                out_by_variant[variant] = meta
+            else:
+                new_meta = dict(meta) if meta else {}
+                info = dict(new_meta.get("info") or {})
+                info["original_start"] = variant.start
+                if id(shifted) in bounded_by_coverage:
+                    info["left_align_partial"] = True
+                new_meta["info"] = info
+                out_by_variant[shifted] = new_meta
+        out_metadata[path] = out_by_variant
+
+    return VariantCollection(
+        variants=out_variants,
+        sources=vc.sources,
+        source_to_metadata_dict=out_metadata,
+    )
+
+
+def _left_align_one(variant, reference_range_fn):
+    """Shift one indel to its canonical leftmost position.
+
+    Returns ``(variant_or_shifted, partial_shift)``. ``partial_shift``
+    is True iff the loop exited because reference coverage ran out
+    (Tier 2 without a FASTA), not because the reference disagreed —
+    consumers can flag the result so downstream tools know a fuller
+    shift would have been possible with a chromosome FASTA.
+
+    varcode normalizes indels in :class:`Variant.__init__` so that
+    one side of (ref, alt) is empty after shared prefix/suffix
+    trimming — a deletion has ``ref != ''`` and ``alt == ''``, an
+    insertion has ``ref == ''`` and ``alt != ''``. The check
+    position differs between the two:
+
+    * **Deletion** ``ref=payload, alt='', start=N``: removes
+      ``payload`` from positions ``[N, N+len-1]``. Shift left valid
+      iff ``reference[N-1] == payload[-1]`` — the base entering on
+      the left equals the base leaving on the right.
+    * **Insertion** ``ref='', alt=payload, start=N``: inserts
+      ``payload`` after position ``N``. Shift left valid iff
+      ``reference[N] == payload[-1]`` — the anchor base equals the
+      last inserted base, allowing the payload to rotate around it.
+    """
+    if not variant.is_indel:
+        return variant, False
+
+    ref, alt = variant.ref, variant.alt
+    if ref and alt:
+        # Complex variant (both sides non-empty after normalization).
+        # Shouldn't happen for is_indel, but defensively pass through.
+        return variant, False
+
+    is_insertion = (not ref) and alt
+    payload = alt if is_insertion else ref
+    if not payload:
+        return variant, False
+
+    start = variant.start
+    new_start = start
+    new_payload = payload
+    partial = False
+
+    while new_start > 1:
+        # Insertion checks at new_start (the anchor); deletion checks
+        # at new_start - 1 (the base just before the deletion).
+        check_pos = new_start if is_insertion else (new_start - 1)
+        prev = reference_range_fn(
+            variant.genome, variant.contig, check_pos, check_pos)
+        if not prev:
+            # Reference coverage ran out at this position. If we
+            # already moved, this is a partial shift — a chromosome
+            # FASTA would have allowed continuing.
+            partial = (new_start != start)
+            break
+        if prev.upper() != new_payload[-1].upper():
+            break  # natural stop — reference disagrees
+        new_payload = prev.upper() + new_payload[:-1]
+        new_start -= 1
+
+    if new_start == start:
+        return variant, False
+
+    new_ref = new_payload if not is_insertion else ""
+    new_alt = new_payload if is_insertion else ""
+    shifted = Variant(
+        contig=variant.contig,
+        start=new_start,
+        ref=new_ref,
+        alt=new_alt,
+        genome=variant.genome,
+        allow_extended_nucleotides=getattr(
+            variant, "allow_extended_nucleotides", False),
+        normalize_contig_names=False,
+    )
+    shifted.source_variants = (variant,)
+    return shifted, partial

--- a/varcode/transforms/__init__.py
+++ b/varcode/transforms/__init__.py
@@ -45,6 +45,7 @@ Planned (separate PRs):
 
 import warnings
 
+from ..genome_sequence import reference_range as _reference_range
 from ..structural_variant import StructuralVariant
 from ..variant import Variant
 from ..variant_collection import VariantCollection
@@ -578,25 +579,9 @@ def left_align_indels(vc):
         ``source_variants=(original,)``; everything else passes through
         with ``source_variants=()``.
 
-    Behavior
-    --------
-
-    * **Cardinality**: preserves (1:1, position/payload may change).
-    * **Provenance**: shifted variants carry
-      ``source_variants=(original,)``; unchanged variants stay with
-      ``source_variants=()``.
-    * **Metadata**: per-source-path metadata is re-keyed under the
-      shifted variant; the original entry is no longer in the output
-      collection's metadata dict. ``info["original_start"]`` is added
-      so round-trip / debugging can recover the input position.
-    * **Idempotence**: a variant already at canonical position passes
-      through unchanged on every subsequent call.
-    * **Multi-base indels** (e.g. ``CCAGTC->C`` for a 5bp deletion in
-      a ``CAGTC``-repeat) shift the same way as single-base indels;
-      the shift uses the indel's payload as the unit.
-    * **Complex variants** (length-mismatched and content-mismatched,
-      e.g. ``ATG->GCC``) are not shifted — left-alignment isn't
-      well-defined for them. Pass-through.
+    See :doc:`/transforms` for the behavior table covering all
+    six (location × FASTA-attached) combinations and the metadata
+    fields the transform writes.
 
     Examples
     --------
@@ -604,39 +589,41 @@ def left_align_indels(vc):
     >>> from varcode.transforms import left_align_indels
     >>> normalized = left_align_indels(vc)  # doctest: +SKIP
     """
-    from ..genome_sequence import reference_range
-
-    replacement = {}        # original variant -> shifted variant
-    bounded_by_coverage = set()  # shifted variants whose shift hit a
-                                 # reference-coverage boundary (Tier 2 stop)
+    # original variant -> (shifted variant, bounded_by_coverage flag).
+    # The flag rides with the shifted variant so we don't need a
+    # second data structure keyed on id() — the lifecycle of the
+    # flag and the lifecycle of the shifted variant are identical.
+    replacement = {}
 
     for variant in vc:
         if not variant.is_indel:
             continue
-        shifted, partial = _left_align_one(variant, reference_range)
+        shifted, partial = _left_align_one(variant, _reference_range)
         if shifted is variant:
             continue
-        replacement[variant] = shifted
-        if partial:
-            bounded_by_coverage.add(id(shifted))
+        replacement[variant] = (shifted, partial)
 
     if not replacement:
         return vc
 
-    out_variants = [replacement.get(v, v) for v in vc]
+    out_variants = [
+        replacement[v][0] if v in replacement else v
+        for v in vc
+    ]
 
     out_metadata = {}
     for path, by_variant in vc.source_to_metadata_dict.items():
         out_by_variant = {}
         for variant, meta in by_variant.items():
-            shifted = replacement.get(variant)
-            if shifted is None:
+            entry = replacement.get(variant)
+            if entry is None:
                 out_by_variant[variant] = meta
             else:
+                shifted, partial = entry
                 new_meta = dict(meta) if meta else {}
                 info = dict(new_meta.get("info") or {})
                 info["original_start"] = variant.start
-                if id(shifted) in bounded_by_coverage:
+                if partial:
                     info["left_align_partial"] = True
                 new_meta["info"] = info
                 out_by_variant[shifted] = new_meta


### PR DESCRIPTION
Planning PR for #369. Lands on top of the `varcode.Genome` + tiered reference lookup infrastructure that shipped in #373 (4.20.0), so this PR has **zero new dependencies** — no `reference` kwarg, no new genome accessor. The transform reads bases via `varcode.reference_range(variant.genome, ...)` and gets whatever tier coverage the user has configured: full chromosome FASTA, transcript cDNA only, or nothing.

This commit is **scaffold only** — `varcode/transforms/__init__.py` gets the `left_align_indels` signature and the full contract docstring; body raises `NotImplementedError`. Implementation lands in follow-up commits on this branch.

---

## Table of contents

1. [Why it lives here](#1-why-it-lives-here)
2. [API](#2-api)
3. [Algorithm](#3-algorithm)
4. [Reference coverage tiers + partial shifts](#4-reference-coverage-tiers--partial-shifts)
5. [Metadata behavior](#5-metadata-behavior)
6. [Test matrix](#6-test-matrix)
7. [Open design questions](#7-open-design-questions)
8. [Plan to merge](#8-plan-to-merge)
9. [Test plan](#9-test-plan)

---

## 1. Why it lives here

Two pipelines that exchange variants need a canonical representation per indel — `CTT->T` at position 10 inside a `CT`-repeat means the same biological event as `CT->_` at position 8. Tools that compare variants by `(contig, start, ref, alt)` see these as distinct calls. Standard fix in the genomics tooling world: `bcftools norm -f reference.fa` or GATK `LeftAlignAndTrimVariants`.

Three reasons to put it in varcode now:

- **`(contig, start, ref, alt)` is varcode's variant identity.** Comparing variants across callers, against ClinVar/COSMIC, or pre-/post-pipeline is something varcode users do constantly, and they currently hit the homopolymer-representation mismatch silently.
- **Composes cleanly with the existing transforms pattern.** `pair_breakends` and the planned `combine_cis_snvs` are sibling `VC -> VC` transforms. Left-alignment slots in next to them with the same composition story.
- **#372 made it free of new API surface.** Pre-#372 this transform would have needed its own `reference` kwarg and adapter classes. Now it just reads from the genome the variant already carries.

## 2. API

```python
from varcode import load_vcf, Genome
from varcode.transforms import left_align_indels, pair_breakends

# Default (transcript-cDNA coverage only) — exonic indels normalize,
# others pass through unchanged.
vc = load_vcf("tumor.vcf", genome="GRCh38")
vc = left_align_indels(vc)

# Full coverage — every indel normalizes.
g = Genome(81, fasta="/path/to/GRCh38.fa")
vc = load_vcf("tumor.vcf", genome=g)
vc = left_align_indels(vc)

# Composes with pair_breakends and (future) combine_cis_snvs.
vc = pair_breakends(vc)
effects = vc.effects()
```

Single argument: the `VariantCollection`. Same shape as `pair_breakends`.

## 3. Algorithm

Standard variant-normalization left-shift, mirroring `bcftools norm`:

```python
def _left_align_one(variant):
    ref, alt = variant.ref, variant.alt
    start = variant.start

    # SNV / MNV / complex — already canonical; no shift defined.
    if len(ref) == len(alt):
        return variant
    if len(ref) > 0 and len(alt) > 0 and ref[0] != alt[0]:
        # Complex variant (length-mismatched and content-different) —
        # not a clean indel, can't safely left-shift.
        return variant

    # Step 1: trim shared suffix.
    while ref and alt and ref[-1] == alt[-1]:
        ref, alt = ref[:-1], alt[:-1]

    # Step 2: trim shared prefix (keep at least one base on each side
    # if both are non-empty; VCF convention requires non-empty REF/ALT).
    while len(ref) > 1 and len(alt) > 1 and ref[0] == alt[0]:
        ref, alt = ref[1:], alt[1:]
        start += 1

    # Step 3: left-shift while reference allows. Use the indel payload
    # (whichever side is non-empty after trimming) as the unit.
    payload = ref if len(ref) > len(alt) else alt
    while start > 1:
        prev = reference_range(variant.genome, variant.contig,
                                start - 1, start - 1)
        if not prev:
            break  # bounded by chromosome start or reference coverage
        if payload[-1] != prev:
            break
        payload = prev + payload[:-1]
        start -= 1

    # Step 4: re-anchor with the VCF-required leading shared base.
    if len(ref) == 0 or len(alt) == 0:
        anchor = reference_range(variant.genome, variant.contig,
                                  start - 1, start - 1)
        if not anchor:
            return variant  # can't anchor; pass through unchanged
        if len(ref) == 0:
            ref = anchor
            alt = anchor + payload
        else:
            ref = anchor + payload
            alt = anchor
        start -= 1

    if (start, ref, alt) == (variant.start, variant.ref, variant.alt):
        return variant  # already canonical
    return _build_shifted(variant, start, ref, alt)
```

Notes:

- **No `max_shift` cap.** Loop terminates when reference disagrees or runs out. In repeat regions the shift is bounded by the repeat length (typically <100bp); in homopolymers by the run length. No need for an artificial cap.
- **Reads via `reference_range`** so the algorithm doesn't know or care about coverage tiers — when a position is uncovered (intronic + no FASTA, or off-the-end-of-chromosome), `reference_range` returns `""` and the loop exits cleanly.

## 4. Reference coverage tiers + partial shifts

Because #372's tiered lookup degrades gracefully, left-alignment does too. Three regimes:

| Variant + genome | Behavior |
|---|---|
| Indel inside an exon, no FASTA | Transcript-cDNA fallback covers all candidate positions; shifts to canonical. |
| Indel inside an exon, FASTA attached | Same shift result; FASTA path used. |
| Indel in intron / intergenic, no FASTA | First lookup returns `""`; no shift, pass-through. |
| Indel in intron / intergenic, FASTA attached | Shifts to canonical. |
| **Indel starts exonic, but canonical position is in upstream intron, no FASTA** | **Partial shift** — moves left until hitting the exon boundary, stops there, sets `info["left_align_partial"] = True`. |
| Indel at chromosome start | Shift bounded by `start > 1`; no underflow. |

The partial-shift case is the only subtle one. Two valid behaviors:

- **A. Partial shift with flag** (preferred): the variant moves as far left as the reference allows. The result is *strictly more canonical* than the input. `info["left_align_partial"] = True` signals "a FASTA would have shifted further." Downstream tools comparing variants can choose to filter on this flag.
- **B. Don't shift unless we can shift fully**: simpler invariant but loses normalization for the in-exon-but-near-boundary case, which is common in CDS-edge indels.

I lean A. Reviewer input welcome.

## 5. Metadata behavior

When a variant shifts:

- Identity changes (contig is the same, but start/ref/alt differ). The variant's hash/equality changes accordingly.
- The new variant carries `source_variants=(original,)`. Consumers walking provenance can recover the input position.
- `info["original_start"] = original.start` is set on the new variant for direct lookup without walking source_variants.
- Per-source-path metadata is re-keyed in the output VC's `source_to_metadata_dict` under the shifted variant. The original key is dropped (would otherwise be a stale entry).
- Genotype, INFO, FILTER, QUAL all carry through — left-alignment doesn't change the variant's evidence, just its canonical position.

When a variant doesn't shift:

- It passes through with `source_variants=()` and identical metadata entry.
- This is the idempotence guarantee — running `left_align_indels` twice produces the same output.

## 6. Test matrix

New file `tests/test_transforms_left_align.py`. Uses a `DictBackedFasta` adapter so no real chromosome FASTA dependency (same pattern as `test_genome_sequence.py`).

| # | Case | Expected |
|---|---|---|
| 1 | Pure SNV | pass-through, `source_variants=()` |
| 2 | MNV | pass-through, `source_variants=()` |
| 3 | Complex variant (`ATG->GCC`) | pass-through (not a clean indel) |
| 4 | Already-canonical deletion in non-repeat region | pass-through |
| 5 | Already-canonical insertion in non-repeat region | pass-through |
| 6 | Deletion in homopolymer (`AAAAAA`, del `A`) | shifts to leftmost, `source_variants=(original,)` |
| 7 | Insertion in homopolymer | shifts to leftmost |
| 8 | STR repeat deletion (`AC` repeat, del `AC`) | shifts to first `AC` |
| 9 | Bounded shift at chromosome start (pos=2, can't go past 1) | stops at 1 |
| 10 | Multi-base insertion in a homopolymer | shifts using payload as the unit |
| 11 | Idempotence: applying twice = applying once | second call is no-op |
| 12 | Mixed VC: SNVs + indels + SVs | only indels shift; others pass through |
| 13 | Indel inside an exon, no FASTA — Tier 2 covers full shift | shifts to canonical |
| 14 | Indel inside an exon, would shift past exon start — Tier 2 only | partial shift, `info["left_align_partial"] = True` |
| 15 | Indel in intron, no FASTA | pass-through (no reference) |
| 16 | Indel in intron, FASTA attached | shifts to canonical |
| 17 | Metadata re-keying: shifted variant has source path's metadata; original key gone | ✓ |
| 18 | `info["original_start"]` populated on shifted output | ✓ |
| 19 | Empty VC | empty output, no errors |
| 20 | Compose with `pair_breakends`: SNVs + indels + paired BNDs in one VC | indels normalize, BNDs pair, SNVs pass through |

## 7. Open design questions

1. **Partial shift vs all-or-nothing** (§4) — I lean partial-with-flag for the in-exon-but-near-boundary case. Reviewer input welcome.
2. **Should the transform expose a `max_shift` cap?** I lean no — the loop terminates naturally on reference disagreement; an artificial cap papers over rather than fixing problems. But callers worried about long shifts in pathological inputs (e.g. a 10kb homopolymer in a sequencing artifact) might want one. Punt to a follow-up if anyone asks.
3. **Idempotence detection via short-circuit** — I rely on the algorithm's natural fixed-point property. An explicit "already-canonical" flag on the variant would let the second call exit in O(1) instead of recomputing. Probably not worth the marginal speedup; left-alignment is per-variant, not in a hot loop.

## 8. Plan to merge

Four commits on this branch, each independently reviewable:

| # | Commit | LOC est. |
|---|---|---|
| 1 | **Scaffold** — signature + contract docstring + module docstring update + __all__. (done; this commit, ~85 LOC) |  |
| 2 | `left_align_indels` body — trim, shift, re-anchor, build shifted variant, propagate metadata | ~150 |
| 3 | Test matrix (20 cases) | ~400 |
| 4 | Docs — `docs/transforms.md` update with the `left_align_indels` section + usage recipe | ~80 |

Lift draft -> ready when commits 2–4 land and CI is green.

## 9. Test plan

- [ ] `pytest tests/test_transforms_left_align.py` — 20 cases pass.
- [ ] `pytest tests/test_transforms_pair_breakends.py` — no regressions; `pair_breakends` and `left_align_indels` compose.
- [ ] `pytest tests/` — full suite green across 3.9 / 3.10 / 3.11.
- [ ] Manual: load a real Manta/Strelka VCF, run `left_align_indels`, spot-check normalized positions against `bcftools norm -f reference.fa` output.

---

## Out of scope (deferred)

- **MNV decomposition followed by left-alignment** — `decompose_mnvs` is a separate planned transform.
- **Strict mode / fail-loud for partial shifts** — partial-shift is currently a flag, not an error. If users want hard failures, add a `strict_full_shift=False` opt-in kwarg later.
- **Multi-VCF normalization** — `left_align_indels` operates on one VC at a time. Pipelines comparing across VCFs apply it to each independently; the canonical-position invariant guarantees agreement post-normalization.

## Related

* **#372** — `varcode.Genome` + tiered reference lookup (the infrastructure this PR consumes).
* **#367** — `varcode.transforms` module shape (defines the contract this PR follows).
* **#364** — `pair_breakends` (the first shipped transform; sets the test/doc pattern).