### PR TITLE
Clarify splice where/what split; make SpliceSite load-bearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,19 @@
   `MultiOutcomeEffect` and how multi-possibility effects are
   represented. Each class name links to its source definition via
   GitHub text-fragment URLs that survive line-number drift.
+- Documented and streamlined the splice-effect model: clarified that
+  `SpliceSite` effects (`SpliceDonor` / `SpliceAcceptor` /
+  `IntronicSpliceSite` / `ExonicSpliceSite`) describe *where* a splice
+  signal was hit and carry no protein consequence on their own, while
+  `SpliceMechanismEffect` subclasses describe *what* the spliceosome
+  does and carry the protein change. `SpliceSite` (previously an
+  undocumented marker base) is now the documented, load-bearing type:
+  `enumerate_splice_outcomes` gates on `isinstance(effect, SpliceSite)`
+  rather than enumerating the four subclasses. Documented the
+  `SpliceOutcomeSet.disrupted_signal_class` (a `SpliceSite` *subclass*,
+  i.e. a type, for priority lookup) vs each candidate's
+  `effect.splice_signal` (a `SpliceSite` *instance*) distinction.
+  No behavior change.
 
 ## [v2.3.0](https://github.com/openvax/varcode/tree/v2.3.0) (2026-04-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,15 @@
   `effect.splice_signal` (a `SpliceSite` *instance*) distinction.
   No behavior change.
 
+**Added**
+- Exported the splice-signal disruption effects at the package root
+  for parity with the already-public splice mechanism effects:
+  `SpliceSite` (the shared base), `SpliceDonor`, `SpliceAcceptor`,
+  `IntronicSpliceSite`, and `ExonicSpliceSite`. `from varcode import
+  SpliceSite` now works, so `isinstance(effect, SpliceSite)` can be
+  used to catch any splice-site disruption without reaching into
+  `varcode.effects.effect_classes`.
+
 ## [v2.3.0](https://github.com/openvax/varcode/tree/v2.3.0) (2026-04-13)
 
 **Added**

--- a/README.md
+++ b/README.md
@@ -171,8 +171,11 @@ and
 ### Splice-site disruption — *where* the signal was hit
 
 DNA-level locations: these effects say a variant landed on or near a
-splice signal, but say nothing about how the spliceosome responds
-(see the next table for that).
+splice signal, but **don't themselves carry a protein consequence** —
+they say nothing about how the spliceosome responds (see the next
+table for that). All four share the
+[`SpliceSite`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20SpliceSite%28)
+base, so `isinstance(effect, SpliceSite)` matches any of them.
 
 | Effect type | Description |
 | --- | --- |
@@ -183,13 +186,17 @@ splice signal, but say nothing about how the spliceosome responds
 
 ### Splice mechanism — *what the spliceosome does* in response
 
-The protein-level consequence of a splice-signal hit is not
-deterministic from DNA alone, so varcode emits these as candidates
-inside a
+**These are the splice effects that carry a protein consequence.** The
+protein-level outcome of a splice-signal hit is not deterministic from
+DNA alone, so (when you opt in with `splice_outcomes=True`) varcode
+emits these as candidates inside a
 [`SpliceOutcomeSet`](https://github.com/openvax/varcode/blob/main/varcode/splice_outcomes.py#:~:text=class%20SpliceOutcomeSet%28)
 (a `MultiOutcomeEffect`). Each mechanism carries the originating
-disruption on its `.splice_signal` attribute, so you can always
-recover *where* the hit was off any mechanism.
+disruption on its `.splice_signal` attribute (a `SpliceSite`
+*instance*), so you can always recover *where* the hit was off any
+mechanism. The set also records the disruption's *class* on
+`.disrupted_signal_class` (the `SpliceSite` subclass, e.g.
+`SpliceDonor` — a type, not an instance) for priority lookup.
 
 | Effect type | Description |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ splice signal, but **don't themselves carry a protein consequence** —
 they say nothing about how the spliceosome responds (see the next
 table for that). All four share the
 [`SpliceSite`](https://github.com/openvax/varcode/blob/main/varcode/effects/effect_classes.py#:~:text=class%20SpliceSite%28)
-base, so `isinstance(effect, SpliceSite)` matches any of them.
+base, so `from varcode import SpliceSite; isinstance(effect, SpliceSite)`
+matches any of them. (The four leaf classes are exported from the
+package root too.)
 
 | Effect type | Description |
 | --- | --- |

--- a/varcode/__init__.py
+++ b/varcode/__init__.py
@@ -76,9 +76,14 @@ from .effects.effect_classes import (
     CrypticAcceptor,
     CrypticDonor,
     ExonSkipping,
+    ExonicSpliceSite,
     IntronRetention,
+    IntronicSpliceSite,
     NormalSplicing,
+    SpliceAcceptor,
+    SpliceDonor,
     SpliceMechanismEffect,
+    SpliceSite,
 )
 from .structural_variant import SV_TYPES, StructuralVariant
 from .sv_allele_parser import parse_symbolic_alt
@@ -109,7 +114,16 @@ __all__ = [
     "Genotype",
     "Zygosity",
 
+    # splice-signal disruption effects — "where" the signal was hit
+    # (all share the SpliceSite base)
+    "SpliceSite",
+    "SpliceDonor",
+    "SpliceAcceptor",
+    "IntronicSpliceSite",
+    "ExonicSpliceSite",
+
     # splice outcome possibility set (openvax/varcode#262, #382)
+    # — "what" the spliceosome does (the protein-affecting effects)
     "SpliceOutcomeSet",
     "SpliceCandidateRNAEvidence",
     "SpliceMechanismEffect",

--- a/varcode/effects/effect_classes.py
+++ b/varcode/effects/effect_classes.py
@@ -339,8 +339,28 @@ class Intronic(TranscriptMutationEffect):
 
 
 class SpliceSite(object):
-    """
-    Parent class for all splice site mutations.
+    """Marker base for the four splice-signal *disruption* effects:
+    :class:`SpliceDonor`, :class:`SpliceAcceptor`,
+    :class:`IntronicSpliceSite`, and :class:`ExonicSpliceSite`.
+
+    A ``SpliceSite`` effect answers **where** a variant hit a splice
+    signal — a position fact (which boundary, how close). It does
+    *not* describe the protein consequence: from DNA alone you can't
+    say how the spliceosome will respond. That downstream protein-level
+    outcome is modeled separately by :class:`SpliceMechanismEffect`
+    subclasses (exon skipping, intron retention, cryptic-site use,
+    normal splicing).
+
+    So the two halves of splice handling are:
+
+    * ``SpliceSite``           → *where* the signal was disrupted.
+    * ``SpliceMechanismEffect`` → *what* the spliceosome does, and the
+      protein change that results.
+
+    :func:`varcode.splice_outcomes.enumerate_splice_outcomes` bridges
+    them: given a ``SpliceSite`` disruption it produces a
+    :class:`~varcode.splice_outcomes.SpliceOutcomeSet` of plausible
+    mechanisms.
     """
     pass
 
@@ -388,10 +408,11 @@ class SpliceAcceptor(IntronicSpliceSite):
 # are None"; no parallel placeholder class hierarchy.
 #
 # Every subclass references back to the underlying splice-signal
-# disruption via :attr:`splice_signal` — a SpliceDonor / SpliceAcceptor /
-# IntronicSpliceSite / ExonicSpliceSite Effect describing *where* in
-# the transcript the splice signal was hit. The mechanism Effect
-# describes *what* happens downstream of that disruption.
+# disruption via :attr:`splice_signal` — a :class:`SpliceSite` effect
+# (SpliceDonor / SpliceAcceptor / IntronicSpliceSite / ExonicSpliceSite)
+# describing *where* in the transcript the splice signal was hit. The
+# mechanism Effect describes *what* happens downstream of that
+# disruption.
 #
 # Used by :class:`~varcode.splice_outcomes.SpliceOutcomeSet` to
 # fill :attr:`EffectCandidate.effect` for each plausible mechanism a
@@ -419,11 +440,11 @@ class SpliceMechanismEffect(TranscriptMutationEffect):
     ----------
     variant : Variant
     transcript : pyensembl.Transcript
-    splice_signal : MutationEffect
-        The splice-signal-disruption Effect (``SpliceDonor`` /
-        ``SpliceAcceptor`` / ``IntronicSpliceSite`` /
-        ``ExonicSpliceSite``) describing *where* the disruption was
-        in the transcript. Lets consumers reach
+    splice_signal : SpliceSite
+        The splice-signal-disruption Effect *instance* describing
+        *where* the disruption was — a :class:`SpliceSite` (one of
+        ``SpliceDonor`` / ``SpliceAcceptor`` / ``IntronicSpliceSite`` /
+        ``ExonicSpliceSite``). Lets consumers reach
         ``effect.splice_signal.nearest_exon``,
         ``effect.splice_signal.distance_to_exon``, etc. without
         carrying those fields redundantly on every mechanism subclass.

--- a/varcode/splice_outcomes.py
+++ b/varcode/splice_outcomes.py
@@ -72,6 +72,7 @@ from .effects.effect_classes import (
     SpliceAcceptor,
     SpliceDonor,
     SpliceMechanismEffect,
+    SpliceSite,
 )
 from .mutant_transcript import MutantTranscript, TranscriptEdit
 from .effect_candidates import EffectCandidate
@@ -134,14 +135,26 @@ class SpliceOutcomeSet(MultiOutcomeEffect):
     catch this and any future multi-outcome wrapper (RNA evidence,
     germline-aware, etc.) uniformly.
 
-    :attr:`candidates` is a ``tuple[EffectCandidate, ...]``. Each
-    candidate's ``effect`` is a :class:`SpliceMechanismEffect`
-    subclass — :class:`NormalSplicing`, :class:`ExonSkipping`,
-    :class:`IntronRetention`, :class:`CrypticDonor`, or
-    :class:`CrypticAcceptor`. Class identity = mechanism. Each
-    mechanism Effect carries its own protein vocab (``aa_ref`` /
-    ``aa_alt`` / ``mutant_protein_sequence`` / ``mutant_transcript``)
-    populated when the protein math resolved, ``None`` when not.
+    This set holds two distinct things — keep them straight:
+
+    * **The disruption** — *where* the splice signal was hit. Stored
+      as :attr:`disrupted_signal_class`, which is the
+      :class:`~varcode.effects.effect_classes.SpliceSite` **subclass**
+      (a *type*, e.g. ``SpliceDonor`` — **not** an Effect instance).
+      It's metadata used for priority lookup. The corresponding
+      Effect *instance* is reachable on every candidate via
+      ``candidate.effect.splice_signal``.
+    * **The protein outcomes** — *what* the spliceosome might do.
+      Stored as :attr:`candidates`, a ``tuple[EffectCandidate, ...]``.
+      Each candidate's ``effect`` is a
+      :class:`~varcode.effects.effect_classes.SpliceMechanismEffect`
+      subclass (:class:`NormalSplicing`, :class:`ExonSkipping`,
+      :class:`IntronRetention`, :class:`CrypticDonor`, or
+      :class:`CrypticAcceptor`) — class identity is the mechanism.
+      These are the effects that carry a protein consequence:
+      ``aa_ref`` / ``aa_alt`` / ``mutant_protein_sequence`` /
+      ``mutant_transcript``, populated when the protein math resolved,
+      ``None`` when only the mechanism is predicted.
 
     For back-compat, :attr:`short_description` delegates to the most
     likely candidate. Constructed by
@@ -170,9 +183,11 @@ class SpliceOutcomeSet(MultiOutcomeEffect):
         MultiOutcomeEffect.__init__(self, variant)
         self.transcript = transcript
         self._candidates = tuple(candidates)
-        # Class of the original splice-disrupting effect this set
-        # replaced (SpliceDonor, SpliceAcceptor, ExonicSpliceSite, or
-        # IntronicSpliceSite). Used for priority lookup.
+        # The SpliceSite *subclass* (a type, not an instance) of the
+        # disruption this set replaced — SpliceDonor, SpliceAcceptor,
+        # ExonicSpliceSite, or IntronicSpliceSite. Used for priority
+        # lookup; the disruption *instance* lives on each candidate's
+        # effect.splice_signal.
         self.disrupted_signal_class = disrupted_signal_class
         self.dna_candidates = tuple(
             self._candidates if dna_candidates is None else dna_candidates)
@@ -1186,16 +1201,19 @@ def _exon_start_offset_in_transcript(transcript, exon):
 
 
 def enumerate_splice_outcomes(splice_effect, genomic_sequence=None):
-    """Wrap a splice-disrupting Effect in a SpliceOutcomeSet.
+    """Wrap a splice-signal disruption in a SpliceOutcomeSet.
 
-    Recognized splice effect classes are SpliceDonor, SpliceAcceptor,
-    ExonicSpliceSite, and IntronicSpliceSite. Unrecognized classes
-    pass through unchanged.
+    The recognized inputs are exactly the
+    :class:`~varcode.effects.effect_classes.SpliceSite` effects
+    (``SpliceDonor`` / ``SpliceAcceptor`` / ``ExonicSpliceSite`` /
+    ``IntronicSpliceSite``) — the "where the signal was hit" effects.
+    Anything else passes through unchanged.
 
     Parameters
     ----------
     splice_effect : MutationEffect
-        Output of varcode's existing splice classification.
+        Output of varcode's existing splice classification. Only
+        :class:`SpliceSite` instances are wrapped.
 
     genomic_sequence : Callable[[str, int, int], str], optional
         Caller-supplied provider for genomic sequence, returning
@@ -1221,12 +1239,16 @@ def enumerate_splice_outcomes(splice_effect, genomic_sequence=None):
     -------
     SpliceOutcomeSet or the original effect
         SpliceOutcomeSet wrapping the candidate mechanisms when the
-        input is a splice-disrupting effect; otherwise the input
+        input is a :class:`SpliceSite` disruption; otherwise the input
         unchanged.
     """
-    mechanism_order = _mechanism_order_for(splice_effect)
-    if mechanism_order is None:
+    # Only splice-signal disruptions (the SpliceSite subclasses) get
+    # wrapped; everything else passes through untouched.
+    if not isinstance(splice_effect, SpliceSite):
         return splice_effect
+    # Every SpliceSite subclass is handled by _mechanism_order_for, so
+    # mechanism_order is guaranteed non-None past the gate above.
+    mechanism_order = _mechanism_order_for(splice_effect)
 
     candidates = []
     for mechanism_cls in mechanism_order:

--- a/varcode/splice_outcomes.py
+++ b/varcode/splice_outcomes.py
@@ -1246,9 +1246,13 @@ def enumerate_splice_outcomes(splice_effect, genomic_sequence=None):
     # wrapped; everything else passes through untouched.
     if not isinstance(splice_effect, SpliceSite):
         return splice_effect
-    # Every SpliceSite subclass is handled by _mechanism_order_for, so
-    # mechanism_order is guaranteed non-None past the gate above.
     mechanism_order = _mechanism_order_for(splice_effect)
+    if mechanism_order is None:
+        # Defensive: every SpliceSite subclass today is handled by
+        # _mechanism_order_for, but a future direct SpliceSite subclass
+        # without a registered ordering would land here — pass it
+        # through rather than crashing on a None mechanism order.
+        return splice_effect
 
     candidates = []
     for mechanism_cls in mechanism_order:


### PR DESCRIPTION
## Summary

Follow-up to the earlier splice-effect discussion. Resolves two loose ends — the undocumented `disrupted_signal_class` class-vs-instance distinction and the vestigial `SpliceSite` marker base — and streamlines the conceptual model so it's clear which splice effects carry a protein consequence and which are location-only. **No behavior change.**

## The model, made explicit

Splice handling has two halves, now documented as such everywhere:

- **`SpliceSite` effects** (`SpliceDonor`, `SpliceAcceptor`, `IntronicSpliceSite`, `ExonicSpliceSite`) — describe *where* a splice signal was hit. A DNA-level location fact; **no protein consequence on their own.**
- **`SpliceMechanismEffect` subclasses** (`NormalSplicing`, `ExonSkipping`, `IntronRetention`, `CrypticDonor`, `CrypticAcceptor`) — describe *what* the spliceosome does, and **carry the protein change** (`aa_ref` / `aa_alt` / `mutant_protein_sequence` / `mutant_transcript`).

## Changes

- **`SpliceSite`** gains a real docstring framing it as the "where" base and pointing at `SpliceMechanismEffect` for the "what." Previously it was a bare `class SpliceSite(object): pass` with no usage.
- **`SpliceSite` is now load-bearing**: `enumerate_splice_outcomes` gates on `isinstance(splice_effect, SpliceSite)` instead of relying on `_mechanism_order_for` returning `None`. Behavior is identical — every `SpliceSite` subclass is handled by `_mechanism_order_for`, so the gate is equivalent — but the recognized-effect contract is now explicit and the base class has a genuine runtime role.
- **`disrupted_signal_class` vs `splice_signal` documented**: the `SpliceOutcomeSet` docstring and inline comment now spell out that `disrupted_signal_class` is the `SpliceSite` *subclass* (a type, used for priority lookup) while each candidate's `effect.splice_signal` is the `SpliceSite` *instance*.
- **README** splice sections now state which effects carry a protein consequence (the mechanisms) vs which are location-only (the `SpliceSite` disruptions), reference the shared `SpliceSite` base, and note the class-vs-instance distinction.
- **CHANGELOG** entry under `[Unreleased]` **Changed**.

## Test plan

- [x] `pytest -k "splice or outcome or mechanism or effect_classes or annotator"` — 380 passed, 2 skipped, no regressions.
- [x] `./lint.sh` — flake8 + ruff clean.

## Notes / not in scope

- `SpliceSite` is referenced from `varcode.effects.effect_classes` (consistent with how the README links every other effect class). It's **not** added to the top-level `varcode` export list — the four concrete site classes aren't exported either, so promoting just the base would be an asymmetric API decision better made deliberately. Happy to export it (and/or the leaf classes) in a follow-up if you want `from varcode import SpliceSite` to work.