### PR TITLE
Expand and link the README Effect Types table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,16 @@
   those tags to `FrameShift` before loading. Anyone still reading such
   payloads can pin `varcode<4.7` or resurrect the shim in user code.
 
+**Changed**
+- README "Effect Types" section rewritten: 14 missing concrete
+  effect classes added (`Failure`, the splice mechanisms, the
+  structural-variant effects, `CrypticExonCandidate`,
+  `HaplotypeEffect`, `PhaseCandidateSet`), grouped into 7 sub-tables
+  by biological context, with a new intro explaining
+  `MultiOutcomeEffect` and how multi-possibility effects are
+  represented. Each class name links to its source definition via
+  GitHub text-fragment URLs that survive line-number drift.
+
 ## [v2.3.0](https://github.com/openvax/varcode/tree/v2.3.0) (2026-04-13)
 
 **Added**

--- a/README.md
+++ b/README.md
@@ -107,9 +107,11 @@ by biological context. Each row links to the class definition in
 via a browser text-fragment URL — links survive line-number drift as
 the source file evolves. Severity ordering across types is set by
 [`effect_priority()`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_ordering.py);
-the abstract bases (`MutationEffect`, `TranscriptMutationEffect`,
+the abstract bases — `MutationEffect`, `TranscriptMutationEffect`,
 `CodingMutation`, `NonsilentCodingMutation`, `SpliceMechanismEffect`,
-`StructuralVariantEffect`, `MultiOutcomeEffect`) are documented in the
+`StructuralVariantEffect`, `MultiOutcomeEffect` — define the shared
+interface, with `MutationEffect`, `NonsilentCodingMutation`, and
+`MultiOutcomeEffect` rendered in the
 [API reference](https://openvax.github.io/varcode/api/).
 
 ### Effects that carry multiple possibilities
@@ -132,9 +134,14 @@ instances. Every multi-outcome effect exposes the same surface:
 - `.highest_priority_candidate` / `.highest_priority_effect` — most severe by `effect_priority()`.
 
 The `MultiOutcomeEffect` containers appear in the sub-tables below
-where they're emitted (e.g. `SpliceOutcomeSet`, `ExonicSpliceSite`,
-the structural-variant effects, `HaplotypeEffect`,
-`PhaseCandidateSet`).
+where they're emitted:
+[`SpliceOutcomeSet`](https://github.com/openvax/varcode/blob/main/varcode/splice_outcomes.py#:~:text=class%20SpliceOutcomeSet%28),
+[`ExonicSpliceSite`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20ExonicSpliceSite%28),
+the [`StructuralVariantEffect`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20StructuralVariantEffect%28)
+sub-hierarchy,
+[`HaplotypeEffect`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20HaplotypeEffect%28),
+and
+[`PhaseCandidateSet`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20PhaseCandidateSet%28).
 
 ### Coding region — in-frame changes
 
@@ -174,9 +181,11 @@ splice signal, but say nothing about how the spliceosome responds
 
 The protein-level consequence of a splice-signal hit is not
 deterministic from DNA alone, so varcode emits these as candidates
-inside a `SpliceOutcomeSet` (a `MultiOutcomeEffect`). Each mechanism
-carries the originating disruption on its `.splice_signal` attribute,
-so you can always recover *where* the hit was off any mechanism.
+inside a
+[`SpliceOutcomeSet`](https://github.com/openvax/varcode/blob/main/varcode/splice_outcomes.py#:~:text=class%20SpliceOutcomeSet%28)
+(a `MultiOutcomeEffect`). Each mechanism carries the originating
+disruption on its `.splice_signal` attribute, so you can always
+recover *where* the hit was off any mechanism.
 
 | Effect type | Description |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ the source file evolves. Severity ordering across types is set by
 [`effect_priority()`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_ordering.py);
 the abstract bases — `MutationEffect`, `TranscriptMutationEffect`,
 `CodingMutation`, `NonsilentCodingMutation`, `SpliceMechanismEffect`,
-`StructuralVariantEffect`, `MultiOutcomeEffect` — define the shared
-interface, with `MutationEffect`, `NonsilentCodingMutation`, and
-`MultiOutcomeEffect` rendered in the
-[API reference](https://openvax.github.io/varcode/api/).
+`StructuralVariantEffect` — define the shared interface;
+`MutationEffect` and `NonsilentCodingMutation` have dedicated entries
+in the [API reference](https://openvax.github.io/varcode/api/), and
+`MultiOutcomeEffect` is described in its own section below.
 
 ### Effects that carry multiple possibilities
 
@@ -121,7 +121,11 @@ outcome — splice-signal disruption can resolve as normal splicing,
 exon skipping, intron retention, or cryptic-site use; an exon-edge
 variant might be a routine coding effect *or* a splice disruption;
 a structural variant might affect multiple transcripts or have
-multiple plausible breakpoint resolutions. Varcode wraps these as
+multiple plausible breakpoint resolutions; two or more cis variants
+on one transcript can compose into a joint mutant protein; and when
+phase is unknown between somatic and germline variants sharing a
+window, the somatic effect depends on which haplotype it landed on.
+Varcode wraps these as
 [`MultiOutcomeEffect`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20MultiOutcomeEffect%28)
 instances. Every multi-outcome effect exposes the same surface:
 
@@ -210,9 +214,12 @@ recover *where* the hit was off any mechanism.
 
 ### Exon-level and structural-variant effects
 
-The structural-variant effects are themselves `MultiOutcomeEffect`s
-— `.candidates` may include cryptic-exon outcomes, RNA-evidence-
-ranked alternatives, etc.
+`ExonLoss` is a plain `Exonic` effect. The structural-variant
+effects below (`LargeDeletion` through `TranslocationToIntergenic`)
+are `MultiOutcomeEffect`s — their `.candidates` may include
+cryptic-exon outcomes, RNA-evidence-ranked alternatives, and so on.
+`CrypticExonCandidate` typically appears as a candidate inside those
+SV effects rather than standalone.
 
 | Effect type | Description |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -124,9 +124,10 @@ multiple plausible breakpoint resolutions. Varcode wraps these as
 instances. Every multi-outcome effect exposes the same surface:
 
 - `.candidates` → `tuple[EffectCandidate, ...]`
-- Each [`EffectCandidate`](https://github.com/openvax/varcode/blob/main/varcode/effect_candidates.py)
+- Each [`EffectCandidate`](https://github.com/openvax/varcode/blob/main/varcode/effect_candidates.py#:~:text=class%20EffectCandidate%28)
   wraps an inner effect (`.effect`), a producer tag (`.source`,
   e.g. `"varcode"`, `"rna_evidence"`), and free-form `.evidence`.
+- `.effects` → `tuple[MutationEffect, ...]` — convenience that unwraps `.candidates` to inner effects when provenance isn't needed.
 - `.most_likely_candidate` / `.most_likely_effect` — producer-ordered top pick.
 - `.highest_priority_candidate` / `.highest_priority_effect` — most severe by `effect_priority()`.
 

--- a/README.md
+++ b/README.md
@@ -101,31 +101,130 @@ See [`CHANGELOG.md`](https://github.com/openvax/varcode/blob/main/CHANGELOG.md) 
 
 ## Effect Types
 
-|            Effect type | Description                                                                                                                                   |
-| ---------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------- |
-|  _AlternateStartCodon_ | Replace annotated start codon with alternative start codon (_e.g._ "ATG>CAG").                                                                |
-|  _ComplexSubstitution_ | Insertion and deletion of multiple amino acids.                                                                                               |
-|             _Deletion_ | Coding mutation which causes deletion of amino acid(s).                                                                                       |
-|             _ExonLoss_ | Deletion of entire exon, significantly disrupts protein.                                                                                      |
-|     _ExonicSpliceSite_ | Mutation at the beginning or end of an exon, may affect splicing.                                                                             |
-|         _FivePrimeUTR_ | Variant affects 5' untranslated region before start codon.                                                                                    |
-| _FrameShiftTruncation_ | A frameshift which leads immediately to a stop codon (no novel amino acids created).                                                          |
-|           _FrameShift_ | Out-of-frame insertion or deletion of nucleotides, causes novel protein sequence and often premature stop codon.                              |
-| _IncompleteTranscript_ | Can't determine effect since transcript annotation is incomplete (often missing either the start or stop codon).                              |
-|            _Insertion_ | Coding mutation which causes insertion of amino acid(s).                                                                                      |
-|           _Intergenic_ | Occurs outside of any annotated gene.                                                                                                         |
-|           _Intragenic_ | Within the annotated boundaries of a gene but not in a region that's transcribed into pre-mRNA.                                               |
-|   _IntronicSpliceSite_ | Mutation near the beginning or end of an intron but less likely to affect splicing than donor/acceptor mutations.                             |
-|             _Intronic_ | Variant occurs between exons and is unlikely to affect splicing.                                                                              |
-|  _NoncodingTranscript_ | Transcript doesn't code for a protein.                                                                                                        |
-|        _PrematureStop_ | Insertion of stop codon, truncates protein.                                                                                                   |
-|               _Silent_ | Mutation in coding sequence which does not change the amino acid sequence of the translated protein.                                          |
-|       _SpliceAcceptor_ | Mutation in the last two nucleotides of an intron, likely to affect splicing.                                                                 |
-|          _SpliceDonor_ | Mutation in the first two nucleotides of an intron, likely to affect splicing.                                                                |
-|            _StartLoss_ | Mutation causes loss of start codon, likely result is that an alternate start codon will be used down-stream (possibly in a different frame). |
-|             _StopLoss_ | Loss of stop codon, causes extension of protein by translation of nucleotides from 3' UTR.                                                    |
-|         _Substitution_ | Coding mutation which causes simple substitution of one amino acid for another.                                                               |
-|        _ThreePrimeUTR_ | Variant affects 3' untranslated region after stop codon of mRNA.                                                                              |
+Every concrete `MutationEffect` subclass that varcode may emit, grouped
+by biological context. Each row links to the class definition in
+[`varcode/effects/effect_classes.py`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py)
+via a browser text-fragment URL — links survive line-number drift as
+the source file evolves. Severity ordering across types is set by
+[`effect_priority()`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_ordering.py);
+the abstract bases (`MutationEffect`, `TranscriptMutationEffect`,
+`CodingMutation`, `NonsilentCodingMutation`, `SpliceMechanismEffect`,
+`StructuralVariantEffect`, `MultiOutcomeEffect`) are documented in the
+[API reference](https://openvax.github.io/varcode/api/).
+
+### Effects that carry multiple possibilities
+
+Several effects don't have a single deterministic protein-level
+outcome — splice-signal disruption can resolve as normal splicing,
+exon skipping, intron retention, or cryptic-site use; an exon-edge
+variant might be a routine coding effect *or* a splice disruption;
+a structural variant might affect multiple transcripts or have
+multiple plausible breakpoint resolutions. Varcode wraps these as
+[`MultiOutcomeEffect`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20MultiOutcomeEffect%28)
+instances. Every multi-outcome effect exposes the same surface:
+
+- `.candidates` → `tuple[EffectCandidate, ...]`
+- Each [`EffectCandidate`](https://github.com/openvax/varcode/blob/main/varcode/effect_candidates.py)
+  wraps an inner effect (`.effect`), a producer tag (`.source`,
+  e.g. `"varcode"`, `"rna_evidence"`), and free-form `.evidence`.
+- `.most_likely_candidate` / `.most_likely_effect` — producer-ordered top pick.
+- `.highest_priority_candidate` / `.highest_priority_effect` — most severe by `effect_priority()`.
+
+The `MultiOutcomeEffect` containers appear in the sub-tables below
+where they're emitted (e.g. `SpliceOutcomeSet`, `ExonicSpliceSite`,
+the structural-variant effects, `HaplotypeEffect`,
+`PhaseCandidateSet`).
+
+### Coding region — in-frame changes
+
+| Effect type | Description |
+| --- | --- |
+| [`Substitution`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20Substitution%28) | Coding mutation which causes simple substitution of one amino acid for another. |
+| [`Insertion`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20Insertion%28) | Coding mutation which causes insertion of amino acid(s). |
+| [`Deletion`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20Deletion%28) | Coding mutation which causes deletion of amino acid(s). |
+| [`ComplexSubstitution`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20ComplexSubstitution%28) | Insertion and deletion of multiple amino acids. |
+| [`Silent`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20Silent%28) | Mutation in coding sequence which does not change the amino acid sequence of the translated protein. |
+| [`AlternateStartCodon`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20AlternateStartCodon%28) | Replace annotated start codon with alternative start codon (_e.g._ "ATG>CAG"); a `Silent` subclass since the initiator tRNA still loads Met. |
+
+### Coding region — frame-disrupting / truncating
+
+| Effect type | Description |
+| --- | --- |
+| [`FrameShift`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20FrameShift%28) | Out-of-frame insertion or deletion of nucleotides, causes novel protein sequence and often premature stop codon. |
+| [`FrameShiftTruncation`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20FrameShiftTruncation%28) | A frameshift which leads immediately to a stop codon (no novel amino acids created). |
+| [`PrematureStop`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20PrematureStop%28) | Insertion of stop codon, truncates protein. |
+| [`StartLoss`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20StartLoss%28) | Mutation causes loss of start codon, likely result is that an alternate start codon will be used down-stream (possibly in a different frame). |
+| [`StopLoss`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20StopLoss%28) | Loss of stop codon, causes extension of protein by translation of nucleotides from 3' UTR. |
+
+### Splice-site disruption — *where* the signal was hit
+
+DNA-level locations: these effects say a variant landed on or near a
+splice signal, but say nothing about how the spliceosome responds
+(see the next table for that).
+
+| Effect type | Description |
+| --- | --- |
+| [`SpliceDonor`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20SpliceDonor%28) | Mutation in the first two nucleotides of an intron, likely to affect splicing. |
+| [`SpliceAcceptor`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20SpliceAcceptor%28) | Mutation in the last two nucleotides of an intron, likely to affect splicing. |
+| [`IntronicSpliceSite`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20IntronicSpliceSite%28) | Mutation near the beginning or end of an intron but less likely to affect splicing than donor/acceptor mutations. |
+| [`ExonicSpliceSite`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20ExonicSpliceSite%28) | Mutation at the beginning or end of an exon, may affect splicing; itself a `MultiOutcomeEffect` wrapping the alternate exonic coding effect alongside the splice candidates. |
+
+### Splice mechanism — *what the spliceosome does* in response
+
+The protein-level consequence of a splice-signal hit is not
+deterministic from DNA alone, so varcode emits these as candidates
+inside a `SpliceOutcomeSet` (a `MultiOutcomeEffect`). Each mechanism
+carries the originating disruption on its `.splice_signal` attribute,
+so you can always recover *where* the hit was off any mechanism.
+
+| Effect type | Description |
+| --- | --- |
+| [`NormalSplicing`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20NormalSplicing%28) | Splice signal hit but splicing proceeds normally; protein consequence (if any) is whatever the underlying nucleotide change would produce. |
+| [`ExonSkipping`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20ExonSkipping%28) | Affected exon excluded from the mature transcript; in-frame skip deletes amino acids, out-of-frame skip propagates a frameshift. |
+| [`IntronRetention`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20IntronRetention%28) | Intron stays in the mature transcript; translation usually hits a premature stop inside the retained intron. |
+| [`CrypticDonor`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20CrypticDonor%28) | Disrupted canonical donor replaced by a nearby cryptic GT donor; exon extended or truncated. |
+| [`CrypticAcceptor`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20CrypticAcceptor%28) | Disrupted canonical acceptor replaced by a nearby cryptic AG acceptor; exon extended or truncated. |
+
+### Non-coding regions and unclassifiable contexts
+
+| Effect type | Description |
+| --- | --- |
+| [`FivePrimeUTR`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20FivePrimeUTR%28) | Variant affects 5' untranslated region before start codon. |
+| [`ThreePrimeUTR`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20ThreePrimeUTR%28) | Variant affects 3' untranslated region after stop codon of mRNA. |
+| [`Intronic`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20Intronic%28) | Variant occurs between exons and is unlikely to affect splicing. |
+| [`NoncodingTranscript`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20NoncodingTranscript%28) | Transcript doesn't code for a protein. |
+| [`IncompleteTranscript`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20IncompleteTranscript%28) | Can't determine effect since transcript annotation is incomplete (often missing either the start or stop codon). |
+| [`Intergenic`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20Intergenic%28) | Occurs outside of any annotated gene. |
+| [`Intragenic`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20Intragenic%28) | Within the annotated boundaries of a gene but not in a region that's transcribed into pre-mRNA. |
+| [`Failure`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20Failure%28) | Placeholder effect emitted when annotation failed but a non-empty effect list is required (`raise_on_error=False`). |
+
+### Exon-level and structural-variant effects
+
+The structural-variant effects are themselves `MultiOutcomeEffect`s
+— `.candidates` may include cryptic-exon outcomes, RNA-evidence-
+ranked alternatives, etc.
+
+| Effect type | Description |
+| --- | --- |
+| [`ExonLoss`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20ExonLoss%28) | Deletion of an entire exon, significantly disrupts protein. |
+| [`LargeDeletion`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20LargeDeletion%28) | Structural deletion (`<DEL>` / `<CN0>`) removing one or more exons or an entire gene. |
+| [`LargeDuplication`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20LargeDuplication%28) | Tandem duplication (`<DUP>`) overlapping exons; may yield copy-number increase or a fused reading frame. |
+| [`Inversion`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20Inversion%28) | Inversion (`<INV>`) flipping a stretch of a transcript; consequence depends on whether breakpoints fall in exons or introns. |
+| [`GeneFusion`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20GeneFusion%28) | Breakend (`<BND>`) whose mate lies in another protein-coding gene — the canonical fusion shape. |
+| [`TranslocationToIntergenic`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20TranslocationToIntergenic%28) | Breakend whose mate lies in intergenic space; consequence depends on cryptic splice / ORF signals downstream. |
+| [`CrypticExonCandidate`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20CrypticExonCandidate%28) | An SV brings novel sequence into range of a transcript and motif scoring flags a plausible new splice acceptor / donor pair; attached as additional candidates on SV effects. |
+
+### Multi-variant / phase-dependent effects
+
+Both are `MultiOutcomeEffect`s, emitted alongside per-variant effects
+(additive, not a replacement) when a phase resolver groups cis
+variants together or when phase between somatic and germline variants
+is unknown.
+
+| Effect type | Description |
+| --- | --- |
+| [`HaplotypeEffect`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20HaplotypeEffect%28) | Joint effect of two or more cis variants on the same transcript; the combined mutant cDNA is built and translated as one unit. |
+| [`PhaseCandidateSet`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20PhaseCandidateSet%28) | Possibility set across phase hypotheses when a somatic variant and one or more germline variants share a window on a transcript and phase between them is unknown. |
 
 ## Coordinate System
 


### PR DESCRIPTION
## Summary

The README's Effect Types table predated several rounds of work (splice mechanism promotion #382, structural variants #252/#264, cryptic exons, multi-variant haplotypes #269) and was missing 14 concrete `MutationEffect` subclasses. This rewrite brings it up to the current shape of the type hierarchy and adds the relationships between related effect groups.

## Changes

- **Adds 14 missing concrete effect types** to the table:
  - `Failure` (annotation-failure placeholder)
  - Splice mechanisms: `NormalSplicing`, `ExonSkipping`, `IntronRetention`, `CrypticDonor`, `CrypticAcceptor`
  - Structural variants: `LargeDeletion`, `LargeDuplication`, `Inversion`, `GeneFusion`, `TranslocationToIntergenic`, `CrypticExonCandidate`
  - Multi-variant: `HaplotypeEffect`, `PhaseCandidateSet`
- **Groups into 7 sub-tables** by biological context: in-frame coding, frame-disrupting coding, splice-site disruption, splice mechanism, non-coding regions, exon-level / SV, multi-variant. Distinguishes _where_ a splice signal was hit (`SpliceDonor`, etc.) from _what the spliceosome does_ in response (`NormalSplicing`, `ExonSkipping`, etc.).
- **Adds an intro section on `MultiOutcomeEffect`** explaining which effect types carry multiple candidates (`SpliceOutcomeSet`, `ExonicSpliceSite`, the SV effects, `HaplotypeEffect`, `PhaseCandidateSet`), the shared `.candidates` / `.most_likely_*` / `.highest_priority_*` accessor surface, and how `EffectCandidate` provenance (`.source`, `.evidence`) attaches alongside the inner effect.
- **Links every row to its class definition** in `varcode/effects/effect_classes.py` via GitHub text-fragment URLs (`#:~:text=class%20Name%28`) instead of line-number anchors, so links survive line-number drift as the source evolves. Verified all 37 class names disambiguate cleanly against the file.

## Scope

Documentation only — no code or test changes. No version bump.

## Test plan

- [x] Coverage verified: enumerated every concrete-leaf subclass of `MutationEffect` in `varcode/effects/effect_classes.py` against the new table; all 31 emittable concrete classes present.
- [x] Text-fragment URLs verified: each `class <Name>(` literal is unambiguous in `effect_classes.py` (first match is the class definition, not a docstring mention).
- [ ] Manual: visit the rendered README on GitHub and click a few links to confirm the browser scrolls to the right class definitions.