### PR TITLE
Fix flaky CI: pin shared test snp fixtures to installed Ensembl release 81

### DIFF
--- a/tests/data.py
+++ b/tests/data.py
@@ -15,8 +15,20 @@ Helper functions and shared datasets for tests
 """
 
 import os
+from pyensembl import cached_release
 from varcode import Variant, VariantCollection, load_maf
 import pandas as pd
+
+# Pin shared fixtures to the suite's standard GRCh38 release (81) rather than
+# letting Variant default to "GRCh38", which resolves to pyensembl's LATEST
+# release (e.g. 115). That default is not installed in CI (the
+# openvax/ensembl-data mirror tops out at GRCh38.95), so any test that
+# annotates these snps -- including test_collection_filtering, which calls
+# .effects() at import -- would flake on "GTF database needs to be created".
+# Release 81 is what the downstream transcript-id assertions were written
+# against.
+ENSEMBL_GRCH38 = cached_release(81)
+
 
 def data_path(name):
     """
@@ -33,17 +45,20 @@ snp_rs4244285 = Variant(
     contig=10,
     start=94781859,
     ref="G",
-    alt="A")
+    alt="A",
+    ensembl=ENSEMBL_GRCH38)
 snp_rs1537415 = Variant(
     contig=9,
     start=135637876,
     ref="C",
-    alt="G")
+    alt="G",
+    ensembl=ENSEMBL_GRCH38)
 snp_rs3892097 = Variant(
     contig=22,
     start=42524947,
     ref="G",
-    alt="A")
+    alt="A",
+    ensembl=ENSEMBL_GRCH38)
 
 db_snp_variants = VariantCollection([
     snp_rs4244285,


### PR DESCRIPTION
## Problem

`tests/test_collection_filtering.py` calls `variants.effects()` at **module import** on the `db_snp_variants` fixtures defined in `tests/data.py`. Those `Variant`s defaulted to `reference_name="GRCh38"`, which pyensembl resolves to its **latest known release** (currently 115) rather than an installed one.

CI installs GRCh38 from the `openvax/ensembl-data` mirror, which tops out at **GRCh38.95**. So whenever the latest-release GTF isn't present, collection of that module dies with `"GTF database needs to be created"` — an intermittent failure on main's default `./test.sh` run (seen on 3.9/3.10).

This is the same class of latent release-dependency bug fixed in #399, at a call site that PR didn't touch.

## Fix

Pin the three shared snps to `cached_release(81)` — the installed release the downstream transcript-id assertions (`ENST00000371321`, `...371763`, `...464755`, `...613244`) were already written against. Test-only, no library changes.

## Verification

- `test_collection_filtering.py` → 7 passed (including the expression test that fails under release 115)
- `test_cli_genes.py` → 1 passed
- `ruff check tests/data.py` → clean
- Swept every other module-level `.effects()` call site: the MAF fixtures (`tcga_ov`, `ov_wustle`) resolve to GRCh37/release 75, which **is** installed — no further trap.

https://claude.ai/code/session_01VNtZRyKZ7u9jiMGPQEbx4c