### PR TITLE
Add VariantCollection.difference (closes #229)

### DIFF
--- a/tests/test_variant_collection.py
+++ b/tests/test_variant_collection.py
@@ -31,6 +31,36 @@ def test_variant_collection_intersection():
     eq_(set(combined.sources), {ov_wustle_variants.source, tcga_ov_variants.source})
     eq_(len(combined), 0)
 
+def test_variant_collection_difference_disjoint():
+    diff = ov_wustle_variants.difference(tcga_ov_variants)
+    eq_(set(diff.sources), {ov_wustle_variants.source, tcga_ov_variants.source})
+    eq_(len(diff), len(ov_wustle_variants))
+    eq_(set(diff), set(ov_wustle_variants))
+
+def test_variant_collection_difference_with_self():
+    diff = ov_wustle_variants.difference(ov_wustle_variants)
+    eq_(len(diff), 0)
+
+def test_variant_collection_difference_partial_overlap():
+    v1 = Variant("1", 100, "A", "T", genome="GRCh38")
+    v2 = Variant("1", 200, "C", "G", genome="GRCh38")
+    v3 = Variant("1", 300, "G", "A", genome="GRCh38")
+    a = VariantCollection([v1, v2, v3])
+    b = VariantCollection([v2])
+    diff = a.difference(b)
+    eq_(len(diff), 2)
+    eq_(set(diff), {v1, v3})
+
+def test_variant_collection_difference_multiple_args():
+    v1 = Variant("1", 100, "A", "T", genome="GRCh38")
+    v2 = Variant("1", 200, "C", "G", genome="GRCh38")
+    v3 = Variant("1", 300, "G", "A", genome="GRCh38")
+    a = VariantCollection([v1, v2, v3])
+    b = VariantCollection([v1])
+    c = VariantCollection([v3])
+    diff = a.difference(b, c)
+    eq_(set(diff), {v2})
+
 def test_variant_collection_gene_counts():
     gene_counts = ov_wustle_variants.gene_counts()
     # test that each gene is counted just once

--- a/tests/test_variant_collection.py
+++ b/tests/test_variant_collection.py
@@ -61,6 +61,33 @@ def test_variant_collection_difference_multiple_args():
     diff = a.difference(b, c)
     eq_(set(diff), {v2})
 
+def test_variant_collection_difference_passes_kwargs():
+    v1 = Variant("1", 100, "A", "T", genome="GRCh38")
+    v2 = Variant("1", 200, "C", "G", genome="GRCh38")
+    a = VariantCollection([v1, v2], distinct=True)
+    b = VariantCollection([v2])
+    diff = a.difference(b, distinct=False)
+    eq_(diff.distinct, False)
+
+def test_variant_collection_difference_preserves_metadata():
+    v1 = Variant("1", 100, "A", "T", genome="GRCh38")
+    v2 = Variant("1", 200, "C", "G", genome="GRCh38")
+    v3 = Variant("1", 300, "G", "A", genome="GRCh38")
+    a = VariantCollection(
+        [v1, v2, v3],
+        source_to_metadata_dict={"tumor.vcf": {
+            v1: {"qual": 99},
+            v2: {"qual": 50},
+            v3: {"qual": 30},
+        }})
+    b = VariantCollection(
+        [v2],
+        source_to_metadata_dict={"normal.vcf": {v2: {"qual": 25}}})
+    diff = a.difference(b)
+    eq_(set(diff), {v1, v3})
+    eq_(diff.source_to_metadata_dict["tumor.vcf"][v1], {"qual": 99})
+    eq_(diff.source_to_metadata_dict["tumor.vcf"][v3], {"qual": 30})
+
 def test_variant_collection_gene_counts():
     gene_counts = ov_wustle_variants.gene_counts()
     # test that each gene is counted just once

--- a/varcode/variant_collection.py
+++ b/varcode/variant_collection.py
@@ -416,6 +416,15 @@ class VariantCollection(Collection):
             variant_collections=(self,) + others,
             kwargs=kwargs)
 
+    def difference(self, *others, **kwargs):
+        """
+        Returns variants present in this collection but not in any of the others.
+        """
+        return self._combine_variant_collections(
+            combine_fn=set.difference,
+            variant_collections=(self,) + others,
+            kwargs=kwargs)
+
     _DATAFRAME_COLUMNS = (
         "chr", "start", "ref", "alt", "gene_name", "gene_id",
     )


### PR DESCRIPTION
## Summary

- Adds `VariantCollection.difference(*others, **kwargs)` — returns variants in `self` but not in any of the `others`.
- Mirrors the existing `union` and `intersection` methods at `varcode/variant_collection.py:401-417`, reusing the `_combine_variant_collections(combine_fn=...)` helper. The implementation is three meaningful lines.
- Closes #229.

## Why

`union` and `intersection` have shipped since the early days; `difference` was the missing third side. Practical use case: subtracting a panel-of-normals VCF from a tumor VCF.

## Test plan

- [x] `tests/test_variant_collection.py` — 4 new cases:
  - disjoint inputs (full result)
  - self-difference (empty result)
  - partial overlap (`{a, b, c} - {b} == {a, c}`)
  - multiple `others` args (`{a, b, c} - {a} - {c} == {b}`)
- [x] Full file passes: 16/16.

## Out of scope

Not adding `symmetric_difference` — no asks, and `(A | B) - (A & B)` is one line if you need it.