### PR TITLE
Add auto-generated Effect types docs page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,11 @@
   No behavior change.
 
 **Added**
+- Docs site now has an "Effect types" page that auto-renders every
+  class in `varcode.effects.effect_classes` via mkdocstrings, so the
+  documented catalog stays in sync with the code (previously only the
+  abstract bases were in the API reference, while the full list lived
+  only in the hand-maintained README table).
 - Exported the splice-signal disruption effects at the package root
   for parity with the already-public splice mechanism effects:
   `SpliceSite` (the shared base), `SpliceDonor`, `SpliceAcceptor`,

--- a/docs/effect_types.md
+++ b/docs/effect_types.md
@@ -1,0 +1,31 @@
+# Effect types
+
+Every effect class varcode can attach to a `(variant, transcript)`
+pair, auto-generated from the source docstrings in
+`varcode.effects.effect_classes` — so this list never drifts from the
+code.
+
+Two distinctions are worth keeping in mind while reading:
+
+- **Effects that carry a protein consequence vs. location-only
+  effects.** Coding effects (`Substitution`, `FrameShift`,
+  `PrematureStop`, …) and the splice *mechanism* effects
+  (`NormalSplicing`, `ExonSkipping`, …) describe a change to the
+  protein. The splice-signal *disruption* effects (`SpliceDonor`,
+  `SpliceAcceptor`, `IntronicSpliceSite`, `ExonicSpliceSite`, all
+  sharing the `SpliceSite` base) and the region effects (`Intronic`,
+  `FivePrimeUTR`, …) describe *where* a variant landed and carry no
+  protein consequence on their own.
+- **Single effects vs. multi-outcome containers.** Most effects are a
+  single answer. `MultiOutcomeEffect` subclasses (`SpliceOutcomeSet`,
+  `ExonicSpliceSite`, the structural-variant effects, `HaplotypeEffect`,
+  `PhaseCandidateSet`) bundle several candidate effects when the
+  protein-level outcome isn't deterministic; each exposes
+  `.candidates`, `.most_likely_effect`, and `.highest_priority_effect`.
+
+For a grouped quick-reference, see the
+[Effect Types table in the README](https://github.com/openvax/varcode#effect-types).
+Severity ordering across types is set by
+[`effect_priority`](api.md#varcode.effect_priority).
+
+::: varcode.effects.effect_classes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
       - Error handling: errors.md
       - Germline-aware annotation: germline.md
   - API reference: api.md
+  - Effect types: effect_types.md
   - Changelog: changelog.md
 
 markdown_extensions:


### PR DESCRIPTION
## Summary

The docs site's API reference only documented the abstract effect bases (`MutationEffect`, `NonsilentCodingMutation`, `MultiOutcomeEffect`, …) — the full concrete catalog of effect types lived only in the hand-maintained README table, so the two had drifted.

This adds a **`docs/effect_types.md`** page that mkdocstrings-renders the entire `varcode.effects.effect_classes` module (members in source order). The catalog now stays in sync with the code automatically — no second hand-maintained list.

## Changes

- `docs/effect_types.md` — `::: varcode.effects.effect_classes` plus a short intro framing the two distinctions worth keeping in mind: protein-consequence vs. location-only effects, and single vs. multi-outcome containers. Links back to the README quick-reference and the `effect_priority` API entry.
- `mkdocs.yml` — new nav entry "Effect types" after "API reference".
- CHANGELOG entry under `[Unreleased]` **Added**.

## Test plan

- [x] `mkdocs build --strict` exits 0.
- [x] Verified the rendered page contains the concrete classes (spot-checked `Substitution`, `FrameShift`, `SpliceDonor`, `ExonSkipping`, `HaplotypeEffect`, `SpliceSite`) — 94 doc-class blocks rendered.
- [x] Verified the internal link to `api.md#varcode.effect_priority` resolves against the generated anchor.
- The private helper `_cryptic_motif_score` is excluded automatically (mkdocstrings skips leading-underscore members).

## Scope

Docs only — no code, no behavior change, no version bump needed.